### PR TITLE
UX-504# Log response has missing X-Text-Size header

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
@@ -62,14 +62,15 @@ public class LogResource{
         }
 
         CharSpool spool = new CharSpool();
-        
+
         long r = logText.writeLogTo(offset,spool);
-        Writer w = createWriter(req, rsp, r - offset);
-        spool.writeTo(new LineEndNormalizingWriter(w));
         rsp.addHeader("X-Text-Size",String.valueOf(r));
         if(!logText.isComplete()) {
             rsp.addHeader("X-More-Data", "true");
         }
+
+        Writer w = createWriter(req, rsp, r - offset);
+        spool.writeTo(new LineEndNormalizingWriter(w));
         w.close();
     }
 


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
.
.
.

@reviewbybees 

This header was added but after call to ServletResponse.getWriter(). Servlet
spec doesn't talk about it explicitly but certain servlet container implementation
commits the response such that headers added after call to ServletResponse.getWriter()
are ignored. Fix was to move this code before call to ServletResponse.getWriter().