### PR TITLE
[hotfix/JENKINS-36211] Bind onScroll and handleKeys to this

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -28,6 +28,8 @@ export class RunDetailsPipeline extends Component {
         // we do not want to follow any builds that are finished
         this.state = { followAlong: props && props.result && props.result.state !== 'FINISHED' };
         this.listener = {};
+        this._handleKeys = this._handleKeys.bind(this);
+        this.onScrollHandler = this.onScrollHandler.bind(this);
     }
 
     componentWillMount() {


### PR DESCRIPTION
**Decription**
https://issues.jenkins-ci.org/browse/JENKINS-36639

[hotfix/JENKINS-36211] Bind onScroll and handleKeys to this -> current master throws an exception 

The  "Scrolling down to the bottom of actively tailing log should reactivate karaoke" had not been implement but I can do that when working on the "jump around" issue

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 

