### PR TITLE
[JENKINS-36514] durationInMillis can be null so use Long instead of long

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineNodeGraphBuilder.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -282,6 +283,7 @@ public class PipelineNodeGraphBuilder {
         return parentToChildrenMap.get(parent);
     }
 
+    @Nullable
     public Long getDurationInMillis(FlowNode node){
         long startTime = TimingAction.getStartTime(node);
         if( startTime == 0){

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineStepImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineStepImpl.java
@@ -15,7 +15,7 @@ import java.util.Date;
 public class PipelineStepImpl extends BluePipelineStep {
     private final FlowNode node;
     private final PipelineNodeGraphBuilder.NodeRunStatus status;
-    private final long durationInMillis;
+    private final Long durationInMillis;
     private final Link self;
 
     public PipelineStepImpl(FlowNode node, PipelineNodeGraphBuilder graphBuilder, Link parent) {


### PR DESCRIPTION
Related to issue # . 

Summary of this pull request: 
.
.
.

@reviewbybees 

