### PR TITLE
JENKINS-36808# Fix bug where favorited MBP on classic not handled pro…

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueFavoriteResolver.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueFavoriteResolver.java
@@ -1,0 +1,33 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Item;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.model.BlueFavorite;
+
+/**
+ * Resolves favorite for a given model object {@link Item}
+ *
+ * For example:
+ *
+ * A favorite multi-branch project might resolve to a master branch pipeline
+ *
+ * @author Vivek Pandey
+ */
+public abstract class BlueFavoriteResolver implements ExtensionPoint {
+
+    /**
+     * Resolves a favorite {@link Item} to another model object as {@link BlueFavorite}
+     *
+     * @param item given favorite item that might resolve to another model object as favorite
+     *
+     * @return favorite item. null if it can't resolve.
+     */
+    public abstract BlueFavorite resolve(Item item, Reachable parent);
+
+
+    public static ExtensionList<BlueFavoriteResolver> all(){
+        return ExtensionList.lookup(BlueFavoriteResolver.class);
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -30,8 +30,8 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
         name = FavoriteUtil.decodeFullName(name);
         if(user.isFavorite(name)){
             Item item = Jenkins.getInstance().getItemByFullName(name);
-            if(FavoriteUtil.isFavorableItem(item)) {
-                return new FavoriteImpl(item, this);
+            if(item != null){
+                return FavoriteUtil.getFavorite(item, this);
             }
         }
         return null;
@@ -40,17 +40,23 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
     @Override
     public Iterator<BlueFavorite> iterator() {
         FavoriteUserProperty prop = user.getFavoriteProperty();
-        List<BlueFavorite> pipelines = new ArrayList<>();
+        List<BlueFavorite> favorites = new ArrayList<>();
         Jenkins j = Jenkins.getInstance();
 
         for(final String favorite: prop.getFavorites()){
             Item i = j.getItemByFullName(favorite, Item.class);
-            if(FavoriteUtil.isFavorableItem(i)){
-                pipelines.add(new FavoriteImpl(i, this));
+            if(i == null){
+                continue;
+            }
+            BlueFavorite blueFavorite = FavoriteUtil.getFavorite(i);
+            if(blueFavorite != null){
+                favorites.add(blueFavorite);
             }
         }
-        return pipelines.iterator();
+        return favorites.iterator();
     }
+
+
 
     @Override
     public Link getLink() {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteImpl.java
@@ -1,12 +1,7 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
-import hudson.model.Item;
-import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
-import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
-import jenkins.model.Jenkins;
-import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 
 /**
  * @author Vivek Pandey
@@ -19,21 +14,6 @@ public class FavoriteImpl extends BlueFavorite {
     public FavoriteImpl(Object item, Link self) {
         this.self = self;
         this.item = item;
-    }
-
-    public FavoriteImpl(Item item, Reachable parent) {
-        this.self = parent.getLink().rel(FavoriteUtil.encodeFullName(item.getFullName()));
-        LinkResolver linkResolver = Jenkins.getInstance().getInjector().getInstance(LinkResolver.class);
-
-        final Link link = linkResolver.resolve(item);
-
-        this.item = BluePipelineFactory.getPipelineInstance(item, new Reachable() {
-                @Override
-                public Link getLink() {
-                    return link.ancestor();
-                }
-            });
-
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -93,8 +93,8 @@ public class PipelineFolderImpl extends BluePipelineFolder {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
 
-        Link link = FavoriteUtil.favoriteJob(folder.getFullName(), favoriteAction.isFavorite());
-        return new FavoriteImpl(this, link);
+        FavoriteUtil.favoriteJob(folder.getFullName(), favoriteAction.isFavorite());
+        return FavoriteUtil.getFavorite(folder.getFullName(), this);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
@@ -108,8 +108,14 @@ public class PipelineImpl extends BluePipeline {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
 
-        Link link = FavoriteUtil.favoriteJob(job.getFullName(), favoriteAction.isFavorite());
-        return new FavoriteImpl(this, link);
+        FavoriteUtil.favoriteJob(job.getFullName(), favoriteAction.isFavorite());
+        return FavoriteUtil.getFavorite(job, new Reachable() {
+            @Override
+            public Link getLink() {
+                return PipelineImpl.this.getLink().ancestor();
+            }
+        });
+
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
@@ -8,11 +8,19 @@ import hudson.model.User;
 import hudson.plugins.favorite.FavoritePlugin;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.hal.LinkResolver;
+import io.jenkins.blueocean.rest.model.BlueFavorite;
+import io.jenkins.blueocean.rest.model.BluePipeline;
+import io.jenkins.blueocean.service.embedded.rest.BlueFavoriteResolver;
+import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
+import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
 import io.jenkins.blueocean.service.embedded.rest.UserImpl;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Stapler;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -21,7 +29,7 @@ import java.net.URLDecoder;
  * @author Ivan Meredith
  */
 public class FavoriteUtil {
-    public static Link favoriteJob(String fullName, boolean favorite) {
+    public static void favoriteJob(String fullName, boolean favorite) {
         User user = User.current();
         if(user == null) {
             throw new ServiceException.ForbiddenException("Must be logged in to use set favorites");
@@ -43,7 +51,14 @@ public class FavoriteUtil {
                 throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
             }
         }
-        return new UserImpl(user).getLink().rel("favorites/"+ Util.rawEncode(FavoriteUtil.encodeFullName(fullName)));
+    }
+
+    public static Link getFavoriteLink(String fullName){
+        User user = User.current();
+        if(user != null) {
+            return new UserImpl(user).getLink().rel("favorites/"+ FavoriteUtil.encodeFullName(fullName));
+        }
+        return null;
     }
 
     public static boolean isFavorableItem(Item i){
@@ -60,6 +75,64 @@ public class FavoriteUtil {
         } catch (UnsupportedEncodingException e) {
             throw new ServiceException.UnexpectedErrorException("Something went wrong URL decoding fullName: "+name, e);
         }
+    }
+
+
+    public static BlueFavorite getFavorite(String fullName, Reachable parent){
+        Item item = Jenkins.getInstance().getItem(fullName);
+        return getFavorite(item,parent);
+    }
+
+    public static BlueFavorite getFavorite(Item item){
+        LinkResolver linkResolver = Jenkins.getInstance().getInjector().getInstance(LinkResolver.class);
+
+        final Link l = linkResolver.resolve(item);
+        if(l !=null) {
+            return getFavorite(item, new Reachable() {
+                @Override
+                public Link getLink() {
+                    return l.ancestor();
+                }
+            });
+        }
+        return null;
+    }
+    /**
+     *  Gets favorite model for given model model
+     *
+     *  First it tries to find favorite model using {@link BlueFavoriteResolver}, if none found then it simply gets the
+     *  mapped blueocean API resource for the given favorite item, creates BlueFavorite and returns.
+     *
+     * @param item favorited model object
+     * @param parent {@link Reachable} parent of BlueOcean favorited API resource. It might be null, in that case parent
+     *               is computed using {@link LinkResolver#resolve(Object)}
+     * @return resolved favorite object if found otherwise null
+     */
+    public static BlueFavorite getFavorite(Item item, @Nonnull Reachable parent){
+        if(item == null){
+            return null;
+        }
+
+        //If there is a resolver to resolve this favorite item to another model object as favorite
+        for(BlueFavoriteResolver resolver: BlueFavoriteResolver.all()){
+            BlueFavorite blueFavorite = resolver.resolve(item,parent);
+            if(blueFavorite != null){
+                return blueFavorite;
+            }
+        }
+
+        //otherwise, default
+        Link favouriteLink = getFavoriteLink(item.getFullName());
+        if(favouriteLink == null){
+            return null;
+        }
+
+        BluePipeline pipeline = BluePipelineFactory.getPipelineInstance(item, parent);
+        if(pipeline != null){
+            return new FavoriteImpl(pipeline,favouriteLink);
+        }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
**Decription**

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

1.  Favorite a MBP with master branch in classic UI
2. GET /rest/users/:id/favorites/ should give you favorite with item pointing to master branch
3. Retest  all favorite API functionalities as described in https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-rest#favorite-api.

cc: @cliffmeyers @imeredith 

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 

…perly

- Favorited MBP project favorites MBP in the backend model, both in classic as well as BO
- When MBP favorite is queried using /users/:id/favorites/[:id] API, default branch of MBP is returned
- FavoriteResolver extension point is used to give a chance to pipeline implementor to resolve a favorite Jenkins model object to another item. For example multi branch BO API implementation resolves a favorited MBP project to it's default branch 'master'. Another implementation of MBP API could resolve it to something else if it choses to do so.