### PR TITLE
Fixing afterClose navigation on Pipeline detail view (modal window)

### DIFF
--- a/blueocean-dashboard/src/main/js/PipelineRoutes.jsx
+++ b/blueocean-dashboard/src/main/js/PipelineRoutes.jsx
@@ -1,4 +1,4 @@
-import { Route, IndexRoute, IndexRedirect } from 'react-router';
+import { Route, Redirect, IndexRoute, IndexRedirect } from 'react-router';
 import React from 'react';
 import OrganisationPipelines from './OrganisationPipelines';
 import {
@@ -20,17 +20,21 @@ import { rootRoutePath } from './config';
 export default (
     <Route path={rootRoutePath} component={OrganisationPipelines}>
         <IndexRoute component={Pipelines} />
+
         <Route component={PipelinePage}>
             <Route path=":pipeline/branches" component={MultiBranch} />
             <Route path=":pipeline/activity" component={Activity} />
             <Route path=":pipeline/pr" component={PullRequests} />
-        </Route>
-        <Route path=":pipeline/detail/:branch/:runId" component={RunDetails}>
-            <IndexRedirect to="pipeline" />
-            <Route path="pipeline" component={RunDetailsPipeline} />
-            <Route path="changes" component={RunDetailsChanges} />
-            <Route path="tests" component={RunDetailsTests} />
-            <Route path="artifacts" component={RunDetailsArtifacts} />
+
+            <Route path=":pipeline/detail/:branch/:runId" component={RunDetails}>
+                <IndexRedirect to="pipeline" />
+                <Route path="pipeline" component={RunDetailsPipeline} />
+                <Route path="changes" component={RunDetailsChanges} />
+                <Route path="tests" component={RunDetailsTests} />
+                <Route path="artifacts" component={RunDetailsArtifacts} />
+            </Route>
+
+            <Redirect from=":pipeline/*" to=":pipeline/activity" />
         </Route>
     </Route>
 );

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -44,9 +44,12 @@ class RunDetails extends Component {
                 },
                 config = {},
             } = this.context;
+
             config.pipeline = pipeline;
+
             this.props.fetchRunsIfNeeded(config);
             this.props.setPipeline(config);
+            this.opener = this.props.previous;
         }
     }
     navigateToChanges() {
@@ -60,20 +63,16 @@ class RunDetails extends Component {
             || this.props.isMultiBranch === null) {
             return null;
         }
+
         const {
-            context: {
-                router,
-                location,
-                params: {
-                    branch,
-                    runId,
-                    pipeline: name,
-                },
+            router,
+            location,
+            params: {
+                branch,
+                runId,
+                pipeline: name,
             },
-            props: {
-                previous,
-            },
-        } = this;
+        } = this.context;
 
         const baseUrl = cleanBaseUrl(this.context.location.pathname);
 
@@ -83,12 +82,11 @@ class RunDetails extends Component {
         result.name = name;
 
         const afterClose = () => {
+            const fallback = `/pipelines/${name}/`;
+
+            location.pathname = this.opener || fallback;
             location.hash = `#${branch}-${runId}`;
-            if (previous) {
-                location.pathname = previous;
-            } else {
-                location.pathname = `/pipelines/${name}/activity/`;
-            }
+
             router.push(location);
         };
 

--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -45,7 +45,9 @@ export default class Runs extends Component {
 
         const url = `/pipelines/${pipelineName}/detail/${pipeline}/${id}/pipeline`;
         const open = () => {
+            location.hash = '';
             location.pathname = url;
+
             router.push(location);
         };
 

--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -45,9 +45,7 @@ export default class Runs extends Component {
 
         const url = `/pipelines/${pipelineName}/detail/${pipeline}/${id}/pipeline`;
         const open = () => {
-            location.hash = '';
             location.pathname = url;
-
             router.push(location);
         };
 


### PR DESCRIPTION
When opening the pipeline details view (modal window) and then navigating between tabs and finally dismissing the window, the afterClose navigation url is not correct, and is showing an empty page.

First part of the fix is at routing, so that we can define fallback redirect (pipelines/activity) and then we have to be aware that opener url (previous) is passed from context when component is initialised and should not be set from render method, which is of course called every time we switch between tabs.

@reviewbybees 

