### PR TITLE
Workflow pipeline upgrade to 2.0 breaks hpi:run

### DIFF
--- a/blueocean-plugin/pom.xml
+++ b/blueocean-plugin/pom.xml
@@ -15,7 +15,7 @@
     <name>BlueOcean :: Jenkins Plugin</name>
 
     <properties>
-        <pipeline.plugin>2.0</pipeline.plugin>
+        <pipeline.plugin>1.14</pipeline.plugin>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
.
.
.

@reviewbybees 
