### PR TITLE
[WIP] added Docker build file

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM maven:3
+
+# install nodejs and gulp
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install gulp -g
+
+ADD . /etc/blue-ocean
+
+WORKDIR /etc/blue-ocean


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 

**Motivation**

- Useful if I want to get Blue Ocean up and running without having java, maven etc installed

- Common image to test features/PRs

**Building the image**

`docker build -f Docker.build -t jenkinsci/blueocean-plugin .`

**Run the Container (interactive)**

`docker run -it -v ~/.m2:/root/.m2 jenkinsci/blueocean-plugin mvn clean install`

**TODO**

Expose `8080` and create entry point file which builds (`mvn clean install`) and runs (`mvn hpi:run`)

Initial thoughts guys? 😄 

@reviewbybees 

