### PR TITLE
[UX-284] Updated dependencies and update of node and npm mvn versions

### DIFF
--- a/blueocean-admin/package.json
+++ b/blueocean-admin/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.27",
+    "@jenkins-cd/js-builder": "0.0.29",
     "@jenkins-cd/js-test": "1.1.1",
     "@kadira/storybook": "^1.11.0",
     "babel": "^6.5.2",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -15,7 +15,7 @@
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.27",
+    "@jenkins-cd/js-builder": "0.0.29",
     "@jenkins-cd/js-test": "1.1.1",
     "babel-eslint": "^6.0.0",
     "babel-preset-es2015": "^6.5.0",

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
     <java.level>7</java.level>
     <jackson.version>2.2.3</jackson.version>
     <jenkins.version>1.652</jenkins.version>
-    <node.version>5.6.0</node.version>
-    <npm.version>3.6.0</npm.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Related to issue # [UX-284](https://cloudbees.atlassian.net/browse/UX-284). 

**Note**:
1. Requires a run of `mvn clean -DcleanNode` before building.
2. The newer versions of npm are a lot slower for `npm install`. But apparently the newer versions also fix some major package resolution issues, so prob best that we use it.

@reviewbybees 
