### PR TITLE
Add .editorconfig (easier style guide compliance)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+#
+# This file tells your IDE the formatting (etc) rules for your project.
+# See http://editorconfig.org/
+#
+# Subline Text: https://github.com/editorconfig/editorconfig-sublime
+# Emacs: https://github.com/editorconfig/editorconfig-emacs
+# Jetbrains (IntelliJ etc): https://github.com/editorconfig/editorconfig-jetbrains
+# Eclipse: ??
+#
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[**.xml]
+indent_style = space
+indent_size = 4
+
+[**.jelly]
+indent_style = space
+indent_size = 4
+
+[**.java]
+indent_style = space
+indent_size = 4
+
+[**.hbs]
+indent_style = space
+indent_size = 4
+
+[**.js]
+indent_style = space
+indent_size = 4
+
+[**.css]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false~


### PR DESCRIPTION
Make it easy for people to conform to the style guide. Makes life a bit easier when working in multiple projects that have different styles. Set your IDE to honour `.editorconfig` files and then it will format appropriately on a project-by-project basis (where the project has a `.editorconfig` file).

**BTW**: Not saying what's in this PR is the style guide ... just a starting point that can be edited over time.
