### PR TITLE
[UX-446] use correct empty state icon for Branches view

### DIFF
--- a/blueocean-admin/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-admin/src/main/js/components/MultiBranch.jsx
@@ -15,7 +15,7 @@ const { object, array, func, string } = PropTypes;
 
 const EmptyState = ({ repoName }) => (
     <main>
-        <EmptyStateView iconName="shoes">
+        <EmptyStateView iconName="branch">
             <h1>Branch out</h1>
 
             <p>


### PR DESCRIPTION
Related to issue # UX-446. 

Summary of this pull request: 
- Use proper icon; this was just a mis-merge in an earlier commit

@reviewbybees 
