### PR TITLE
bug/jenkins 36000 - tab links need escaping

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -17,6 +17,8 @@ import {
     connect,
 } from '../redux';
 
+import { buildRunDetailsUrl } from '../util/UrlUtils';
+
 const { func, object, array, any, string } = PropTypes;
 
 class RunDetails extends Component {
@@ -79,8 +81,7 @@ class RunDetails extends Component {
             },
         } = this.context;
 
-        const baseUrl = `/organizations/${organization}/${name}` +
-            `/detail/${branch}/${runId}`;
+        const baseUrl = buildRunDetailsUrl(organization, name, branch, runId);
 
         const currentRun = this.props.runs.filter(
             (run) => run.id === runId && decodeURIComponent(run.pipeline) === branch)[0];

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -125,7 +125,7 @@ class RunDetails extends Component {
                     <div>
                         {React.cloneElement(
                             this.props.children,
-                            { baseUrl, currentRun, ...this.props }
+                            { baseUrl, result: currentRun, ...this.props }
                         )}
                     </div>
                 </ModalBody>

--- a/blueocean-dashboard/src/main/js/util/UrlUtils.js
+++ b/blueocean-dashboard/src/main/js/util/UrlUtils.js
@@ -9,3 +9,18 @@ export const removeLastUrlSegment = (url) => {
     paths.pop();
     return paths.join('/');
 };
+
+/**
+ * Build a root-relative URL to the run details modal.
+ * @param organization
+ * @param pipeline
+ * @param branch
+ * @param runId
+ * @param tabName
+ */
+export const buildRunDetailsUrl = (organization, pipeline, branch, runId, tabName) => {
+    const baseUrl = `/organizations/${encodeURIComponent(organization)}/` +
+        `${encodeURIComponent(pipeline)}/detail/` +
+        `${encodeURIComponent(branch)}/${encodeURIComponent(runId)}`;
+    return tabName ? `${baseUrl}/${tabName}` : baseUrl;
+};

--- a/blueocean-dashboard/src/test/js/UrlUtils-spec.js
+++ b/blueocean-dashboard/src/test/js/UrlUtils-spec.js
@@ -1,0 +1,40 @@
+import { assert } from 'chai';
+
+import { buildRunDetailsUrl } from '../../main/js/util/UrlUtils';
+
+describe('UrlUtils', () => {
+    describe('buildRunDetailsUrl', () => {
+        it('should build the baseUrl if tabName ommitted', () => {
+            const url = buildRunDetailsUrl(
+                'jenkins',
+                'blueocean',
+                'master',
+                1
+            );
+
+            assert.equal(url, '/organizations/jenkins/blueocean/detail/master/1');
+        });
+        it('should build the full url with tab name', () => {
+            const url = buildRunDetailsUrl(
+                'jenkins',
+                'blueocean',
+                'master',
+                1,
+                'changes'
+            );
+
+            assert.equal(url, '/organizations/jenkins/blueocean/detail/master/1/changes');
+        });
+        it('should escape characters correctly', () => {
+            const url = buildRunDetailsUrl(
+                'jenkins',
+                'blueocean',
+                'feature/JENKINS-666',
+                1,
+                'changes'
+            );
+
+            assert.equal(url, '/organizations/jenkins/blueocean/detail/feature%2FJENKINS-666/1/changes');
+        });
+    });
+});


### PR DESCRIPTION
Related to issue # JENKINS-36000. 

Summary of this pull request: 
* Fix broken tab links that were broken with branch names that included special chars
* Fix a regression from a prior commit

@reviewbybees 
