### PR TITLE
Bug/jenkins 36904 running queued anim

### DIFF
--- a/blueocean-personalization/src/main/js/stories/PipelineCardStories.jsx
+++ b/blueocean-personalization/src/main/js/stories/PipelineCardStories.jsx
@@ -13,8 +13,8 @@ const style2 = { paddingBottom: '10px' };
 storiesOf('PipelineCard', module)
     .add('all states', () => {
         const states = 'SUCCESS,QUEUED,RUNNING,FAILURE,ABORTED,UNSTABLE,NOT_BUILT,UNKNOWN'.split(',');
-        const startTime = moment().subtract(30, 'seconds').toISOString();
-        const estimatedDuration = 60000;
+        const startTime = moment().subtract(60, 'seconds').toISOString();
+        const estimatedDuration = 1000 * 60 * 5; // 5 mins
 
         return (
             <div style={style}>

--- a/blueocean-personalization/src/main/less/components/pipeline-card.less
+++ b/blueocean-personalization/src/main/less/components/pipeline-card.less
@@ -77,7 +77,7 @@
 
     .progress-spinner.queued {
         circle {
-            stroke: white;
+            stroke: #bcd8f1;
         }
         circle.inner {
             stroke: white;

--- a/blueocean-personalization/src/main/less/components/pipeline-card.less
+++ b/blueocean-personalization/src/main/less/components/pipeline-card.less
@@ -69,6 +69,10 @@
         path.running {
             stroke: white;
         }
+        circle.inner {
+            stroke: white;
+            fill: white;
+        }
     }
 
     .progress-spinner.queued {


### PR DESCRIPTION
**Description**
* Change styles for pulse
* @386 I attached a video of the anim, want to make sure it's right before we merge. "running" now uses a solid white pulse that matches what we had for "queued". I also noticed that previously the outer circle for "queued" was a solid white, so it looked more like a "running" job that was 100% done. I changed the outer circle to the lighter color, which I think is visually appropriate. If you'd rather we stick with the more solid white just lmk.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
