### PR TITLE
JENKINS-36829 - fix context path passed to blue ocean - don't end with /

### DIFF
--- a/blueocean-dashboard/src/main/js/Dashboard.jsx
+++ b/blueocean-dashboard/src/main/js/Dashboard.jsx
@@ -4,12 +4,16 @@ import appConfig from './config';
 
 const { object, node } = PropTypes;
 
+appConfig.loadConfig();
+
 // Connect to the SSE Gateway and allocate a
 // dispatcher for blueocean.
 // TODO: We might want to move this code to a local SSE util module.
-sse.connect('jenkins_blueocean');
-
-appConfig.loadConfig();
+sse.connect({
+    clientId: 'jenkins_blueocean',
+    onConnect: undefined,
+    jenkinsUrl: `${appConfig.getJenkinsRootURL()}/`, // FIXME sse should not require this to end with a /
+});
 
 class Dashboard extends Component {
 

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -38,7 +38,7 @@ export default class Pipelines extends Component {
         ];
 
         const baseUrl = config.getRootURL();
-        const newJobUrl = `${baseUrl}view/All/newJob`;
+        const newJobUrl = `${baseUrl}/view/All/newJob`;
 
         return (
             <Page>

--- a/blueocean-web/src/main/js/config.js
+++ b/blueocean-web/src/main/js/config.js
@@ -6,10 +6,10 @@
 export default class Config {
 
     constructor(options) {
-        this._appURLBase = options.appURLBase || "/";
-        this._rootURL = options.rootURL || "/";
-        this._resourceURL = options.resourceURL || "/";
-        this._adjunctURL = options.adjunctURL || "/";
+        this._appURLBase = options.appURLBase || '';
+        this._rootURL = options.rootURL || '';
+        this._resourceURL = options.resourceURL || '';
+        this._adjunctURL = options.adjunctURL || '';
     }
 
     getAppURLBase() {

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -84,7 +84,7 @@ function startApp(routes, stores) {
     let appURLBase = headElement.getAttribute("data-appurl");
 
     if (typeof appURLBase !== "string") {
-        appURLBase = "/";
+        appURLBase = '';
     }
 
     // Look up some other URLs we may need

--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -9,7 +9,7 @@
         <j:invokeStatic var="j" className="jenkins.model.Jenkins" method="getActiveInstance"/>
         ${h.initPageVariables(context)}
 
-        <head data-rooturl="${rootURL}/"
+        <head data-rooturl="${rootURL}"
               data-resurl="${resURL}"
               data-appurl="${rootURL}/${it.urlBase}"
               data-adjuncturl="${rootURL}/${j.getAdjuncts('').rootURL}"


### PR DESCRIPTION
**Decription**

Context path was not handled properly from Java, use typical Java handling: always begin things appended to it with a `/`. I can't test this properly without an ATH test...

To test: verify the app works as expected (including sse) under root context and `/jenkins` context.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 

