### PR TITLE
[JENKINS-35912] use either the result or state for the header status

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -24,15 +24,13 @@ export default class LogToolbar extends Component {
                   filename: fileName,
                   contents: data,
                   mime: 'text/plain',
-              } }}
-              />}
+              } }} />}
 
                 <a {...{
                     title: 'Display the log in new window',
                     target: '_blank',
                     href: url,
-                }}
-                >
+                }}>
                     <Icon {...{ style, icon: 'launch' }} />
                 </a>
             </div>

--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -27,10 +27,11 @@ export default class LogToolbar extends Component {
               } }}
               />}
 
-                <a { ...{
+                <a {...{
                     title: 'Display the log in new window',
                     target: '_blank',
-                    href: url } }
+                    href: url,
+                }}
                 >
                     <Icon {...{ style, icon: 'launch' }} />
                 </a>

--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -15,17 +15,23 @@ export default class LogToolbar extends Component {
             return null;
         }
         const style = { fill: '#4a4a4a' };
+        const downloadLink = data ?
+            <DownloadLink
+              {...{ style,
+                    fileData: {
+                        filename: fileName,
+                        contents: data,
+                        mime: 'text/plain',
+                    },
+              }}
+            /> : null;
+
         return (<div className="log-header">
             <div className="log-header__section">
                 Build log – Build > Build source
             </div>
             <div className="log-header__section download-log-button">
-              { data && <DownloadLink {...{ style, fileData: {
-                  filename: fileName,
-                  contents: data,
-                  mime: 'text/plain',
-              } }}
-              />}
+                { downloadLink }
 
                 <a { ...{
                     title: 'Display the log in new window',

--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -27,11 +27,10 @@ export default class LogToolbar extends Component {
               } }}
               />}
 
-                <a {...{
+                <a { ...{
                     title: 'Display the log in new window',
                     target: '_blank',
-                    href: url,
-                }}
+                    href: url } }
                 >
                     <Icon {...{ style, icon: 'launch' }} />
                 </a>

--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -15,23 +15,17 @@ export default class LogToolbar extends Component {
             return null;
         }
         const style = { fill: '#4a4a4a' };
-        const downloadLink = data ?
-            <DownloadLink
-              {...{ style,
-                    fileData: {
-                        filename: fileName,
-                        contents: data,
-                        mime: 'text/plain',
-                    },
-              }}
-            /> : null;
-
         return (<div className="log-header">
             <div className="log-header__section">
                 Build log – Build > Build source
             </div>
             <div className="log-header__section download-log-button">
-                { downloadLink }
+              { data && <DownloadLink {...{ style, fileData: {
+                  filename: fileName,
+                  contents: data,
+                  mime: 'text/plain',
+              } }}
+              />}
 
                 <a { ...{
                     title: 'Display the log in new window',

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -82,10 +82,12 @@ class RunDetails extends Component {
         const baseUrl = `/organizations/${organization}/${name}` +
             `/detail/${branch}/${runId}`;
 
-        const result = this.props.runs.filter(
+        const currentRun = this.props.runs.filter(
             (run) => run.id === runId && decodeURIComponent(run.pipeline) === branch)[0];
 
-        result.name = name;
+        currentRun.name = name;
+
+        const status = currentRun.result === 'UNKNOWN' ? currentRun.state : currentRun.result;
 
         const afterClose = () => {
             const fallback = `/organizations/${organization}/${name}/`;
@@ -101,12 +103,12 @@ class RunDetails extends Component {
               isVisible
               transitionClass="slideup"
               transitionDuration={300}
-              result={result.result}
+              result={status}
               {...{ afterClose }}
             >
                 <ModalHeader>
                     <div>
-                        <PipelineResult data={result}
+                        <PipelineResult data={currentRun}
                           onOrganizationClick={() => this.navigateToOrganization()}
                           onNameClick={() => this.navigateToPipeline()}
                           onAuthorsClick={() => this.navigateToChanges()}
@@ -123,7 +125,7 @@ class RunDetails extends Component {
                     <div>
                         {React.cloneElement(
                             this.props.children,
-                            { baseUrl, result, ...this.props }
+                            { baseUrl, currentRun, ...this.props }
                         )}
                     </div>
                 </ModalBody>


### PR DESCRIPTION
**----
NOTE: Cannot be merged until jenkinsci/blueocean-plugin#56 is merged, published and our package.json files are updated
----**

Related to issue # JENKINS-35912. 

Summary of this pull request: 
* Simple change to pass result or state down to header

@reviewbybees 

