### PR TITLE
[FIXED JENKINS-36712] Get rid of React warning about duplicate/missing keys on test page

### DIFF
--- a/blueocean-dashboard/src/main/js/components/testing/TestResults.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestResults.jsx
@@ -116,31 +116,31 @@ export default class TestResult extends Component {
             );
 
             if (newFailures.length > 0) {
-                newFailureBlock = [
-                    <h4>New failing - {newFailures.length}</h4>,
-                    newFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
-                ];
+                newFailureBlock = (<div className="test-result-block new-failure-block">
+                    <h4>New failing - {newFailures.length}</h4>
+                    {newFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />)}
+                </div>);
             }
 
             if (existingFailures.length > 0) {
-                existingFailureBlock = [
-                    <h4>Existing failures - {existingFailures.length}</h4>,
-                    existingFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
-                ];
+                existingFailureBlock = (<div className="test-result-block existing-failure-block">
+                    <h4>Existing failures - {existingFailures.length}</h4>
+                    {existingFailures.map((t, i) => <TestCaseResultRow key={i} testCase={t} />)}
+                </div>);
             }
 
             if (fixed.length > 0) {
-                fixedBlock = [
-                    <h4>Fixed</h4>,
-                    fixed.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
-                ];
+                fixedBlock = (<div className="test-result-block fixed-block">
+                    <h4>Fixed</h4>
+                    {fixed.map((t, i) => <TestCaseResultRow key={i} testCase={t} />)}
+                </div>);
             }
 
             if (skipped.length > 0) {
-                skippedBlock = [
-                    <h4>Skipped - {skipped.length}</h4>,
-                    skipped.map((t, i) => <TestCaseResultRow key={i} testCase={t} />),
-                ];
+                skippedBlock = (<div className="test-result-block skipped-block">
+                    <h4>Skipped - {skipped.length}</h4>
+                    {skipped.map((t, i) => <TestCaseResultRow key={i} testCase={t} />)}
+                </div>);
             }
         }
 

--- a/blueocean-dashboard/src/main/less/testing.less
+++ b/blueocean-dashboard/src/main/less/testing.less
@@ -1,8 +1,11 @@
 .test-results-container {
-  h4 {
-    margin: 1em 0 .4em 0;
+  .test-result-block {
+    margin: 1em 0 0 0;
     &:first-child {
       margin-top: 0;
+    }
+    h4 {
+      margin: 0 0 .4em 0;
     }
   }
   .test-console {


### PR DESCRIPTION
**Decription**

"Erroneous" message about missing keys on the test reporting page due to use of an array. Unsure how to test for react warning messages to console, don't think it's necessary. To test: go to test report page with some failures, validate there are no react warning messages in the browser console log.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees esp. @cliffmeyers 

