### PR TITLE
Paginating the Pipelines View

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -30,8 +30,6 @@ export default class Pipelines extends Component {
             { label: '', className: 'favorite' },
         ];
 
-        console.log(config);
-
         const isShowMoreButtonVisible = pipelines.length > 5;
 
         const baseUrl = config.getRootURL();
@@ -61,7 +59,6 @@ export default class Pipelines extends Component {
                             }
 
                             {isShowMoreButtonVisible && <tr><td colspan="5"><button className="">Show More</button></td></tr>}
-
 
                         </Table>
                     </article>

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -10,8 +10,22 @@ const { array } = PropTypes;
 
 export default class Pipelines extends Component {
 
+    constructor(props) {
+        super(props);
+        this.state = {
+            showAllPipelines: false,
+        };
+        this.onShowAllClick = this.onShowAllClick.bind(this);
+    }
+
+    onShowAllClick() {
+        this.state.showAllPipelines = true;
+        this.forceUpdate();
+    }
+
     render() {
         const { pipelines, config } = this.context;
+        const numInitialPiplinesToDisplay = 5;
 
         // Early out
         if (!pipelines) {
@@ -22,6 +36,20 @@ export default class Pipelines extends Component {
             .map(data => new PipelineRecord(data))
             .sort(pipeline => !!pipeline.branchNames);
 
+        // Identify if we will only display the first {numInitialPiplinesToDisplay} pipelines or display them all
+        const isShowMoreButtonVisible = !this.state.showAllPipelines && pipelines.length > numInitialPiplinesToDisplay;
+        var pipelinesToDisplay = [];
+        if(isShowMoreButtonVisible) {
+            for(var i = 0; i < pipelines.length; i++) {
+                if(i >= numInitialPiplinesToDisplay) {
+                    break;
+                }
+                pipelinesToDisplay.push(pipelines[i]);
+            }
+        } else {
+            pipelinesToDisplay = pipelineRecords;
+        }
+
         const headers = [
             { label: 'Name', className: 'name' },
             'Health',
@@ -30,7 +58,9 @@ export default class Pipelines extends Component {
             { label: '', className: 'favorite' },
         ];
 
-        const isShowMoreButtonVisible = pipelines.length > 5;
+
+        console.log('len', pipelinesToDisplay);
+        console.log('isShowMoreButtonVisible', isShowMoreButtonVisible);
 
         const baseUrl = config.getRootURL();
         const newJobUrl = `${baseUrl}view/All/newJob`;
@@ -52,13 +82,18 @@ export default class Pipelines extends Component {
                           className="pipelines-table"
                           headers={headers}
                         >
-                            { pipelineRecords
+                            { pipelinesToDisplay
                                 .map(pipeline => <PipelineRowItem
                                   key={pipeline.name} pipeline={pipeline}
                                 />)
                             }
-
-                            {isShowMoreButtonVisible && <tr><td colspan="5"><button className="">Show More</button></td></tr>}
+                            {isShowMoreButtonVisible &&
+                                <tr>
+                                    <td colspan="5">
+                                        <button className="pipelines-show-all-button" onClick={this.onShowAllClick}>Show All</button>
+                                    </td>
+                                </tr>
+                            }
 
                         </Table>
                     </article>

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -30,6 +30,10 @@ export default class Pipelines extends Component {
             { label: '', className: 'favorite' },
         ];
 
+        console.log(config);
+
+        const isShowMoreButtonVisible = pipelines.length > 5;
+
         const baseUrl = config.getRootURL();
         const newJobUrl = `${baseUrl}view/All/newJob`;
 
@@ -55,6 +59,10 @@ export default class Pipelines extends Component {
                                   key={pipeline.name} pipeline={pipeline}
                                 />)
                             }
+
+                            {isShowMoreButtonVisible && <tr><td colspan="5"><button className="">Show More</button></td></tr>}
+
+
                         </Table>
                     </article>
                 </main>

--- a/blueocean-dashboard/src/main/js/config.js
+++ b/blueocean-dashboard/src/main/js/config.js
@@ -1,3 +1,4 @@
 // Shared consts.urlPrefix
 export const rootRoutePath = 'pipelines';
 export const urlPrefix = `/${rootRoutePath}`;
+export const numInitialPiplinesToDisplay = 5;

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -122,6 +122,7 @@ export const actions = {
      * @param config Application configuration.
      */
     fetchPipelines(config) {
+
         return (dispatch) => {
             const url = `${config.getAppURLBase()}` +
                 '/rest/organizations/jenkins/pipelines/';
@@ -140,9 +141,10 @@ export const actions = {
     fetchPipelinesIfNeeded(config) {
         return (dispatch, getState) => {
             const pipelines = getState().adminStore.pipelines;
-            const url = `${config.getAppURLBase()}` +
-                '/rest/organizations/jenkins/pipelines/';
             if (!pipelines) {
+                const url = `${config.getAppURLBase()}` +
+                    '/rest/organizations/jenkins/pipelines/';
+
                 return dispatch(actions.generateData(
                     url,
                     ACTION_TYPES.SET_PIPELINES_DATA


### PR DESCRIPTION
This was a feature request by @i386 

I've done some initial parts on showing the `Show More` button when the number of pipelines reaches a certain amount. There's just a bit of complexity here that I've discovered and wanted to share.

- the crud subscriber code that I've stumbled across will pull in a set of data and doesn't know anything about the paginated state.
- the UI would have to then persist the current offset/limit that it's on somewhere. Also a few other parts of the code, would have to be updated to respect this state paginated state.
- I foresee a bunch of code needing written to allow new pipelines to make their way to Blue Ocean subscriber jobs and update the UI with the pagination logic in mind, always.

**Simplified Approach**
I'm proposing a simplification, so rather than having Pagination at all with a `Show More` button, we just make a `Show All` button.

This would allow me to not even care about pagination offset/limit states and continue to always pull in `all pipelines` via the `/rest/` call and just toggle the UI upon initial page load.

Keen to get some feedback on this change in direction, and any additional input that should be considered.
