### PR TITLE
bug/jenkins-36619 - close modal 404

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -96,9 +96,9 @@ class RunDetails extends Component {
         const status = currentRun.result === 'UNKNOWN' ? currentRun.state : currentRun.result;
 
         const afterClose = () => {
-            const fallback = `/organizations/${organization}/${name}/`;
+            const fallbackUrl = buildPipelineUrl(organization, name);
 
-            location.pathname = this.opener || fallback;
+            location.pathname = this.opener || fallbackUrl;
             location.hash = `#${branch}-${runId}`;
 
             router.push(location);


### PR DESCRIPTION
**Decription**
* Fix the bug by encoding the project name correctly in the fallbackUrl
* I invested several hours into trying to write a unit test for this scenario. The idea was to expose a property "navigateToLocation:func" on RunDetails that would be called with the correct URL, then use sinon.spy to spy on it and assert that the URL was correct. Unfortunately this won't work because the callback is only invoked after the modal closes, which is requires some React state transitions to fire off first. The test execution won't wait, so it just shows the callback as not having been invoked. Maybe there's a way to delay it but I'm at a loss. I will push up a feature branch of the testing work so we have it for later in case someone else wants to take a look. Adding this bug to https://issues.jenkins-ci.org/browse/JENKINS-36660 so we can catch it in an acceptance test.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 