### PR TITLE
JENKINS-36278# Fixed Link generation of Multibranch project

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BranchContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BranchContainerImpl.java
@@ -15,11 +15,12 @@ import java.util.List;
  */
 public class BranchContainerImpl extends BluePipelineContainer {
     private final MultiBranchPipelineImpl pipeline;
+    private final Link self;
 
-    public BranchContainerImpl(MultiBranchPipelineImpl pipeline) {
+    public BranchContainerImpl(MultiBranchPipelineImpl pipeline, Link self) {
         this.pipeline = pipeline;
+        this.self = self;
     }
-
     //TODO: implement rest of the methods
     @Override
     public BluePipeline get(String name) {
@@ -42,6 +43,6 @@ public class BranchContainerImpl extends BluePipelineContainer {
 
     @Override
     public Link getLink() {
-        return pipeline.getLink().rel("branches");
+        return self;
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BranchImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BranchImpl.java
@@ -18,7 +18,7 @@ public class BranchImpl extends PipelineImpl {
     private final Link parent;
 
     public BranchImpl(Job job, Link parent) {
-        super(job, parent);
+        super(job);
         this.parent = parent;
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/MultiBranchPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/MultiBranchPipelineImpl.java
@@ -109,6 +109,21 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     }
 
     @Override
+    public BluePipelineContainer getPipelines() {
+        return new BranchContainerImpl(this, getLink().rel("pipelines"));
+    }
+
+    @Override
+    public Integer getNumberOfFolders() {
+        return 0;
+    }
+
+    @Override
+    public Integer getNumberOfPipelines() {
+        return getTotalNumberOfBranches();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public Integer getWeatherScore(){
         /**
@@ -168,7 +183,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     @Override
     @Navigable
     public BluePipelineContainer getBranches() {
-        return new BranchContainerImpl(this);
+        return new BranchContainerImpl(this, getLink().rel("branches"));
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/MultiBranchPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/MultiBranchPipelineImpl.java
@@ -38,9 +38,9 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     /*package*/ final MultiBranchProject mbp;
 
     private final Link self;
-    public MultiBranchPipelineImpl(MultiBranchProject mbp, Link parent) {
+    public MultiBranchPipelineImpl(MultiBranchProject mbp) {
         this.mbp = mbp;
-        this.self = parent.rel(mbp.getName());
+        this.self = OrganizationImpl.INSTANCE.getLink().rel("pipelines").rel(PipelineImpl.getRecursivePathFromFullName(this));
     }
 
     @Override
@@ -288,7 +288,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
             if (item instanceof MultiBranchProject) {
-                return new MultiBranchPipelineImpl((MultiBranchProject) item, parent.getLink());
+                return new MultiBranchPipelineImpl((MultiBranchProject) item);
             }
             return null;
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -59,7 +59,7 @@ public class PipelineFolderImpl extends BluePipelineFolder {
 
     @Override
     public BluePipelineContainer getPipelines() {
-        return new PipelineContainerImpl(folder);
+        return new PipelineContainerImpl(folder, this);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
@@ -2,9 +2,7 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.Extension;
 import hudson.model.Action;
-import hudson.model.BuildableItem;
 import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.model.Job;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Navigable;
@@ -17,7 +15,6 @@ import io.jenkins.blueocean.rest.model.BlueQueueContainer;
 import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.BlueRunContainer;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
-import jenkins.branch.MultiBranchProject;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -29,8 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static io.jenkins.blueocean.service.embedded.rest.PipelineContainerImpl.isMultiBranchProjectJob;
-
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -38,23 +33,10 @@ import static io.jenkins.blueocean.service.embedded.rest.PipelineContainerImpl.i
 public class PipelineImpl extends BluePipeline {
     /*package*/ final Job job;
 
-    private final ItemGroup folder;
-
-    private final Link parent;
-
-    protected PipelineImpl(ItemGroup folder, Job job, Link parent) {
+    protected PipelineImpl(Job job) {
         this.job = job;
-        this.folder = folder;
-        this.parent = null;
     }
 
-    public PipelineImpl(ItemGroup folder, Link parent) {
-        this(folder, null,parent);
-    }
-
-    public PipelineImpl(Job job, Link parent) {
-        this(null, job, parent);
-    }
     @Override
     public String getOrganization() {
         return OrganizationImpl.INSTANCE.getName();
@@ -134,25 +116,6 @@ public class PipelineImpl extends BluePipeline {
         return job.getFullName();
     }
 
-    public BluePipeline getPipelines(String name){
-        assert folder != null;
-        return getPipeline(folder, name);
-    }
-
-    private  BluePipeline getPipeline(ItemGroup itemGroup, String name){
-        Item item = itemGroup.getItem(name);
-        if(item instanceof BuildableItem){
-            if(item instanceof MultiBranchProject){
-                return new MultiBranchPipelineImpl((MultiBranchProject) item, getLink());
-            }else if(!isMultiBranchProjectJob((BuildableItem) item) && item instanceof Job){
-                return new PipelineImpl(itemGroup, (Job) item, parent);
-            }
-        }else if(item instanceof ItemGroup){
-            return new PipelineImpl((ItemGroup) item, null);
-        }
-        throw new ServiceException.NotFoundException(String.format("Pipeline %s not found", name));
-    }
-
     @Override
     public Link getLink() {
         return OrganizationImpl.INSTANCE.getLink().rel("pipelines").rel(getRecursivePathFromFullName(this));
@@ -183,7 +146,7 @@ public class PipelineImpl extends BluePipeline {
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
             if (item instanceof Job) {
-                return new PipelineImpl((Job) item, parent.getLink());
+                return new PipelineImpl((Job) item);
             }
             return null;
         }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -12,7 +12,6 @@ import hudson.model.CauseAction;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
@@ -26,7 +25,6 @@ import hudson.tasks.Shell;
 import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.tasks.junit.TestResultAction;
 import io.jenkins.blueocean.rest.Reachable;
-import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.PipelineImpl;
@@ -560,7 +558,7 @@ public class PipelineApiTest extends BaseTest {
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
             if(item instanceof Job){
-                return new TestPipelineImpl(null, (Job)item, parent.getLink());
+                return new TestPipelineImpl((Job)item);
             }
             return null;
         }
@@ -568,8 +566,8 @@ public class PipelineApiTest extends BaseTest {
 
     public static class TestPipelineImpl extends PipelineImpl {
 
-        public TestPipelineImpl(ItemGroup folder, Job job, Link parent) {
-            super(folder, job, parent);
+        public TestPipelineImpl(Job job) {
+            super(job);
         }
 
         @Exported(name = "hello")

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueMultiBranchPipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueMultiBranchPipeline.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
  *
  * @author Vivek Pandey
  */
-public abstract class BlueMultiBranchPipeline extends BluePipeline{
+public abstract class BlueMultiBranchPipeline extends BluePipelineFolder{
     public static final String TOTAL_NUMBER_OF_BRANCHES="totalNumberOfBranches";
     public static final String NUMBER_OF_FAILING_BRANCHES="numberOfFailingBranches";
     public static final String NUMBER_OF_SUCCESSFULT_BRANCHES="numberOfSuccessfulBranches";


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
.
.
.

@reviewbybees 

Fixes:
- Link generation of multi branch project nested inside a folder
- BlueMultiBranchPipeline is a BluePipelineFolder now
- branches are reachable via /pipelines/:id/branches/:id or /pipelines/:id/pipelines/:id.
  This makes it consistent with generic folder as multibranch project is really a folder.