### PR TITLE
feature/jenkins 35690 - adding live indicator for job start/stop on Branches and PR's; fix estimated duration for Activity

### DIFF
--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -35,7 +35,7 @@
     "skin-deep": "^0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/design-language": "0.0.45",
+    "@jenkins-cd/design-language": "0.0.46",
     "@jenkins-cd/js-extensions": "0.0.15",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.5",

--- a/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
+++ b/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
@@ -71,10 +71,12 @@ class OrganizationPipelines extends Component {
                 }
                 case 'job_run_started': {
                     _this.props.updateRunState(eventCopy, _this.context.config, true);
+                    _this.props.updateBranchState(eventCopy, _this.context.config);
                     break;
                 }
                 case 'job_run_ended': {
                     _this.props.updateRunState(eventCopy, _this.context.config);
+                    _this.props.updateBranchState(eventCopy, _this.context.config);
                     break;
                 }
                 default :
@@ -106,6 +108,7 @@ OrganizationPipelines.propTypes = {
     fetchPipelinesIfNeeded: func.isRequired,
     processJobQueuedEvent: func.isRequired,
     updateRunState: func.isRequired,
+    updateBranchState: func.isRequired,
     organization: string,
     params: object, // From react-router
     children: node, // From react-router

--- a/blueocean-dashboard/src/main/js/components/Branches.jsx
+++ b/blueocean-dashboard/src/main/js/components/Branches.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { CommitHash, ReadableDate } from '@jenkins-cd/design-language';
-import { WeatherIcon, StatusIndicator } from '@jenkins-cd/design-language';
+import { LiveStatusIndicator, WeatherIcon } from '@jenkins-cd/design-language';
 
 const { object } = PropTypes;
 
@@ -26,7 +26,7 @@ export default class Branches extends Component {
                 },
             } = this;
         const {
-            latestRun: { id, result, endTime, changeSet, state, commitId },
+            latestRun: { id, result, startTime, endTime, changeSet, state, commitId, estimatedDurationInMillis },
             weatherScore,
             name,
         } = data;
@@ -36,10 +36,13 @@ export default class Branches extends Component {
             router.push(location);
         };
         const { msg } = changeSet[0] || {};
+
         return (<tr key={name} onClick={open} id={`${name}-${id}`} >
             <td><WeatherIcon score={weatherScore} /></td>
             <td>
-                <StatusIndicator result={result === 'UNKNOWN' ? state : result} />
+                <LiveStatusIndicator result={result === 'UNKNOWN' ? state : result}
+                  startTime={startTime} estimatedDuration={estimatedDurationInMillis}
+                />
             </td>
             <td>{decodeURIComponent(name)}</td>
             <td><CommitHash commitId={commitId} /></td>

--- a/blueocean-dashboard/src/main/js/components/PullRequest.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequest.jsx
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { ReadableDate, StatusIndicator } from '@jenkins-cd/design-language';
+import { LiveStatusIndicator, ReadableDate } from '@jenkins-cd/design-language';
 
 const { object } = PropTypes;
 
@@ -13,7 +13,9 @@ export default class PullRequest extends Component {
             latestRun: {
                 result: resultString,
                 id,
+                startTime,
                 endTime,
+                estimatedDurationInMillis,
                 state,
             },
             pullRequest: {
@@ -38,8 +40,13 @@ export default class PullRequest extends Component {
             location.pathname = url;
             router.push(location);
         };
+
         return (<tr key={id} onClick={open} id={`${name}-${id}`} >
-            <td><StatusIndicator result={result} /></td>
+            <td>
+                <LiveStatusIndicator result={result} startTime={startTime}
+                  estimatedDuration={estimatedDurationInMillis}
+                />
+            </td>
             <td>{id}</td>
             <td>{title || '-'}</td>
             <td>{author || '-'}</td>

--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -4,7 +4,6 @@ import {
 }
     from '@jenkins-cd/design-language';
 import { removeLastUrlSegment } from '../util/UrlUtils';
-import moment from 'moment';
 
 const { object, string, any } = PropTypes;
 
@@ -33,6 +32,7 @@ export default class Runs extends Component {
                     id,
                     result,
                     state,
+                    startTime,
                     endTime,
                     commitId,
                 },
@@ -42,7 +42,6 @@ export default class Runs extends Component {
 
         const resultRun = result === 'UNKNOWN' ? state : result;
         const estimatedDuration = this.context.pipeline.estimatedDurationInMillis;
-        const startTime = moment.parseZone(this.props.result.startTime).valueOf();
 
         const baseUrl = removeLastUrlSegment(this.context.location.pathname);
         const url = `${baseUrl}/detail/${pipeline}/${id}/pipeline`;

--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -28,6 +28,7 @@ export default class Runs extends Component {
             props: {
                 result: {
                     durationInMillis,
+                    estimatedDurationInMillis,
                     pipeline,
                     id,
                     result,
@@ -41,8 +42,6 @@ export default class Runs extends Component {
         } = this;
 
         const resultRun = result === 'UNKNOWN' ? state : result;
-        const estimatedDuration = this.context.pipeline.estimatedDurationInMillis;
-
         const baseUrl = removeLastUrlSegment(this.context.location.pathname);
         const url = `${baseUrl}/detail/${pipeline}/${id}/pipeline`;
         const open = () => {
@@ -52,7 +51,9 @@ export default class Runs extends Component {
 
         return (<tr key={id} onClick={open} id={`${pipeline}-${id}`} >
             <td>
-                <LiveStatusIndicator result={resultRun} startTime={startTime} estimatedDuration={estimatedDuration} />
+                <LiveStatusIndicator result={resultRun} startTime={startTime}
+                  estimatedDuration={estimatedDurationInMillis}
+                />
             </td>
             <td>
                 {id}

--- a/blueocean-dashboard/src/main/js/components/records.jsx
+++ b/blueocean-dashboard/src/main/js/components/records.jsx
@@ -48,6 +48,7 @@ export const ActivityRecord = Record({
     durationInMillis: null,
     enQueueTime: null,
     endTime: null,
+    estimatedDurationInMillis: null,
     id: null,
     organization: null,
     pipeline: null,

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -25,7 +25,7 @@
     "zombie": "^4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/design-language": "0.0.45",
+    "@jenkins-cd/design-language": "0.0.46",
     "@jenkins-cd/js-extensions": "0.0.15",
     "@jenkins-cd/js-modules": "0.0.5",
     "history": "2.0.2",


### PR DESCRIPTION
Related to issue # JENKINS-35690 . 

Summary of this pull request: 
* Fix a bug where the Activity view was using an incorrect value for the estimation run duration
* Add store logic for the Branches and PR tabs to update as jobs start/stop

@reviewbybees 
