### PR TITLE
[Fix UX-140] Hook mocha/es6 tests into maven build via gulp build

### DIFF
--- a/blueocean-admin/gulpfile.js
+++ b/blueocean-admin/gulpfile.js
@@ -1,4 +1,25 @@
 //
 // See https://github.com/jenkinsci/js-builder
 //
-require('@jenkins-cd/js-builder');
+var builder = require('@jenkins-cd/js-builder');
+
+//
+// Redefine the "test" task to use mocha and support es6.
+// We might build this into js-builder, but is ok here
+// for now.
+//
+builder.defineTask('test', function() {
+    var mocha = require('gulp-mocha');
+    var babel = require('babel-core/register');
+
+    builder.gulp.src('src/test/js/*-spec.js')
+        .pipe(mocha({
+            compilers: {js: babel}
+        })).on('error', function(e) {
+            if (builder.isRetest()) {
+                // ignore test failures if we are running retest.
+                return;
+            }
+            throw e;
+        });
+});

--- a/blueocean-admin/package.json
+++ b/blueocean-admin/package.json
@@ -4,13 +4,13 @@
   "scripts": {
     "lint": "gulp lint --silent",
     "lint:fix": "gulp lint --fixLint --silent",
-    "test": "mocha  --compilers js:babel-core/register --recursive",
-    "test:watch": "npm test -- --watch --reporter min",
+    "test": "gulp test --silent",
+    "retest": "gulp retest --silent",
     "bundle": "gulp bundle --silent",
     "rebundle": "gulp rebundle --silent"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.11",
+    "@jenkins-cd/js-builder": "0.0.12",
     "@jenkins-cd/js-test": "^1.x",
     "babel": "^6.5.2",
     "babel-core": "^6.6.5",
@@ -20,6 +20,7 @@
     "chai": "^3.5.0",
     "eslint-plugin-react": "^4.1.0",
     "gulp": "^3.9.0",
+    "gulp-mocha": "^2.2.0",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^0.14.7",
     "skin-deep": "^0.14.0"

--- a/blueocean-admin/src/test/js/pipeline-spec.js
+++ b/blueocean-admin/src/test/js/pipeline-spec.js
@@ -4,7 +4,7 @@ import { assert} from 'chai';
 import sd from 'skin-deep';
 
 
-import Pipeline from '../../src/main/js/components/Pipeline.jsx';
+import Pipeline from '../../main/js/components/Pipeline.jsx';
 
 const
   hack= ()=>{},

--- a/blueocean-admin/src/test/js/pipelines-spec.js
+++ b/blueocean-admin/src/test/js/pipelines-spec.js
@@ -3,7 +3,7 @@ import { assert} from 'chai';
 import sd from 'skin-deep';
 import Immutable from 'immutable';
 
-import Pipelines from '../../src/main/js/components/Pipelines.jsx';
+import Pipelines from '../../main/js/components/Pipelines.jsx';
 
 const
   hack= ()=>{},


### PR DESCRIPTION
Related to issue # [UX-140](https://cloudbees.atlassian.net/browse/UX-140). 

Hooking of the mocha/es6 based tests into the maven build by hooking them into the gulp build (which maven will run).

We might put this mocha/es6 support into `js-builder`. I looked at that but didn't see an obvious way of changing from mocha to jasmine and working with es6. I think this is ok for now though.

@reviewbybees 
