### PR TITLE
[JENKINS-36231] less timeout for scrollBottom and scroll on every pro…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -86,9 +86,8 @@ export class LogConsole extends Component {
             this.timeouts.render = setTimeout(() => {
                 this._processNextLines();
             }, RERENDER_DELAY);
-        } else {
-            this.scroll();
         }
+        this.scroll();
     }
 
     scroll() {
@@ -100,7 +99,7 @@ export class LogConsole extends Component {
          * React needs the timeout to have the dom ready
          */
         if (this.props.scrollToBottom && !match) {
-            this.timeouts.scroll = setTimeout(() => this.props.scrollBottom(), INITIAL_RENDER_DELAY + 1);
+            this.timeouts.scroll = setTimeout(() => this.props.scrollBottom(), RERENDER_DELAY + 1);
         } else if (match) {
             // we need to scroll to a certain line now
             this.timeouts.scroll = this.props.scrollToAnchorTimeOut(RERENDER_DELAY + 1);


### PR DESCRIPTION
**Decription**
reduce  timeout on scrollBottom and scroll after each cycle and not at the end

This is a change that is granular, creation of test case is not possible.
**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 

especially @i386  ANOTHER OPTION AFTER is not the PR! AFTER is

** Freestyle ***

BEFORE: https://youtu.be/KOe5VqWeCZo
AFTER: https://youtu.be/mkBaPrNNjys

```
const RENDER_CHUNK_SIZE = 500;
const RERENDER_DELAY = 17;
```

ANOTHER OPTION AFTER  https://youtu.be/jVWLVqeGmeY

```
const RENDER_CHUNK_SIZE = 50;
const RERENDER_DELAY = 7;
```

**pipeline**

Jenkinsfile

```
node {
    stage 'deploy'
    sh '''#!/bin/bash -l
echo $0
COUNTER=0
while [  $COUNTER -lt 5000 ]; do
 echo The counter is $COUNTER
 let COUNTER=COUNTER+1
done
sleep 2;
'''
stage 'end'
    sh '''#!/bin/bash -l
echo $0
COUNTER=0
while [  $COUNTER -lt 5000 ]; do
 echo The counter is $COUNTER
 let COUNTER=COUNTER+1
done
sleep 2;
'''
}
```

BEFORE: https://youtu.be/wqQ6FDxTyiI
AFTER: https://youtu.be/y33vsY7C5I0

```
const RENDER_CHUNK_SIZE = 500;
const RERENDER_DELAY = 17;
```
ANOTHER OPTION AFTER https://youtu.be/FXPSXmR_KYQ

```
const RENDER_CHUNK_SIZE = 50;
const RERENDER_DELAY = 7;
```
