### PR TITLE
[FIXED JENKINS-36100] - fallback for DevelopmentFooter version string

### DIFF
--- a/blueocean-web/src/main/js/DevelopmentFooter.jsx
+++ b/blueocean-web/src/main/js/DevelopmentFooter.jsx
@@ -5,8 +5,13 @@ import revisionInfo from '../../../target/classes/io/jenkins/blueocean/revisionI
 
 export class DevelopmentFooter extends Component {
     render() {
-        if (!revisionInfo.name) {
-            return null;
+        if (!revisionInfo || !revisionInfo.name) {
+            var blueOceanVersion = document.getElementsByTagName('head')[0].getAttribute('data-blue-ocean-version');
+            return (
+                <div className="development-footer">
+                    <span>Blue Ocean UI v{blueOceanVersion}</span>
+                </div>
+            );
         }
         return (
           <div className="development-footer">

--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -12,7 +12,8 @@
         <head data-rooturl="${rootURL}/"
               data-resurl="${resURL}"
               data-appurl="${rootURL}/${it.urlBase}"
-              data-adjuncturl="${rootURL}/${j.getAdjuncts('').rootURL}">
+              data-adjuncturl="${rootURL}/${j.getAdjuncts('').rootURL}"
+              data-blue-ocean-version="${it.getPluginVersion()}">
 
             <title>Jenkins Blue Ocean</title>
 


### PR DESCRIPTION
Related to issue #JENKINS-36100. 

Summary of this pull request: 
. Add a fallback for DevelopmentFooter, when the json file can't be found

@reviewbybees 

![image](https://cloud.githubusercontent.com/assets/3009477/16418314/42431538-3d17-11e6-809e-27058e06651c.png)