### PR TITLE
[JENKINS-37020] fix bug where branch name was not decoded

### DIFF
--- a/blueocean-personalization/src/main/js/components/PipelineCard.jsx
+++ b/blueocean-personalization/src/main/js/components/PipelineCard.jsx
@@ -96,7 +96,7 @@ export class PipelineCard extends Component {
                 { this.props.branch ?
                 <span className="branch">
                     <span className="octicon octicon-git-branch"></span>
-                    <span className="branchText">{this.props.branch}</span>
+                    <span className="branchText">{decodeURIComponent(this.props.branch)}</span>
                 </span>
                 :
                 <span className="branch"></span>

--- a/blueocean-personalization/src/test/js/components/PipelineCard-spec.jsx
+++ b/blueocean-personalization/src/test/js/components/PipelineCard-spec.jsx
@@ -55,4 +55,17 @@ describe('PipelineCard', () => {
 
         assert.equal(wrapper.find('.actions .run').length, 0);
     });
+
+    it('escapes the branch name', () => {
+        const branchName = 'feature/JENKINS-667';
+        const wrapper = shallow(
+            <PipelineCard status="SUCCESS" organization="Jenkins" pipeline="blueocean"
+              branch={encodeURIComponent(branchName)} commitId="447d8e1"
+            />
+        );
+
+        const elements = wrapper.find('.branchText');
+        assert.equal(elements.length, 1);
+        assert.equal(elements.at(0).text(), branchName);
+    });
 });


### PR DESCRIPTION
**Description**
* Simple logic to escape the branch name
* Favorite a branch with a git-flow style name, e.g. "feature/JENKINS-123", then return to dashboard and ensure the branch name is properly displayed.
* Added a unit test

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

