### PR TITLE
bug/UX-318: remove margin from icon that was throwing off alignment

### DIFF
--- a/jenkins-design-language/less/theme.less
+++ b/jenkins-design-language/less/theme.less
@@ -621,10 +621,6 @@ code.inline {
             margin-right: 0;
         }
     }
-
-    .weather-icon {
-        margin-top: 1rem;
-    }
 }
 
 .sub-header nav.page-tabs {


### PR DESCRIPTION
Related to issue # UX-318. 

Summary of this pull request: 
. remove margin that was mucking up layout

@reviewbybees 
