### PR TITLE
feature/JENKINS-35994 - freestyle missing empty states

### DIFF
--- a/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
@@ -33,8 +33,13 @@ const EmptyState = ({ repoName }) => (
 
 const NotSupported = () => (
     <main>
-        <EmptyStateView tightSpacing>
-            <p>Branches are not supported for this job type.</p>
+        <EmptyStateView>
+            <h1>Branches are unsupported</h1>
+            <p>
+            Branch builds only work with the <i>Multi-Branch Pipeline</i> job type.
+            This is just one of the many reasons to switch to Jenkins Pipeline.
+            </p>
+            <a href="https://jenkins.io/doc/book/pipeline-as-code/" target="_blank">Learn more</a>
         </EmptyStateView>
     </main>
 );
@@ -50,7 +55,7 @@ export class MultiBranch extends Component {
             unsupportedJob: false,
         };
     }
-    
+
     componentWillMount() {
         if (this.context.config && this.context.params) {
             const {

--- a/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
@@ -31,26 +31,55 @@ const EmptyState = ({ repoName }) => (
     </main>
 );
 
+const NotSupported = () => (
+    <main>
+        <EmptyStateView tightSpacing>
+            <p>Branches are not supported for this job type.</p>
+        </EmptyStateView>
+    </main>
+);
+
 EmptyState.propTypes = {
     repoName: string,
 };
 
 export class MultiBranch extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            unsupportedJob: false,
+        };
+    }
+    
     componentWillMount() {
         if (this.context.config && this.context.params) {
             const {
-                params: {
-                    pipeline,
-                },
                 config = {},
+                params: {
+                    pipeline: pipelineName,
+                },
+                pipeline,
             } = this.context;
-            config.pipeline = pipeline;
+
+            if (!pipeline.branchNames || !pipeline.branchNames.length) {
+                this.setState({
+                    unsupportedJob: true,
+                });
+                return;
+            }
+
+            config.pipeline = pipelineName;
             this.props.fetchBranchesIfNeeded(config);
         }
     }
 
     render() {
         const { branches } = this.props;
+
+        if (this.state.unsupportedJob) {
+            return (<NotSupported />);
+        }
+
         // early out
         if (!branches) {
             return null;
@@ -91,8 +120,9 @@ export class MultiBranch extends Component {
 }
 
 MultiBranch.contextTypes = {
-    params: object.isRequired,
     config: object.isRequired,
+    params: object.isRequired,
+    pipeline: object,
 };
 
 MultiBranch.propTypes = {

--- a/blueocean-dashboard/src/main/js/components/PullRequests.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequests.jsx
@@ -28,27 +28,55 @@ const EmptyState = ({ repoName }) => (
     </main>
 );
 
+const NotSupported = () => (
+    <main>
+        <EmptyStateView tightSpacing>
+            <p>Pull Requests are not supported for this job type.</p>
+        </EmptyStateView>
+    </main>
+);
+
 EmptyState.propTypes = {
     repoName: string,
 };
 
 export class PullRequests extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            unsupportedJob: false,
+        };
+    }
+
     componentWillMount() {
         if (this.context.config && this.context.params) {
             const {
-                params: {
-                    pipeline,
-                },
                 config = {},
+                params: {
+                    pipeline: pipelineName,
+                },
+                pipeline,
             } = this.context;
-            config.pipeline = pipeline;
+
+            if (!pipeline.branchNames || !pipeline.branchNames.length) {
+                this.setState({
+                    unsupportedJob: true,
+                });
+                return;
+            }
+
+            config.pipeline = pipelineName;
             this.props.fetchBranchesIfNeeded(config);
         }
     }
 
-
     render() {
         const { branches } = this.props;
+
+        if (this.state.unsupportedJob) {
+            return (<NotSupported />);
+        }
+
         // early out
         if (!branches) {
             return null;
@@ -87,8 +115,9 @@ export class PullRequests extends Component {
 }
 
 PullRequests.contextTypes = {
-    params: object.isRequired,
     config: object.isRequired,
+    params: object.isRequired,
+    pipeline: object,
 };
 
 PullRequests.propTypes = {

--- a/blueocean-dashboard/src/main/js/components/PullRequests.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequests.jsx
@@ -30,8 +30,13 @@ const EmptyState = ({ repoName }) => (
 
 const NotSupported = () => (
     <main>
-        <EmptyStateView tightSpacing>
-            <p>Pull Requests are not supported for this job type.</p>
+        <EmptyStateView>
+            <h1>Pull Requests are unsupported</h1>
+            <p>
+            Validated pull request builds only work with the <i>Multi-Branch Pipeline</i> job type.
+            This is just one of the many reasons to switch to Jenkins Pipeline.
+            </p>
+            <a href="https://jenkins.io/doc/book/pipeline-as-code/" target="_blank">Learn more</a>
         </EmptyStateView>
     </main>
 );


### PR DESCRIPTION
Related to issue # JENKINS-35994. 

Summary of this pull request: 
* Branches and Pull Requests tabs now check the pipeline to see if branch names are available. If not, it immediately renders an empty state message and suppresses any REST API calls that would otherwise produce 404.

@reviewbybees 
