### PR TITLE
Fix js-builder issue with --fixLint and relative .eslintrc files

### DIFF
--- a/blueocean-admin/package.json
+++ b/blueocean-admin/package.json
@@ -10,7 +10,7 @@
     "rebundle": "gulp rebundle"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.16",
+    "@jenkins-cd/js-builder": "0.0.17",
     "@jenkins-cd/js-test": "^1.x",
     "babel": "^6.5.2",
     "babel-core": "^6.6.5",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -15,7 +15,7 @@
     "rebundle": "gulp rebundle"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.16",
+    "@jenkins-cd/js-builder": "0.0.17",
     "@jenkins-cd/js-test": "^1.x",
     "babel-eslint": "^6.0.0",
     "babel-preset-es2015": "^6.5.0",


### PR DESCRIPTION
Update to js-builder 0.0.17 to get `--fixLint` fix.

@reviewbybees 
