### PR TITLE
feature/ux 297: use TimeDuration component in dashboard

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -1,9 +1,9 @@
 import React, { Component, PropTypes } from 'react';
-import moment from 'moment';
-import { StatusIndicator, CommitHash, ReadableDate } from '@jenkins-cd/design-language';
+import {
+    CommitHash, ReadableDate, StatusIndicator, TimeDuration,
+}
+    from '@jenkins-cd/design-language';
 const { object, string, any } = PropTypes;
-
-require('moment-duration-format');
 
 /*
  http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/PR-demo/runs
@@ -40,7 +40,6 @@ export default class Runs extends Component {
             },
         } = this;
 
-        const duration = moment.duration(durationInMillis).humanize();
         const resultRun = result === 'UNKNOWN' ? state : result;
 
         const url = `/pipelines/${pipelineName}/detail/${pipeline}/${id}/pipeline`;
@@ -59,7 +58,7 @@ export default class Runs extends Component {
             <td><CommitHash commitId={commitId} /></td>
             <td>{decodeURIComponent(pipeline)}</td>
             <td>{changeset && changeset.comment || '-'}</td>
-            <td>{duration}</td>
+            <td><TimeDuration millis={durationInMillis} /></td>
             <td><ReadableDate date={endTime} /></td>
         </tr>);
     }

--- a/blueocean-dashboard/src/test/js/branches-spec.js
+++ b/blueocean-dashboard/src/test/js/branches-spec.js
@@ -31,7 +31,7 @@ describe("Branches should render", () => {
     assert.isNotNull(weatherIcon.props.score);
     assert.equal(weatherIcon.props.score, data[0].score);
     // dash for empty or id
-    const commitHash = data[0].latestRun.commitId.substr(0, 8);
+    const commitHash = data[0].latestRun.commitId.substr(0, 7);
     const hashComp = row[3].getRenderOutput().props.children;
     const hashRendered = sd.shallowRender(hashComp).getRenderOutput();
     assert.equal(hashRendered.props.children, commitHash);

--- a/blueocean-dashboard/src/test/js/branches-spec.js
+++ b/blueocean-dashboard/src/test/js/branches-spec.js
@@ -31,7 +31,7 @@ describe("Branches should render", () => {
     assert.isNotNull(weatherIcon.props.score);
     assert.equal(weatherIcon.props.score, data[0].score);
     // dash for empty or id
-    const commitHash = data[0].latestRun.commitId.substr(0, 7);
+    const commitHash = data[0].latestRun.commitId.substr(0, 8);
     const hashComp = row[3].getRenderOutput().props.children;
     const hashRendered = sd.shallowRender(hashComp).getRenderOutput();
     assert.equal(hashRendered.props.children, commitHash);

--- a/blueocean-dashboard/src/test/js/pullRequest-spec.js
+++ b/blueocean-dashboard/src/test/js/pullRequest-spec.js
@@ -2,7 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import { createRenderer } from 'react-addons-test-utils';
 import { assert } from 'chai';
 import sd from 'skin-deep';
-import moment from 'moment';
 
 import PullRequest from '../../main/js/components/PullRequest.jsx';
 import { RunsRecord } from '../../main/js/components/records.jsx';


### PR DESCRIPTION
Related to issue # UX-297. 

Summary of this pull request: 
* use TimeDuration
* remove moment/duration usages
* ~~fix a test regression in recent update to CommitHash~~