### PR TITLE
[JENKINS-37200] Set NODE_ENV via js-extensions js-builder plugin

### DIFF
--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.67",
-    "@jenkins-cd/js-extensions": "0.0.20",
+    "@jenkins-cd/js-extensions": "0.0.21-beta4",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.7",
     "immutable": "3.8.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.67",
-    "@jenkins-cd/js-extensions": "0.0.20",
+    "@jenkins-cd/js-extensions": "0.0.21-beta4",
     "@jenkins-cd/js-modules": "0.0.5",
     "@jenkins-cd/sse-gateway": "0.0.7",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.67",
-    "@jenkins-cd/js-extensions": "0.0.20",
+    "@jenkins-cd/js-extensions": "0.0.21-beta4",
     "@jenkins-cd/js-modules": "0.0.5",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/js-extensions/@jenkins-cd/js-builder.js
+++ b/js-extensions/@jenkins-cd/js-builder.js
@@ -7,7 +7,7 @@
 /**
  * Install the js-builder plugin. This function will be called by js-builder.
  */
-exports.install = function() {
+exports.install = function(builder) {
     var jsBundle = require('./subs/extensions-bundle');
     var cssBundle = require('./subs/css-bundle');
 
@@ -19,4 +19,22 @@ exports.install = function() {
         // Save extensions JSON again.
         jsBundle.setJSExtensionsJSON(extensionsJSON);
     }
+    
+    //
+    // Defaulting the NODE_ENV to "production" so as to optimize
+    // bundle generation. This ensures that e.g. the react dev tools are
+    // disabled by default.
+    //
+    // If you need a "development" bundle then build the bundle by hand,
+    // supplying a "NODE_ENV" arg e.g.
+    //
+    //   $ gulp bundle --NODE_ENV development
+    // 
+    // We can build this into the mvn build later if this proves to be
+    // a bit painful.
+    //
+    process.env.NODE_ENV = builder.args.argvValue('--NODE_ENV', 'production');
+    builder.onPreBundle(function (bundler) { // See https://github.com/jenkinsci/js-builder#onprebundle-listeners
+        bundler.transform(require('envify'));
+    });
 };

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.20",
+  "version": "0.0.21-beta4",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.6.0",
+    "envify": "3.4.1",
     "@jenkins-cd/js-modules": "0.0.5"
   }
 }


### PR DESCRIPTION
# Description

An attempt to address [JENKINS-37200](https://issues.jenkins-ci.org/browse/JENKINS-37200).

It definitely seems to work better on FF when we build everything with `NODE_ENV=production` (i.e. doesn't hang on my machine, but did hang before), but not totally convinced this is the only issue. Still, I think this is worth doing.

There are no unit tests for this and imo it doesn't make sense to create any. I did run the ATH, but it is failing. I do not think it is relating to these changes. Seems like karaoke mode is broken. Looking into that now.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

... defaulting to "production" mode so as to disable react dev tools, which seems to grind Firefox to a crawl