### PR TITLE
[feature/JENKINS-36064] use start param to show full log

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -29,7 +29,7 @@ export default class LogToolbar extends Component {
                 <a {...{
                     title: 'Display the log in new window',
                     target: '_blank',
-                    href: url,
+                    href: `${url}?start=0`,
                 }}>
                     <Icon {...{ style, icon: 'launch' }} />
                 </a>


### PR DESCRIPTION
Related to issue # . JENKINS-36064

Summary of this pull request: 
.
.use start param to show full log
.

@reviewbybees 

