### PR TITLE
[FIXED JENKINS-36302] - show test totals in blue ocean

### DIFF
--- a/blueocean-dashboard/src/main/js/components/testing/TestResults.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestResults.jsx
@@ -63,6 +63,7 @@ export default class TestResult extends Component {
         
         // possible statuses: PASSED, FAILED, SKIPPED
         const failures = tests.filter(t => t.status === 'FAILED');
+        const fixed = tests.filter(t => t.status === 'FIXED');
         const skipped = tests.filter(t => t.status === 'SKIPPED');
         const newFailures = failures.filter(t => t.age === 1);
         const existingFailures = failures.filter(t => t.age > 1);
@@ -71,6 +72,31 @@ export default class TestResult extends Component {
         let newFailureBlock = null;
         let existingFailureBlock = null;
         let skippedBlock = null;
+        let summaryBlock = null;
+        summaryBlock = (
+            <div className="test-summary">
+                <div className={`new-passed count-${fixed.length}`}>
+                    <div className="count">{fixed.length}</div>
+                    <label>Fixed</label>
+                </div>
+                <div className={`new-failed count-${newFailures.length}`}>
+                    <div className="count">{newFailures.length}</div>
+                    <label>New Failures</label>
+                </div>
+                <div className={`failed count-${testResults.failCount}`}>
+                    <div className="count">{testResults.failCount}</div>
+                    <label>Failures</label>
+                </div>
+                <div className={`passed count-${testResults.passCount}`}>
+                    <div className="count">{testResults.passCount}</div>
+                    <label>Passing</label>
+                </div>
+                <div className={`skipped count-${testResults.skipCount}`}>
+                    <div className="count">{testResults.skipCount}</div>
+                    <label>Skipped</label>
+                </div>
+            </div>
+        );
         
         if (testResults.failCount === 0) {
             passBlock = [
@@ -84,18 +110,11 @@ export default class TestResult extends Component {
             ];
         }
 
-        if (newFailures.length > 0 || existingFailures.length > 0) {
-            if (newFailures.length === 0) {
-                newFailureBlock = [
-                    <h4>New failing - {newFailures.length}</h4>,
-                    <div className="">No new failures</div>,
-                ];
-            } else {
-                newFailureBlock = [
-                    <h4>New failing - {newFailures.length}</h4>,
-                    newFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
-                ];
-            }
+        if (newFailures.length > 0) {
+            newFailureBlock = [
+                <h4>New failing - {newFailures.length}</h4>,
+                newFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
+            ];
         }
 
         if (existingFailures.length > 0) {
@@ -113,6 +132,7 @@ export default class TestResult extends Component {
         }
 
         return (<div>
+            {summaryBlock}
             {newFailureBlock}
             {existingFailureBlock}
             {skippedBlock}

--- a/blueocean-dashboard/src/main/less/testing.less
+++ b/blueocean-dashboard/src/main/less/testing.less
@@ -11,4 +11,56 @@
   .stack-trace {
     white-space: pre;
   }
+  .count {
+    font-size: 4rem;
+    padding-bottom: 0.1em;
+  }
+  .new-passed, .passed {
+    .count {
+      color: #4A9900; // @brand-success;
+    }
+  }
+  .count-0.count-0 {
+    .count {
+      color: #949393; // @brand-grey-lite;
+    }
+  }
+  .new-failed, .failed {
+    .count {
+      color: #C4000A; // @brand-danger;
+    }
+  }
+  .skipped {
+    .count {
+      color: #F5A623; // @branding-warning;
+    }
+  }
+  .test-summary {
+    width: 80%;
+    margin: 1.5em auto 2.5em auto;
+    display: table;
+    position: relative;
+    
+    > div {
+      display: table-cell;
+      text-align: center;
+      position: relative;
+      padding: .5em 1em;
+      width: 1%;
+    }
+    .failed:before {
+      content: '';
+      position: absolute;
+      height: 100%;
+      width: 1px;
+      display: inline-block;
+      border-left: 1px solid #949393; // @brand-grey-lite;
+      right: 100%;
+      top: 0;
+      margin-right: -0.4rem;
+    }
+    .skipped.count-0 {
+      display: none;
+    }
+  }
 }

--- a/blueocean-dashboard/src/test/js/testResult-spec.js
+++ b/blueocean-dashboard/src/test/js/testResult-spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import {createRenderer} from 'react-addons-test-utils';
+import { assert} from 'chai';
+import { shallow } from 'enzyme';
+
+import TestResults from '../../main/js/components/testing/TestResults.jsx';
+
+describe("TestResults", () => {
+  let wrapper;
+  const
+    renderer = createRenderer();
+
+  beforeEach(() => {
+    const testResults = {
+        "_class":"hudson.tasks.junit.TestResult",
+        "duration":0.008,
+        "empty":false,
+        "failCount":4,
+        "passCount":9,
+        "skipCount":3,
+        "suites":[
+            {"cases":[
+                    {"age":0,"className":"failure.TestThisWillFailAbunch","duration":0.002,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aPassingTest3","skipped":false,"skippedMessage":null,"status":"PASSED","stderr":null,"stdout":null},
+                    {"age":0,"className":"failure.TestThisWillFailAbunch","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aPassingTest4","skipped":false,"skippedMessage":null,"status":"PASSED","stderr":null,"stdout":null},
+                    {"age":4,"className":"failure.TestThisWillFailAbunch","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":7,"name":"aFailingTest2","skipped":true,"skippedMessage":null,"status":"SKIPPED","stderr":null,"stdout":null},
+                    {"age":4,"className":"failure.TestThisWillFailAbunch","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":7,"name":"aFailingTest3","skipped":true,"skippedMessage":null,"status":"SKIPPED","stderr":null,"stdout":null},
+                    {"age":0,"className":"failure.TestThisWillFailAbunch","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aFailingTest4","skipped":false,"skippedMessage":null,"status":"FIXED","stderr":null,"stdout":null},
+                    {"age":1,"className":"failure.TestThisWillFailAbunch","duration":0.003,"errorDetails":"<some exception here>","failedSince":7,"name":"aFailingTest","skipped":false,"skippedMessage":null,"status":"FAILED","stderr":null,"stdout":null},
+                    {"age":4,"className":"failure.TestThisWillFailAbunch","duration":0.001,"errorDetails":null,"errorStackTrace":null,"failedSince":7,"name":"aNewFailingTest31","skipped":true,"skippedMessage":null,"status":"SKIPPED","stderr":null,"stdout":null}
+                ],
+                "duration":0.008,
+                "id":null,
+                "name":"failure.TestThisWillFailAbunch",
+                "stderr":null,
+                "stdout":null,
+                "timestamp":null
+            },
+            {"cases":[
+                    {"age":0,"className":"failure.TestThisWontFail","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aPassingTest2","skipped":false,"skippedMessage":null,"status":"PASSED","stderr":null,"stdout":null},
+                    {"age":0,"className":"failure.TestThisWontFail","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aPassingTest3","skipped":false,"skippedMessage":null,"status":"PASSED","stderr":null,"stdout":null},
+                    {"age":0,"className":"failure.TestThisWontFail","duration":0,"errorDetails":null,"errorStackTrace":null,"failedSince":0,"name":"aPassingTest4","skipped":false,"skippedMessage":null,"status":"PASSED","stderr":null,"stdout":null},
+                    {"age":4,"className":"failure.TestThisWillFailAbunch","duration":0.003,"errorDetails":"<some exception here>","failedSince":7,"name":"aFailingTest","skipped":false,"skippedMessage":null,"status":"FAILED","stderr":null,"stdout":null},
+                    {"age":4,"className":"failure.TestThisWillFailAbunch","duration":0.003,"errorDetails":"<some exception here>","failedSince":7,"name":"aFailingTest","skipped":false,"skippedMessage":null,"status":"FAILED","stderr":null,"stdout":null},
+                ],
+                "duration":0,
+                "id":null,
+                "name":"failure.TestThisWontFail",
+                "stderr":null,
+                "stdout":null,
+                "timestamp":null
+            }
+        ]
+    };
+    wrapper = shallow(<TestResults testResults={testResults} />);
+  });
+
+  it("Test fixed included", () => {
+      const fixed = wrapper.find('.new-passed .count').text();
+      assert.equal(fixed, 1);
+
+      const failed = wrapper.find('.failed .count').text();
+      assert.equal(failed, 4);
+
+      const skipped = wrapper.find('.skipped .count').text();
+      assert.equal(skipped, 3);
+
+      const newFailed = wrapper.find('.new-failed .count').text();
+      assert.equal(newFailed, 1);
+  });
+});


### PR DESCRIPTION
Related to issue #JENKINS-36302. 

Summary of this pull request: 
. Add test total display to test results page

![image](https://cloud.githubusercontent.com/assets/3009477/16783746/62fd1516-4853-11e6-946e-36e1c7069f35.png)

![image](https://cloud.githubusercontent.com/assets/3009477/16783753/69b2ee58-4853-11e6-88a2-527952e5eb8b.png)

![image](https://cloud.githubusercontent.com/assets/3009477/16783757/6ddbc9fa-4853-11e6-942d-2c1ca9de9860.png)


@reviewbybees 

