### PR TITLE
feature/UX-407: use shared instance of react-addons-css-transition-group

### DIFF
--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -35,6 +35,7 @@
     "keymirror": "^0.1.1",
     "moment": "^2.13.0",
     "react": "15.0.1",
+    "react-addons-css-transition-group": "15.0.1",
     "react-dom": "15.0.1",
     "react-redux": "^4.4.5",
     "react-router": "^2.3.0",

--- a/blueocean-web/src/main/js/init.jsx
+++ b/blueocean-web/src/main/js/init.jsx
@@ -54,9 +54,11 @@ exports.initialize = function (oncomplete) {
     const react = require('react');
     const reactRouter = require('react-router');
     const reactDOM = require('react-dom');
+    const reactCssTransitions = require('react-addons-css-transition-group');
     jenkinsMods.export('react', 'react', react);
     jenkinsMods.export('react', 'react-dom', reactDOM);
     jenkinsMods.export('react', 'react-router', reactRouter);
+    jenkinsMods.export('react', 'react-addons-css-transition-group', reactCssTransitions);
 
     // Manually register extention points. TODO: we will be auto-registering these.
     extensions.store.addExtension('jenkins.topNavigation.menu', AboutNavLink);


### PR DESCRIPTION
Related to issue # UX-407. 

Summary of this pull request: 
- Discussed with @tfennelly. My feeling is that since other plugins (and admin/pipelines) are almost certain to use these CSS animation utils themselves, it makes sense to export this in blueocean-web now.

@reviewbybees
