### PR TITLE
Updated SSE Gateway to 1.7 to fix ATH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Quick fix to allow ATH connect to SSE gateway. This was an ATH regression introduced by TomF (bad boy !!!) when adding store and forward.

This is a super trivial fix. I tested it with the ATH and it fixed the issues locally, so hoping it will fix the ATH CI job.