### PR TITLE
[UX-561] Add a "Try Blue Ocean UI" button in classic Jenkins

### DIFF
--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -35,6 +35,17 @@ builder.bundle('src/main/js/blueocean.js')
     .less('src/main/less/blueocean.less')
     .generateNoImportsBundle();
 
+//
+// Create the "Try Blue Ocean" Javascript bundle.
+// This .js bundle will be added to every classic Jenkins page
+// via a PageDecorator. Using this as a way of enticing Jenkins
+// users to move from classic Jenkins to Blue Ocean where possible.
+//
+builder.bundle('src/main/js/try.js')
+    .inDir('target/classes/io/jenkins/blueocean')
+    .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2') // Bundled in Jenkins 2.x 
+    .less('src/main/less/try.less');
+
 // 
 // Copy/link the JDL assests into the webapp dir, making them available at runtime.
 // 

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-react": "^5.0.1",
     "giti": "^1.0.6",
     "gulp": "^3.9.1",
+    "jquery-detached": "^2.1.4-v4",
     "ncp": "^2.0.0",
     "zombie": "^4.2.1"
   },

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/TryBlueOceanPageDecorator.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/TryBlueOceanPageDecorator.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.blueocean;
+
+import hudson.Extension;
+import hudson.model.PageDecorator;
+
+/**
+ * Stapler page decorator for decorating classic Jenkins pages with visual
+ * prompts to the user that will hopefully entice/remind them into giving
+ * Blue ocean a try.
+ * 
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Extension
+public class TryBlueOceanPageDecorator extends PageDecorator {
+}

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -1,0 +1,18 @@
+var $ = require('jquery-detached').getJQuery();
+var jsModules = require('@jenkins-cd/js-modules');
+
+$(document).ready(function () {
+    var tryBlueOcean = $('<div class="try-blueocean header-callout">Try Blue Ocean UI ...</div>');
+    
+    tryBlueOcean.click(function () {
+        // We could enhance this further by looking at the current
+        // URL and going to different places in the BO UI depending
+        // on where the user is in classic jenkins UI e.g. if they
+        // are currently in a job on classic UI, bring them to the
+        // same job in BO UI Vs just brining them to the root of
+        // BO UI i.e. make the button context sensitive.
+        window.location.replace(jsModules.getRootURL() + '/blue');
+    });
+    
+    $('#page-head #header').append(tryBlueOcean);
+});

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -1,17 +1,17 @@
 var $ = require('jquery-detached').getJQuery();
 var jsModules = require('@jenkins-cd/js-modules');
 
-$(document).ready(function () {
+$(document).ready(() => {
     var tryBlueOcean = $('<div class="try-blueocean header-callout">Try Blue Ocean UI ...</div>');
     
-    tryBlueOcean.click(function () {
+    tryBlueOcean.click(() => {
         // We could enhance this further by looking at the current
         // URL and going to different places in the BO UI depending
         // on where the user is in classic jenkins UI e.g. if they
         // are currently in a job on classic UI, bring them to the
         // same job in BO UI Vs just brining them to the root of
         // BO UI i.e. make the button context sensitive.
-        window.location.replace(jsModules.getRootURL() + '/blue');
+        window.location.replace(`${jsModules.getRootURL()}/blue`);
     });
     
     $('#page-head #header').append(tryBlueOcean);

--- a/blueocean-web/src/main/less/try.less
+++ b/blueocean-web/src/main/less/try.less
@@ -4,9 +4,11 @@
   position: absolute;
   padding: 5px 10px;
   right: 50%;
+  margin-right: -5em;
   height: 30px !important;
   top: 5px;
-  color: #4a90e2;
+  background-color: @blueocean_blue;
+  color: white;
   border: 1px solid;
   border-color: #4a90e2;
   border-radius: 3px;
@@ -14,6 +16,5 @@
 
 .try-blueocean.header-callout:hover {
   cursor: pointer;
-  background-color: #4a90e2;
-  color: white;
+  background-color: darken(@blueocean_blue, 10%);
 }

--- a/blueocean-web/src/main/less/try.less
+++ b/blueocean-web/src/main/less/try.less
@@ -1,0 +1,19 @@
+@import "variables";
+
+.try-blueocean.header-callout {
+  position: absolute;
+  padding: 5px 10px;
+  right: 50%;
+  height: 30px !important;
+  top: 5px;
+  color: #4a90e2;
+  border: 1px solid;
+  border-color: #4a90e2;
+  border-radius: 3px;
+}
+
+.try-blueocean.header-callout:hover {
+  cursor: pointer;
+  background-color: #4a90e2;
+  color: white;
+}

--- a/blueocean-web/src/main/less/variables.less
+++ b/blueocean-web/src/main/less/variables.less
@@ -1,3 +1,6 @@
 //
 // TODO: Gather variables and add here.
+// How might we get these from the JDL? Maybe include the LESS files in the JDL distro?
 //
+
+@blueocean_blue: #4A90E2;

--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/TryBlueOceanPageDecorator/header.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/TryBlueOceanPageDecorator/header.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <!--
+  The following Stapler adjunct adds the "Try Blue Ocean JavaScript bundle to
+  every page in "classic" Jenkins.
+  -->
+  <st:adjunct includes="io.jenkins.blueocean.try"/>
+</j:jelly>


### PR DESCRIPTION
Related to issue [UX-561](https://cloudbees.atlassian.net/browse/UX-561). 

A button on the classic Jenkins top nav bar (on every page), helping new users to get to blue ocean (vs having to type in the URL) + a constant reminder to existing users to go back to Blue Ocean.

<img width="1106" alt="screenshot 2016-06-09 21 27 30" src="https://cloud.githubusercontent.com/assets/429311/15945225/3fb78ba6-2e89-11e6-81e0-4ace3be6c20f.png">

I think I'd like to make the button contextual i.e. depending on where you are in Jenkins, clicking on the button will bring you to the most appropriate place in Blue Ocean e.g. if you're in a Job, clicking on it brings you to that job in Blue Ocean etc ... on the page for a specific job run ... go to the run details page etc etc.

@jenkinsci/code-reviewers @reviewbybees 

