### PR TITLE
JENKINS-35999# Fixed computation of parallel step if its running

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
@@ -434,7 +434,7 @@ public class PipelineNodeGraphBuilder {
         public NodeRunStatus(FlowNode endNode) {
             if (endNode.getError() != null) {
                 this.result = BlueRun.BlueRunResult.FAILURE;
-                this.state = BlueRun.BlueRunState.FINISHED;
+                this.state = endNode.isRunning() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
             }else if (endNode.isRunning()) {
                 this.result = BlueRun.BlueRunResult.UNKNOWN;
                 this.state = BlueRun.BlueRunState.RUNNING;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
@@ -98,6 +98,9 @@ public class PipelineNodeGraphBuilder {
                 FlowNode endNode = getStepEndNode(node);
                 if (endNode != null) {
                     nodeStatusMap.put(node, new PipelineNodeGraphBuilder.NodeRunStatus(endNode));
+                }else{
+                    //It's still running, report it as state: running and result: unknown
+                    nodeStatusMap.put(node, new PipelineNodeGraphBuilder.NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.RUNNING));
                 }
                 previousBranch = node;
             }
@@ -429,7 +432,10 @@ public class PipelineNodeGraphBuilder {
         private final BlueRun.BlueRunState state;
 
         public NodeRunStatus(FlowNode endNode) {
-            if (endNode.isRunning()) {
+            if (endNode.getError() != null) {
+                this.result = BlueRun.BlueRunResult.FAILURE;
+                this.state = BlueRun.BlueRunState.FINISHED;
+            }else if (endNode.isRunning()) {
                 this.result = BlueRun.BlueRunResult.UNKNOWN;
                 this.state = BlueRun.BlueRunState.RUNNING;
             } else if (NotExecutedNodeAction.isExecuted(endNode)) {

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineNodeTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineNodeTest.java
@@ -10,14 +10,78 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 /**
  * @author Vivek Pandey
  */
 public class PipelineNodeTest extends BaseTest {
+
+    //TODO: Enable this test if there is way to determine when test starts running and not waiting till launched
+//    @Test
+    public void nodesTest1() throws IOException, ExecutionException, InterruptedException {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "p1");
+        job.setDefinition(new CpsFlowDefinition("node {\n" +
+            "   stage 'Stage 1a'\n" +
+            "    echo 'Stage 1a'\n" +
+            "\n" +
+            "   stage 'Stage 2'\n" +
+            "   echo 'Stage 2'\n" +
+            "}\n" +
+            "node {\n" +
+            "    stage 'testing'\n" +
+            "    echo 'testig'\n" +
+            "}\n" +
+            "\n" +
+            "node {\n" +
+            "    parallel firstBranch: {\n" +
+            "    echo 'first Branch'\n" +
+            "    sh 'sleep 1'\n" +
+            "    echo 'first Branch end'\n" +
+            "    }, secondBranch: {\n" +
+            "       echo 'Hello second Branch'\n" +
+            "    sh 'sleep 1'   \n" +
+            "    echo 'second Branch end'\n" +
+            "       \n" +
+            "    },\n" +
+            "    failFast: false\n" +
+            "}"));
+        job.scheduleBuild2(0).waitForStart();
+
+        Thread.sleep(1000);
+        List<Map> resp = get("/organizations/jenkins/pipelines/p1/runs/1/nodes/", List.class);
+
+        for(int i=0; i< resp.size();i++){
+            Map rn = resp.get(i);
+            List<Map> edges = (List<Map>) rn.get("edges");
+
+            if(rn.get("displayName").equals("Stage 1a")){
+                Assert.assertEquals(1, edges.size());
+                Assert.assertEquals(rn.get("result"), "SUCCESS");
+                Assert.assertEquals(rn.get("state"), "FINISHED");
+            }else if(rn.get("displayName").equals("Stage 2")){
+                Assert.assertEquals(1, edges.size());
+                Assert.assertEquals(rn.get("result"), "SUCCESS");
+                Assert.assertEquals(rn.get("state"), "FINISHED");
+            }else if(rn.get("displayName").equals("testing")){
+                Assert.assertEquals(2, edges.size());
+                Assert.assertEquals(rn.get("result"), "UNKNOWN");
+                Assert.assertEquals(rn.get("state"), "RUNNING");
+            }else if(rn.get("displayName").equals("firstBranch")){
+                Assert.assertEquals(0, edges.size());
+                Assert.assertEquals(rn.get("result"), "UNKNOWN");
+                Assert.assertEquals(rn.get("state"), "RUNNING");
+            }else if(rn.get("displayName").equals("secondBranch")){
+                Assert.assertEquals(0, edges.size());
+                Assert.assertEquals(rn.get("result"), "UNKNOWN");
+                Assert.assertEquals(rn.get("state"), "RUNNING");
+            }
+        }
+    }
 
     @Test
     public void nodesWithFutureTest() throws Exception {


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
.
.
.

@reviewbybees 

State of a pipeline node is determined by looking at EndNode. In case of
parallel, if steps are running/not completed yet the reported status should be
UNKNOWN/RUNNING.