### PR TITLE
bug/UX-268 * de-silence gulp tasks

### DIFF
--- a/blueocean-admin/package.json
+++ b/blueocean-admin/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.1",
   "scripts": {
     "storybook": "start-storybook -p 9001",
-    "lint": "gulp lint --silent",
-    "lint:fix": "gulp lint --fixLint --silent",
+    "lint": "gulp lint",
+    "lint:fix": "gulp lint --fixLint",
     "lint:watch": "gulp lint:watch",
-    "test": "gulp test --silent",
-    "test:watch": "gulp test:watch --silent",
-    "bundle": "gulp bundle --silent",
+    "test": "gulp test",
+    "test:watch": "gulp test:watch",
+    "bundle": "gulp bundle",
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/cloudbees/blueocean.git"
   },
   "scripts": {
-    "lint": "gulp lint --silent",
-    "lint:fix": "gulp lint --fixLint --silent",
-    "test": "gulp test --silent",
+    "lint": "gulp lint",
+    "lint:fix": "gulp lint --fixLint",
+    "test": "gulp test",
     "test:watch": "gulp test:watch",
     "bundle": "gulp bundle",
     "bundle:watch": "gulp bundle:watch"


### PR DESCRIPTION
Related to issue #UX-268 

Summary of this pull request: 
"gulp foo --silent" is swallowing important error information when things go wrong.

@reviewbybees 
