### PR TITLE
[FIX JENKINS-36704] New sse-gateway NPM package version - SSE diag logging

### DIFF
--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -38,7 +38,7 @@
     "@jenkins-cd/design-language": "0.0.63",
     "@jenkins-cd/js-extensions": "0.0.17-beta-1",
     "@jenkins-cd/js-modules": "0.0.5",
-    "@jenkins-cd/sse-gateway": "0.0.6-beta10",
+    "@jenkins-cd/sse-gateway": "0.0.6",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "keymirror": "0.1.1",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -38,7 +38,7 @@
     "@jenkins-cd/design-language": "0.0.63",
     "@jenkins-cd/js-extensions": "0.0.17-beta-1",
     "@jenkins-cd/js-modules": "0.0.5",
-    "@jenkins-cd/sse-gateway": "0.0.5",
+    "@jenkins-cd/sse-gateway": "0.0.6-beta4",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "keymirror": "0.1.1",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -38,7 +38,7 @@
     "@jenkins-cd/design-language": "0.0.63",
     "@jenkins-cd/js-extensions": "0.0.17-beta-1",
     "@jenkins-cd/js-modules": "0.0.5",
-    "@jenkins-cd/sse-gateway": "0.0.6-beta4",
+    "@jenkins-cd/sse-gateway": "0.0.6-beta10",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "keymirror": "0.1.1",

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.4</version>
+            <version>1.5-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.5-SNAPSHOT</version>
+            <version>1.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Description**

See [JENKINS-36704](https://issues.jenkins-ci.org/browse/JENKINS-36704) and [JENKINS-36763](https://issues.jenkins-ci.org/browse/JENKINS-36763).

Depends on https://github.com/jenkinsci/sse-gateway-plugin/pull/5

This pulls in a new version of the SSE Gateway NPM package (above PR). This new version has:

1. [JENKINS-36704](https://issues.jenkins-ci.org/browse/JENKINS-36704): Client-side logging around SSE activity that will hopefully make it easier to debug problems that are perceived to be related to SSE. There's no real automated/unit tests that can be reasonably done to automate testing of this (I say "reasonably" because there's prob some convoluted/unreasonable way of testing logging).
1. [JENKINS-36763](https://issues.jenkins-ci.org/browse/JENKINS-36763): A fix to the headless SSE client that was causing issues in the acceptance tests when running multiple test suites at once in dev mode ( `--dev` ). Tested in https://github.com/jenkinsci/blueocean-acceptance-test/issues/10

[See SSE Gateway PR branch docs for how to turn on and off logging](https://github.com/jenkinsci/sse-gateway-plugin/tree/JENKINS-36704#browser-diagnostics).

Some screenshots ...

<img width="1050" alt="screenshot 2016-07-15 14 16 45" src="https://cloud.githubusercontent.com/assets/429311/16876037/4cec2732-4a9a-11e6-83a0-895545ea8e51.png">

<img width="786" alt="screenshot 2016-07-15 14 17 13" src="https://cloud.githubusercontent.com/assets/429311/16876043/51605504-4a9a-11e6-886a-22885d17ef2c.png">

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

