### PR TITLE
added an example extension that can host the organisation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Yarr...
 # Modules of note
 (check the readme in each of them!)
 
+## blueocean-admin
+
+Example plugin - a starting point. Take a look at it if you want to extend blue ocean. 
+
 ## blueocean-web
 
-BlueOcean Web module, everything interesting web related lives here. If you are doing web, you want to be in here. You probably want to look at the README for this for how to play with it.
+BlueOcean Web module, core web module with layout and extention points. You probably want to look at the README for this for how to play with it. This should mostly be infrastructure and core components.
 
 ## blueocean-plugin
 

--- a/blueocean-admin/README.md
+++ b/blueocean-admin/README.md
@@ -1,8 +1,11 @@
 # Example plugin
 
-This plugin adds an extension to the Top Nav Bar via its ExtensionPoint. 
+This plugin is an example of a few extensions
+The extension points are defined in `blueocean-web`
 
 ## Running this
 
-Best way is to run `mvn hpi:run` from blueocean-plugin. 
-Then from this directory, run `gulp rebundle` to watch for JS changes and reload them.
+1) Go into `blueocean-plugin` and run `mvn hpi:run` in a terminal. 
+2) From this directory, run `gulp rebundle` to watch for JS changes and reload them.
+3) Open browser to http://localhost:8080/jenkins/blue/ to see this
+4) hack away. Refreshing the browser will pick up changes. If you add a new extension point or export a new extension you may need to restart the `mvn hpi:run` process. 

--- a/blueocean-admin/src/main/js/OrganisationPipelines.jsx
+++ b/blueocean-admin/src/main/js/OrganisationPipelines.jsx
@@ -1,0 +1,55 @@
+import React, {Component} from 'react';
+
+/**
+ * This is a place holder extension to show the organisation pipeline listing. 
+ * It loads the data once, lists it etc. 
+ * Have at it!
+ */
+export default class OrganisationPipelines extends Component {  
+     constructor() {
+       super();
+       this.state = {pipelines : []};
+     }  
+     componentDidMount() {
+       fetchPipelineData((data) => {
+         this.setState({pipelines: data});
+       });              
+     }
+    
+    render() {        
+        return <div>
+                  <h1><p>This is also from a plugin. Number of pipelines: {this.state.pipelines.length} </p></h1>
+                    <iframe width="420" height="315" src="//www.youtube.com/embed/xZuQz1tO8aQ"></iframe>  
+                    <p/>
+                    {this.state.pipelines.map(renderHomepagePipeline)}                    
+                </div>;
+    }
+}
+
+/** Pipeline row component */
+function renderHomepagePipeline(pipeline) {
+    return <div key={pipeline.name}>
+              <h3>{pipeline.name}</h3>
+           </div>
+}
+
+
+
+/** Ghetto ajax loading of pipeline data for an org */
+function fetchPipelineData(onLoad) {    
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange = function() {
+        if (xmlhttp.readyState == XMLHttpRequest.DONE ) {
+           if(xmlhttp.status == 200){
+               console.log(xmlhttp.responseText);
+               var pipes = JSON.parse(xmlhttp.responseText);
+               onLoad(pipes);
+               console.log(pipes);
+           }  else {         
+              console.log('something else other than 200 was returned')
+           }
+        }
+    }
+    xmlhttp.open("GET", "/jenkins/blue/rest/organizations/jenkins/pipelines/", true);
+    xmlhttp.send();
+}

--- a/blueocean-admin/src/main/js/jenkins-js-extension.yaml
+++ b/blueocean-admin/src/main/js/jenkins-js-extension.yaml
@@ -1,3 +1,5 @@
 extensions:
   - component: AdminNavLink
     extensionPoint: jenkins.topNavigation.menu
+  - component: OrganisationPipelines
+    extensionPoint: jenkins.main.body

--- a/blueocean-web/README.md
+++ b/blueocean-web/README.md
@@ -5,6 +5,8 @@ Look for blueocean.js for excitement.
 
 # Running Blue Ocean in development
 
+If you want to add to some extension points, take a look at the blueocean-admin module (actually a plugin) for an example.
+
 ## Firstly build all modules from root
 
     cd .. 

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -20,6 +20,7 @@ class App extends Component {
                 <main>
                     {/* children currently set by router */}
                     {this.props.children}
+                    <ExtensionPoint name="jenkins.main.body"/>
                 </main>
                 <footer>
                     <p>This is a footer. I'm sure you'll agree.</p>


### PR DESCRIPTION
Related to issue #UX-11 

This adds an extra extension point, and a sample extension that loads the pipeline listing for an org. Dumb and needs work but is starting point for examples. 

Clearer docs

@reviewbybees 
@tfennelly 
