### PR TITLE
Jenkins 36131 "Show all" link required anywhere a log is displayed

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -116,7 +116,7 @@ export class LogConsole extends Component {
         return (<code
           className="block"
         >
-            { hasMore && <div key={0} id={`${prefix}log-${0}`}>
+            { hasMore && <div key={0} id={`${prefix}log-${0}`} className='fullLog'>
                 <a
                   key={0}
                   href={`?start=0#${prefix || ''}log-${1}`}

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -108,7 +108,7 @@ export class LogConsole extends Component {
 
     render() {
         const lines = this.state.lines;
-        const { prefix = '' } = this.props;
+        const { prefix = '', hasMore = false } = this.props;
         if (!lines) {
             return null;
         }
@@ -117,7 +117,18 @@ export class LogConsole extends Component {
           className="block"
         >
             { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
-                <a key={index + 1} href={`#${prefix || ''}log-${index + 1}`} name={`${prefix}log-${index + 1}`}>{line}</a>
+                { hasMore && index === 0 && <a
+                  key={index + 1}
+                  href={`#${prefix || ''}log-${index}`}
+                >
+                    href to fullLog
+                </a>}
+                { index > 0 && <a
+                  key={index + 1}
+                  href={`#${prefix || ''}log-${index + 1}`}
+                  name={`${prefix}log-${index + 1}`}
+                >{line}
+                </a>}
             </p>)}</code>);
     }
 }
@@ -129,6 +140,7 @@ LogConsole.propTypes = {
     scrollToAnchorTimeOut: func,
     scrollBottom: func,
     prefix: string,
+    hasMore: bool,
 };
 
 export default scrollHelper(LogConsole);

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -116,14 +116,14 @@ export class LogConsole extends Component {
         return (<code
           className="block"
         >
-            { hasMore && <p key={0} id={`${prefix}log-${0}`}>
+            { hasMore && <div key={0} id={`${prefix}log-${0}`}>
                 <a
                   key={0}
                   href={`?start=0#${prefix || ''}log-${1}`}
                 >
-                Full Log
+                Show complete log
             </a>
-            </p>}
+            </div>}
             { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
                 <a
                   key={index + 1}

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -108,7 +108,7 @@ export class LogConsole extends Component {
 
     render() {
         const lines = this.state.lines;
-        const { prefix = '', hasMore = false } = this.props;
+        const { prefix = '', hasMore = false } = this.props; // if hasMore true then show link to full log
         if (!lines) {
             return null;
         }
@@ -116,19 +116,21 @@ export class LogConsole extends Component {
         return (<code
           className="block"
         >
-            { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
-                { hasMore && index === 0 && <a
-                  key={index + 1}
-                  href={`#${prefix || ''}log-${index}`}
+            { hasMore && <p key={0} id={`${prefix}log-${0}`}>
+                <a
+                  key={0}
+                  href={`#${prefix || ''}log-${0}`}
                 >
-                    href to fullLog
-                </a>}
-                { index > 0 && <a
+                Full Log
+            </a>
+            </p>}
+            { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
+                <a
                   key={index + 1}
                   href={`#${prefix || ''}log-${index + 1}`}
                   name={`${prefix}log-${index + 1}`}
                 >{line}
-                </a>}
+                </a>
             </p>)}</code>);
     }
 }

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -119,7 +119,7 @@ export class LogConsole extends Component {
             { hasMore && <p key={0} id={`${prefix}log-${0}`}>
                 <a
                   key={0}
-                  href={`#${prefix || ''}log-${0}`}
+                  href={`?start=0#${prefix || ''}log-${1}`}
                 >
                 Full Log
             </a>

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -116,7 +116,7 @@ export class LogConsole extends Component {
         return (<code
           className="block"
         >
-            { hasMore && <div key={0} id={`${prefix}log-${0}`} className='fullLog'>
+            { hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
                 <a
                   key={0}
                   href={`?start=0#${prefix || ''}log-${1}`}

--- a/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogToolbar.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import { Icon } from 'react-material-icons-blue';
+import { fetchAllSuffix as suffix } from '../util/UrlUtils';
 
 const { string } = PropTypes;
 
@@ -12,6 +13,7 @@ export default class LogToolbar extends Component {
         if (!url) {
             return null;
         }
+        const logUrl = url.includes(suffix) ? url : `${url}${suffix}`;
         const style = { fill: '#4a4a4a' };
         return (<div className="log-header">
             <div className="log-header__section">
@@ -21,13 +23,13 @@ export default class LogToolbar extends Component {
                 <a {...{
                     title: 'Display the log in new window',
                     target: '_blank',
-                    href: `${url}?start=0`,
+                    href: logUrl,
                 }}>
                     <Icon size={24} {...{ style, icon: 'launch' }} />
                 </a>
                 <a {...{
                     title: 'Download the log file',
-                    href: `${url}?start=0&download=true`,
+                    href: `${logUrl}&download=true`,
                 }}>
                     <Icon size={24} {...{ style, icon: 'file_download' }} />
                 </a>

--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -45,7 +45,9 @@ export class RunDetailsPipeline extends Component {
         } else {
             // console.log('fetch the log directly')
             const logGeneral = calculateRunLogURLObject(this.mergedConfig);
-            fetchLog({ ...logGeneral });
+            // fetchAll indicates whether we want all logs
+            const fetchAll = this.mergedConfig.fetchAll;
+            fetchLog({ ...logGeneral, fetchAll });
         }
 
         // Listen for pipeline flow node events.
@@ -127,10 +129,13 @@ export class RunDetailsPipeline extends Component {
             // if we have actions we fire them
             this.props[nodeAction.action](this.mergedConfig);
         }
+        const fetchAll = this.mergedConfig.fetchAll;
+        // console.log('this.mergedConfig.fetchAll', fetchAll)
         // if we only interested in logs (in case of e.g. freestyle)
         const { logs, fetchLog } = nextProps;
-        if (logs !== this.props.logs) {
+        if (logs !== this.props.logs || fetchAll) {
             const logGeneral = calculateRunLogURLObject(this.mergedConfig);
+            // console.log('logGenralReceive', logGeneral)
             const log = logs ? logs[logGeneral.url] : null;
             if (log && log !== null) {
                 // we may have a streaming log
@@ -144,9 +149,15 @@ export class RunDetailsPipeline extends Component {
                         this.timeout = setTimeout(() => fetchLog({ ...logGeneral, newStart }), 1000);
                     }
                 }
+            } else if (fetchAll) {
+                // kill current  timeout if any
+                clearTimeout(this.timeout);
+                // we need to get mpre input from the log stream
+                this.timeout = setTimeout(() => fetchLog({ ...logGeneral, fetchAll }), 1000);
             }
         }
     }
+
 
     componentWillUnmount() {
         const domNode = ReactDOM.findDOMNode(this.refs.scrollArea);
@@ -173,6 +184,20 @@ export class RunDetailsPipeline extends Component {
             this.setState({ followAlong: false });
         }
     }
+    // using the hook 'location.hash' === #log-0 to trigger fetchAll
+    calculateFetchAll(props) {
+        const { location: { hash: anchorName } } = props;
+        //console.log(location)
+        if (anchorName) {
+            const stepReg = /log-([0-9]{1,}$)/;
+            const match = stepReg.exec(anchorName);
+            if (match && match[1] && Number(match[1]) === 0) {
+                console.log(true)
+                return true;
+            }
+        }
+        return false;
+    }
 
     generateConfig(props) {
         const {
@@ -183,6 +208,7 @@ export class RunDetailsPipeline extends Component {
             isMultiBranch,
             params: { pipeline: name, branch, runId, node: nodeParam },
         } = props;
+        const fetchAll = this.calculateFetchAll(props);
         // we would use default properties however the node can be null so no default properties will be triggered
         let { nodeReducer } = props;
         if (!nodeReducer) {
@@ -191,7 +217,7 @@ export class RunDetailsPipeline extends Component {
         // if we have a node param we do not want the calculation of the focused node
         const node = nodeParam || nodeReducer.id;
 
-        const mergedConfig = { ...config, name, branch, runId, isMultiBranch, node, nodeReducer, followAlong };
+        const mergedConfig = { ...config, name, branch, runId, isMultiBranch, node, nodeReducer, followAlong, fetchAll };
         return mergedConfig;
     }
 

--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -279,6 +279,19 @@ export class RunDetailsPipeline extends Component {
         };
         const noSteps = !log && currentSteps && currentSteps.model && currentSteps.model.length === 0;
         const shouldShowLogHeader = log !== null || !noSteps;
+        const logProps = {
+            scrollToBottom,
+            key: logGeneral.url,
+        };
+        if (log) {
+            // in follow along the Full Log button should not be shown, since you see everything already
+            if (followAlong) {
+                logProps.hasMore = false;
+            } else {
+                logProps.hasMore = log.hasMore;
+            }
+            logProps.logArray = log.logArray;
+        }
         return (
             <div ref="scrollArea">
                 { nodes && nodes[nodeKey] && <Extensions.Renderer
@@ -310,12 +323,7 @@ export class RunDetailsPipeline extends Component {
                 </EmptyStateView>
                 }
 
-                { log && <LogConsole
-                  hasMore={log.hasMore}
-                  key={logGeneral.url}
-                  logArray={log.logArray}
-                  scrollToBottom={scrollToBottom}
-                /> }
+                { log && <LogConsole {...logProps} /> }
             </div>
         );
     }

--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -298,7 +298,12 @@ export class RunDetailsPipeline extends Component {
                 </EmptyStateView>
                 }
 
-                { log && <LogConsole key={logGeneral.url} logArray={log.logArray} scrollToBottom={scrollToBottom} /> }
+                { log && <LogConsole
+                  hasMore={log.hasMore}
+                  key={logGeneral.url}
+                  logArray={log.logArray}
+                  scrollToBottom={scrollToBottom}
+                /> }
             </div>
         );
     }

--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -150,14 +150,14 @@ export class RunDetailsPipeline extends Component {
 
     componentWillUnmount() {
         const domNode = ReactDOM.findDOMNode(this.refs.scrollArea);
-        domNode.removeEventListener('wheel', this._onScrollHandler);
-        document.removeEventListener('keydown', this._handleKeys);
         if (this.listener.sse) {
             sse.unsubscribe(this.listener.sse);
             delete this.listener.sse;
         }
         this.props.cleanNodePointer();
         clearTimeout(this.timeout);
+        domNode.removeEventListener('wheel', this._onScrollHandler);
+        document.removeEventListener('keydown', this._handleKeys);
     }
 
     // need to register handler to step out of karaoke mode

--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -17,7 +17,7 @@ import {
     createSelector,
 } from '../redux';
 
-import { calculateStepsBaseUrl, calculateRunLogURLObject, calculateNodeBaseUrl } from '../util/UrlUtils';
+import { calculateStepsBaseUrl, calculateRunLogURLObject, calculateNodeBaseUrl, calculateFetchAll } from '../util/UrlUtils';
 import { calculateNode } from '../util/KaraokeHelper';
 
 
@@ -184,20 +184,6 @@ export class RunDetailsPipeline extends Component {
             this.setState({ followAlong: false });
         }
     }
-    // using the hook 'location.hash' === #log-0 to trigger fetchAll
-    calculateFetchAll(props) {
-        const { location: { hash: anchorName } } = props;
-        //console.log(location)
-        if (anchorName) {
-            const stepReg = /log-([0-9]{1,}$)/;
-            const match = stepReg.exec(anchorName);
-            if (match && match[1] && Number(match[1]) === 0) {
-                console.log(true)
-                return true;
-            }
-        }
-        return false;
-    }
 
     generateConfig(props) {
         const {
@@ -208,7 +194,7 @@ export class RunDetailsPipeline extends Component {
             isMultiBranch,
             params: { pipeline: name, branch, runId, node: nodeParam },
         } = props;
-        const fetchAll = this.calculateFetchAll(props);
+        const fetchAll = calculateFetchAll(props);
         // we would use default properties however the node can be null so no default properties will be triggered
         let { nodeReducer } = props;
         if (!nodeReducer) {

--- a/blueocean-dashboard/src/main/js/components/Step.jsx
+++ b/blueocean-dashboard/src/main/js/components/Step.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { ResultItem } from '@jenkins-cd/design-language';
-import { calculateLogUrl } from '../util/UrlUtils';
+import { calculateFetchAll, calculateLogUrl } from '../util/UrlUtils';
 
 import LogConsole from './LogConsole';
 
@@ -72,22 +72,20 @@ export default class Node extends Component {
     expandAnchor(props) {
         const { node, location: { hash: anchorName } } = props;
         const isFocused = true;
+        const fetchAll = calculateFetchAll(props);
+        const general = { ...node, fetchAll };
         // e.g. #step-10-log-1 or #step-10
         if (anchorName) {
             const stepReg = /step-([0-9]{1,})?($|-log-([0-9]{1,})$)/;
             const match = stepReg.exec(anchorName);
 
             if (match && match[1] && match[1] === node.id) {
-                const newVar = { ...node, isFocused };
-                if (match[3] && Number(match[3]) === 0) {
-                    newVar.fetchAll = true;
-                }
-                return newVar;
+                return { ...general, isFocused };
             }
         } else if (this.state && this.state.isFocused) {
-            return { ...node, isFocused };
+            return { ...general, isFocused };
         }
-        return { ...node };
+        return general;
     }
 
     render() {

--- a/blueocean-dashboard/src/main/js/components/Step.jsx
+++ b/blueocean-dashboard/src/main/js/components/Step.jsx
@@ -126,7 +126,12 @@ export default class Node extends Component {
             prefix: `step-${id}-`,
         };
         if (log) {
-            logProps.hasMore = log.hasMore;
+            // in follow along the Full Log button should not be shown, since you see everything already
+            if (followAlong) {
+                logProps.hasMore = false;
+            } else {
+                logProps.hasMore = log.hasMore;
+            }
             logProps.logArray = log.logArray;
         }
         return (<div className="logConsole">

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -777,6 +777,9 @@ export const actions = {
                     config.newStart || null,
                     response => response.response.text()
                         .then(text => {
+                            const maxLength = 19200;
+                            const contentLength = Number(response.response.headers.get('Content-Length'));
+                            console.log('response', contentLength > maxLength)
                             const { newStart } = response;
                             const payload = {
                                 logUrl,

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -785,6 +785,7 @@ export const actions = {
                             // set flag that there are more logs then we deliver
                             let hasMore = contentLength > maxLength;
                             // when we came from ?start=0, hasMore has to be false since there is no more
+                            // console.log(config.fetchAll, 'inner')
                             if (config.fetchAll) {
                                 hasMore = false;
                             }

--- a/blueocean-dashboard/src/main/js/util/UrlUtils.js
+++ b/blueocean-dashboard/src/main/js/util/UrlUtils.js
@@ -40,6 +40,16 @@ export const buildRunDetailsUrl = (organization, pipeline, branch, runId, tabNam
  */
 export const uriString = (input) => encodeURIComponent(input).replace(/%2F/g, '%252F');
 
+export const fetchAllSuffix = '?start=0';
+
+export const applyFetchAll = function (config, url) {
+// if we pass fetchAll means we want the full log -> start=0 will trigger that on the server
+    if (config.fetchAll && !url.includes(fetchAllSuffix)) {
+        return `${url}${fetchAllSuffix}`;
+    }
+    return url;
+};
+
 /*
  * helper to calculate log url. When we have a node we get create a special url, otherwise we use the url passed to us
  * @param config { nodesBaseUrl, node, url}
@@ -50,11 +60,7 @@ export const calculateLogUrl = (config) => {
         const { nodesBaseUrl, node } = config;
         returnUrl = `${nodesBaseUrl}/${node.id}/log/`;
     }
-    // if we pass fetchAll means we want the full log -> start=0 will trigger that on the server
-    if (config.fetchAll) {
-        returnUrl += '?start=0';
-    }
-    return returnUrl;
+    return applyFetchAll(config, returnUrl);
 };
 
 /*
@@ -110,6 +116,7 @@ export function calculateRunLogURLObject(config) {
         url = `${baseUrl}/runs/${runId}/log/`;
         fileName = `${runId}.txt`;
     }
+    url = applyFetchAll(config, url);
     return {
         url,
         fileName,

--- a/blueocean-dashboard/src/main/js/util/UrlUtils.js
+++ b/blueocean-dashboard/src/main/js/util/UrlUtils.js
@@ -45,11 +45,16 @@ export const uriString = (input) => encodeURIComponent(input).replace(/%2F/g, '%
  * @param config { nodesBaseUrl, node, url}
  */
 export const calculateLogUrl = (config) => {
+    let returnUrl = config.url;
     if (config.node) {
         const { nodesBaseUrl, node } = config;
-        return `${nodesBaseUrl}/${node.id}/log/`;
+        returnUrl = `${nodesBaseUrl}/${node.id}/log/`;
     }
-    return config.url;
+    // if we pass fetchAll means we want the full log -> start=0 will trigger that on the server
+    if (config.fetchAll) {
+        returnUrl += '?start=0';
+    }
+    return returnUrl;
 };
 
 /*

--- a/blueocean-dashboard/src/main/js/util/UrlUtils.js
+++ b/blueocean-dashboard/src/main/js/util/UrlUtils.js
@@ -40,14 +40,30 @@ export const buildRunDetailsUrl = (organization, pipeline, branch, runId, tabNam
  */
 export const uriString = (input) => encodeURIComponent(input).replace(/%2F/g, '%252F');
 
+// general fetchAllTrigger
 export const fetchAllSuffix = '?start=0';
 
+// Add fetchAllSuffix in case it is needed
 export const applyFetchAll = function (config, url) {
 // if we pass fetchAll means we want the full log -> start=0 will trigger that on the server
     if (config.fetchAll && !url.includes(fetchAllSuffix)) {
         return `${url}${fetchAllSuffix}`;
     }
     return url;
+};
+
+// using the hook 'location.search'.includes('start=0') to trigger fetchAll
+export const calculateFetchAll = function (props) {
+    const { location: { search } } = props;
+
+    if (search) {
+        const stepReg = /start=([0-9]{1,})/;
+        const match = stepReg.exec(search);
+        if (match && match[1] && Number(match[1]) === 0) {
+            return true;
+        }
+    }
+    return false;
 };
 
 /*

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -164,3 +164,23 @@
     border: none;
     padding: 0;
 }
+
+code div {
+    font-size: 12px;
+    margin: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+code div a{
+    border: solid 1px @pre-color;
+    padding: 3px 10px;
+    margin: 5px;
+    color: @pre-color;
+}
+
+code div a:hover{
+    background-color: @pre-color-hover;
+}
+

--- a/blueocean-dashboard/src/main/less/variables.less
+++ b/blueocean-dashboard/src/main/less/variables.less
@@ -2,3 +2,5 @@
 @blueocean-blue-darkened: darken(@blueocean-blue, 20%);
 @gray-base: #000;
 @pre-bg: lighten(@gray-base, 20%);   // #333
+@pre-color:                   #f5f5f5;
+@pre-color-hover:             #444!important;


### PR DESCRIPTION
**Decription**

- [X] works for freestyle
- [X] works for pipeline
- [X] links "Full log" shown only if needed (e.g. when fetchAll was true we do not show the link)
- [X] in follow along the Full Log button should not never be shown, since you see everything already
- [X] you can link in a "full log"
- [X] in freestyle we really show the full log, however the "show all" link only apply to that step, so the user can look back if needed
- [X] loading the content using ?start=0 will trigger loading of all

AT: https://github.com/jenkinsci/blueocean-acceptance-test/pull/21

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 
