### PR TITLE
[UX-431] Externalize some packages

### DIFF
--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.31",
+    "@jenkins-cd/js-builder": "0.0.33-beta7",
     "@jenkins-cd/js-test": "1.1.1",
     "@kadira/storybook": "1.19.0",
     "babel": "^6.5.2",
@@ -36,28 +36,36 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.14",
+    "@jenkins-cd/js-extensions": "0.0.15-beta3",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.5",
-    "immutable": "^3.8.1",
-    "isomorphic-fetch": "^2.2.1",
-    "keymirror": "^0.1.1",
-    "moment": "^2.13.0",
-    "moment-duration-format": "^1.3.0",
+    "immutable": "3.8.1",
+    "isomorphic-fetch": "2.2.1",
+    "keymirror": "0.1.1",
+    "moment": "2.13.0",
+    "moment-duration-format": "1.3.0",
     "react": "15.0.1",
     "react-dom": "15.0.1",
-    "react-material-icons-blue": "^1.0.4",
-    "react-redux": "^4.4.5",
-    "react-router": "^2.3.0",
-    "redux": "^3.5.2",
-    "redux-thunk": "^2.0.1",
-    "reselect": "^2.5.1",
-    "window-handle": "^1.0.0"
+    "react-material-icons-blue": "1.0.4",
+    "react-redux": "4.4.5",
+    "react-router": "2.3.0",
+    "redux": "3.5.2",
+    "redux-thunk": "2.0.1",
+    "reselect": "2.5.1",
+    "window-handle": "1.0.0"
   },
   "jenkinscd": {
     "extDependencies": [
+      "@jenkins-cd/sse-gateway",
       "immutable",
-      "react-router"
+      "isomorphic-fetch",
+      "react-router",
+      "keymirror",
+      "react-redux",
+      "react-router",
+      "redux",
+      "redux-thunk",
+      "reselect"
     ]
   }
 }

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.15-beta3",
+    "@jenkins-cd/js-extensions": "0.0.15-beta4",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.5",
     "immutable": "3.8.1",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.33-beta7",
+    "@jenkins-cd/js-builder": "0.0.33",
     "@jenkins-cd/js-test": "1.1.1",
     "@kadira/storybook": "1.19.0",
     "babel": "^6.5.2",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.33",
+    "@jenkins-cd/js-builder": "0.0.34",
     "@jenkins-cd/js-test": "1.1.1",
     "@kadira/storybook": "1.19.0",
     "babel": "^6.5.2",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.15-beta4",
+    "@jenkins-cd/js-extensions": "0.0.15",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.5",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.15-beta3",
+    "@jenkins-cd/js-extensions": "0.0.15-beta4",
     "@jenkins-cd/js-modules": "0.0.5",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -15,7 +15,7 @@
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.33-beta7",
+    "@jenkins-cd/js-builder": "0.0.33",
     "@jenkins-cd/js-test": "1.1.1",
     "babel-eslint": "^6.0.2",
     "babel-preset-es2015": "^6.6.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -15,7 +15,7 @@
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.31",
+    "@jenkins-cd/js-builder": "0.0.33-beta7",
     "@jenkins-cd/js-test": "1.1.1",
     "babel-eslint": "^6.0.2",
     "babel-preset-es2015": "^6.6.0",
@@ -28,19 +28,32 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.14",
+    "@jenkins-cd/js-extensions": "0.0.15-beta3",
     "@jenkins-cd/js-modules": "0.0.5",
-    "history": "^2.0.2",
-    "immutable": "^3.8.1",
-    "keymirror": "^0.1.1",
-    "moment": "^2.13.0",
+    "history": "2.0.2",
+    "immutable": "3.8.1",
+    "keymirror": "0.1.1",
+    "moment": "2.13.0",
     "react": "15.0.1",
     "react-addons-css-transition-group": "15.0.1",
     "react-dom": "15.0.1",
-    "react-redux": "^4.4.5",
-    "react-router": "^2.3.0",
-    "redux": "^3.5.2",
-    "redux-thunk": "^2.0.1",
-    "window-handle": "^1.0.0"
+    "react-redux": "4.4.5",
+    "react-router": "2.3.0",
+    "redux": "3.5.2",
+    "redux-thunk": "2.0.1",
+    "window-handle": "1.0.0"
+  },
+  "jenkinscd": {
+    "extDependencies": [
+      "history",
+      "immutable",
+      "react-router",
+      "keymirror",
+      "react-addons-css-transition-group",
+      "react-redux",
+      "react-router",
+      "redux",
+      "redux-thunk"
+    ]
   }
 }

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -15,7 +15,7 @@
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.33",
+    "@jenkins-cd/js-builder": "0.0.34",
     "@jenkins-cd/js-test": "1.1.1",
     "babel-eslint": "^6.0.2",
     "babel-preset-es2015": "^6.6.0",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.43",
-    "@jenkins-cd/js-extensions": "0.0.15-beta4",
+    "@jenkins-cd/js-extensions": "0.0.15",
     "@jenkins-cd/js-modules": "0.0.5",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -2,10 +2,6 @@
   "name": "blueocean-web",
   "version": "0.0.1",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cloudbees/blueocean.git"
-  },
   "scripts": {
     "lint": "gulp lint",
     "lint:fix": "gulp lint --fixLint",

--- a/blueocean-web/src/main/js/init.jsx
+++ b/blueocean-web/src/main/js/init.jsx
@@ -52,13 +52,9 @@ exports.initialize = function (oncomplete) {
 
     // Load and export the react modules, allowing them to be imported by other bundles.
     const react = require('react');
-    const reactRouter = require('react-router');
     const reactDOM = require('react-dom');
-    const reactCssTransitions = require('react-addons-css-transition-group');
     jenkinsMods.export('react', 'react', react);
     jenkinsMods.export('react', 'react-dom', reactDOM);
-    jenkinsMods.export('react', 'react-router', reactRouter);
-    jenkinsMods.export('react', 'react-addons-css-transition-group', reactCssTransitions);
 
     // Manually register extention points. TODO: we will be auto-registering these.
     extensions.store.addExtension('jenkins.topNavigation.menu', AboutNavLink);

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -100,7 +100,7 @@ function transformToJSX() {
         var extensions = extensionsMeta.extensions;
         var srcRoot = path.dirname(jsExtensionsYAMLFile);
         var targetRoot = cwd + '/target';
-        var relPath = path.relative(targetRoot, srcRoot);
+        var relPath = path.relative(targetRoot, srcRoot).replace(/\\/g, "/");
         var jsxFilePath = targetRoot + '/jenkins-js-extension.jsx';
         var jsxFileContent = '';
 

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^0.14.7 || ^15.0.0"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.33-beta7",
+    "@jenkins-cd/js-builder": "0.0.33",
     "@jenkins-cd/js-test": "1.1.1",
     "gulp": "^3.9.1",
     "react-tools": "^0.13.3"

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.14",
+  "version": "0.0.15-beta3",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [
@@ -21,7 +21,7 @@
     "react-dom": "^0.14.7 || ^15.0.0"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.31",
+    "@jenkins-cd/js-builder": "0.0.33-beta7",
     "@jenkins-cd/js-test": "1.1.1",
     "gulp": "^3.9.1",
     "react-tools": "^0.13.3"

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.15-beta3",
+  "version": "0.0.15-beta4",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.15-beta4",
+  "version": "0.0.15",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [
@@ -21,7 +21,7 @@
     "react-dom": "^0.14.7 || ^15.0.0"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.33",
+    "@jenkins-cd/js-builder": "0.0.34",
     "@jenkins-cd/js-test": "1.1.1",
     "gulp": "^3.9.1",
     "react-tools": "^0.13.3"


### PR DESCRIPTION
Related to issue [UX-431](https://cloudbees.atlassian.net/browse/UX-431). 

Externalizes some of the NPM packages used in the web and dashboard  plugins.

I had to make a bugfix to js-builder and so also included a possible fix for [JENKINS-35180](https://issues.jenkins-ci.org/browse/JENKINS-35180)

@reviewbybees 
