### PR TITLE
Fixes JENKINS-36074

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -202,7 +202,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     public String getCommitId(){
         BuildData data = run.getAction(BuildData.class);
 
-        if (data == null
+        if(data == null
             || data.getLastBuiltRevision() == null
             || data.getLastBuiltRevision().getSha1String() == null) {
             return null;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -179,7 +179,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     public Collection<?> getActions() {
         List<BlueActionProxy> actionProxies = new ArrayList<>();
         for(Action action:run.getAllActions()){
-            if(!action.getClass().isAnnotationPresent(ExportedBean.class)){
+            if(action == null || !action.getClass().isAnnotationPresent(ExportedBean.class)){
                 continue;
             }
             actionProxies.add(new ActionProxiesImpl(action, this));
@@ -202,7 +202,9 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     public String getCommitId(){
         BuildData data = run.getAction(BuildData.class);
 
-        if(data == null){
+        if (data == null
+            || data.getLastBuiltRevision() == null
+            || data.getLastBuiltRevision().getSha1String() == null) {
             return null;
         } else {
             return data.getLastBuiltRevision().getSha1String();


### PR DESCRIPTION
Related to issue # JENKINS-36074. 

Summary of this pull request: 

The change to `getCommitId()` resolves a null pointer exception for an
edge case where a job with an SCM configuration was run, but the run
failed because the SCM configuration was faulty (bad URL, unable to
connect to private repo, etc)

The change to `getActions()` is unrelated to JENKINS-36074, but I needed
to fix that after pulling the latest changes in order to see the
`getCommitId()` fix working. I do not understand why an action would be
`null`; this behavior seems to have been introduced in the past few days,
as it did not occur when I originally fixed `getCommitId()` a few days ago

@reviewbybees 

