### PR TITLE
UX-394: Only check for number of passing branches when we care about it

### DIFF
--- a/blueocean-plugin/src/test/java/io/jenkins/blueocean/service/embedded/BaseTest.java
+++ b/blueocean-plugin/src/test/java/io/jenkins/blueocean/service/embedded/BaseTest.java
@@ -226,15 +226,21 @@ public abstract class BaseTest {
         }
     }
 
-
+    protected void validateMultiBranchPipeline(WorkflowMultiBranchProject p, Map resp, int numBranches){
+        validateMultiBranchPipeline(p, resp, numBranches, -1, -1);
+    }
     protected void validateMultiBranchPipeline(WorkflowMultiBranchProject p, Map resp, int numBranches, int numSuccBranches, int numOfFailingBranches){
         Assert.assertEquals("jenkins", resp.get("organization"));
         Assert.assertEquals(p.getName(), resp.get("name"));
         Assert.assertEquals(p.getDisplayName(), resp.get("displayName"));
         Assert.assertNull(resp.get("lastSuccessfulRun"));
         Assert.assertEquals(numBranches, resp.get("totalNumberOfBranches"));
-        Assert.assertEquals(numOfFailingBranches, resp.get("numberOfFailingBranches"));
-        Assert.assertEquals(numSuccBranches, resp.get("numberOfSuccessfulBranches"));
+        if(numOfFailingBranches >= 0) {
+            Assert.assertEquals(numOfFailingBranches, resp.get("numberOfFailingBranches"));
+        }
+        if(numSuccBranches >= 0) {
+            Assert.assertEquals(numSuccBranches, resp.get("numberOfSuccessfulBranches"));
+        }
         Assert.assertEquals(p.getBuildHealth().getScore(), resp.get("weatherScore"));
     }
 

--- a/blueocean-plugin/src/test/java/io/jenkins/blueocean/service/embedded/MultiBranchTest.java
+++ b/blueocean-plugin/src/test/java/io/jenkins/blueocean/service/embedded/MultiBranchTest.java
@@ -68,7 +68,7 @@ public class MultiBranchTest extends BaseTest{
         List<Map> resp = get("/organizations/jenkins/pipelines/", List.class);
         Assert.assertEquals(2, resp.size());
         validatePipeline(f, resp.get(0));
-        validateMultiBranchPipeline(mp, resp.get(1), 3, 0, 0);
+        validateMultiBranchPipeline(mp, resp.get(1), 3);
         Assert.assertEquals(mp.getBranch("master").getBuildHealth().getScore(), resp.get(0).get("weatherScore"));
     }
 
@@ -88,7 +88,7 @@ public class MultiBranchTest extends BaseTest{
 
         List<Map> resp = get("/organizations/jenkins/pipelines/", List.class);
         Assert.assertEquals(1, resp.size());
-        validateMultiBranchPipeline(mp, resp.get(0), 2, 0, 0);
+        validateMultiBranchPipeline(mp, resp.get(0), 2);
         Assert.assertNull(mp.getBranch("master"));
     }
 
@@ -105,7 +105,7 @@ public class MultiBranchTest extends BaseTest{
 
 
         Map resp = get("/organizations/jenkins/pipelines/p/");
-        validateMultiBranchPipeline(mp,resp,3,0,0);
+        validateMultiBranchPipeline(mp,resp,3);
 
         List<String> names = (List<String>) resp.get("branchNames");
 
@@ -178,7 +178,7 @@ public class MultiBranchTest extends BaseTest{
         int i = 0;
         for(String n:branches){
             WorkflowRun b = runs[i];
-
+            j.waitForCompletion(b);
             Map run = get("/organizations/jenkins/pipelines/p/branches/"+n+"/runs/"+b.getId());
             validateRun(b,run);
             i++;


### PR DESCRIPTION
Tests were trying to verify successful runs of branches, without waiting for jobs to finish. Most times we dont care, so dont check in those cases. In the one we do care about, wait for job completion
