### PR TITLE
UX-338: allow storybook to load imports with or without .jsx extension

### DIFF
--- a/jenkins-design-language/.storybook/webpack.config.js
+++ b/jenkins-design-language/.storybook/webpack.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = {
+    module: {},
+    resolve: {
+        extensions: [
+            '.js', // required by storybook
+            '', '.jsx' // for blueocean files
+        ],
+    }
+};


### PR DESCRIPTION
Related to issue # UX-338. 

Summary of this pull request: 
. This allows components loaded via Storybook to use imports with or without the ".jsx" extension,  e.g './MyComponent' or './OtherComponent.jsx'

see: https://github.com/kadirahq/react-storybook/blob/master/docs/configure_storybook.md#custom-webpack-configurations

@reviewbybees 
