### PR TITLE
UX-553# In case accept header is */* or text/*, defaults to text/plain.

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
@@ -30,11 +30,12 @@ public class LogResource{
 
     private void writeLog(StaplerRequest req, StaplerResponse rsp, AcceptHeader accept) {
         try {
-            switch (accept.select("text/html","text/plain")) {
+            switch (accept.select("text/plain","text/html")) {
                 case "text/html":
                     rsp.setContentType("text/html;charset=UTF-8");
                     rsp.setStatus(HttpServletResponse.SC_OK);
                     req.setAttribute("html", Boolean.valueOf(true));
+                    break;
                 case "text/plain":
                     rsp.setContentType("text/plain;charset=UTF-8");
                     rsp.setStatus(HttpServletResponse.SC_OK);

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestBuilder;
+import org.kohsuke.stapler.AcceptHeader;
 
 import java.io.IOException;
 import java.util.List;
@@ -334,7 +335,9 @@ public class PipelineApiTest extends BaseTest {
         WorkflowRun b1 = job1.scheduleBuild2(0).get();
         j.assertBuildStatusSuccess(b1);
 
-        HttpResponse<String> response = get("/organizations/jenkins/pipelines/pipeline1/runs/"+b1.getId()+"/log?start=0", 200,"text/plain",HttpResponse.class);
+        HttpResponse<String> response = get("/organizations/jenkins/pipelines/pipeline1/runs/"+b1.getId()+"/log?start=0", 200,HttpResponse.class);
+        AcceptHeader acceptHeader = new AcceptHeader(response.getHeaders().getFirst("Content-Type"));
+        Assert.assertNotNull(acceptHeader.select("text/plain"));
 
         int size = Integer.parseInt(response.getHeaders().getFirst("X-Text-Size"));
         System.out.println(response.getBody());


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
@michaelneale previous log fix caused this regression where default behavior changed to serve text/html logs. To prevent future regression a test to check text/plain being default type is added.

@reviewbybees 

