### PR TITLE
Feature/ux 262 display "empty state" messages for all Pipeline detail tabs

### DIFF
--- a/blueocean-admin/src/main/js/components/Activity.jsx
+++ b/blueocean-admin/src/main/js/components/Activity.jsx
@@ -10,19 +10,21 @@ export class Activity extends Component {
 
     renderEmptyState(repoName) {
         return (
-            <EmptyStateView iconName="shoes">
-                <h1>Ready, get set...</h1>
+            <main>
+                <EmptyStateView iconName="shoes">
+                    <h1>Ready, get set...</h1>
 
-                <p>
-                    Hmm, looks like there are no runs in this pipeline’s history.
-                </p>
+                    <p>
+                        Hmm, looks like there are no runs in this pipeline’s history.
+                    </p>
 
-                <p>
-                    Commit to the repository <em>{repoName}</em> or run the pipeline manually.
-                </p>
+                    <p>
+                        Commit to the repository <em>{repoName}</em> or run the pipeline manually.
+                    </p>
 
-                <button>Run Now</button>
-            </EmptyStateView>
+                    <button>Run Now</button>
+                </EmptyStateView>
+            </main>
         );
     }
 

--- a/blueocean-admin/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-admin/src/main/js/components/MultiBranch.jsx
@@ -10,20 +10,22 @@ export class MultiBranch extends Component {
 
     renderEmptyState(repoName) {
         return (
-            <EmptyStateView iconName="shoes">
-                <h1>Branch out</h1>
+            <main>
+                <EmptyStateView iconName="shoes">
+                    <h1>Branch out</h1>
 
-                <p>
-                    Create a branch in the repository <em>{repoName}</em> and
-                    Jenkins will start testing your changes.
-                </p>
+                    <p>
+                        Create a branch in the repository <em>{repoName}</em> and
+                        Jenkins will start testing your changes.
+                    </p>
 
-                <p>
-                    Give it a try and become a hero to your team.
-                </p>
+                    <p>
+                        Give it a try and become a hero to your team.
+                    </p>
 
-                <button>Enable</button>
-            </EmptyStateView>
+                    <button>Enable</button>
+                </EmptyStateView>
+            </main>
         );
     }
 

--- a/blueocean-admin/src/main/js/components/PullRequests.jsx
+++ b/blueocean-admin/src/main/js/components/PullRequests.jsx
@@ -10,17 +10,19 @@ export class PullRequests extends Component {
 
     renderEmptyState(repoName) {
         return (
-            <EmptyStateView iconName="goat">
-                <h1>Push me, pull you</h1>
+            <main>
+                <EmptyStateView iconName="goat">
+                    <h1>Push me, pull you</h1>
 
-                <p>
-                    When a Pull Request is opened on the repository <em>{repoName}</em>,
-                    Jenkins will test it and report the status of
-                    your changes back to the pull request on Github.
-                </p>
+                    <p>
+                        When a Pull Request is opened on the repository <em>{repoName}</em>,
+                        Jenkins will test it and report the status of
+                        your changes back to the pull request on Github.
+                    </p>
 
-                <button>Enable</button>
-            </EmptyStateView>
+                    <button>Enable</button>
+                </EmptyStateView>
+            </main>
         );
     }
 


### PR DESCRIPTION
Related to issue # UX-262. 

Summary of this pull request: 
. display "empty state" messages for all Pipeline detail tabs

@reviewbybees 
