### PR TITLE
[JENKINS-37141] rework Dockerfile for development image

### DIFF
--- a/bin/build-in-docker.sh
+++ b/bin/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-HERE="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+PROJECT_ROOT="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
 
 setup_nice_output() {
   # check if stdout is a terminal...
@@ -30,13 +30,13 @@ setup_nice_output() {
 new_build_container() {
   local build_image=$1; shift
 
-  build_container=$(docker create -i -v "$HERE":/build -w /build "$build_image" /bin/cat)
-  echo "$build_container" > "$HERE/.build_container"
+  build_container=$(docker create -i -v "$PROJECT_ROOT":/build -w /build "$build_image" /bin/cat)
+  echo "$build_container" > "$PROJECT_ROOT/.build_container"
 }
 
 delete_build_container() {
   docker rm "$build_container"
-  rm "$HERE/.build_container"
+  rm "$PROJECT_ROOT/.build_container"
 }
 
 stop_build_container() {
@@ -53,8 +53,8 @@ stop_trap() {
 
 prepare_build_container() {
   local build_image=$1; shift
-  if [[ -f $HERE/.build_container ]]; then
-    read -r build_container < "$HERE/.build_container"
+  if [[ -f $PROJECT_ROOT/.build_container ]]; then
+    read -r build_container < "$PROJECT_ROOT/.build_container"
   else
     new_build_container "$build_image"
     return
@@ -64,7 +64,7 @@ prepare_build_container() {
     echo "${yellow}=> ${normal}Removing old build container ${build_container}"
     docker kill "$build_container" || true
     docker rm "$build_container" || true
-    rm "$HERE/.build_container"
+    rm "$PROJECT_ROOT/.build_container"
   else
     local state; state=$(docker inspect --format="{{ .State.Status }}" "$build_container")
     if [[ $? -ne 0 || "$state" != "exited" ]]; then
@@ -100,7 +100,7 @@ build_inside() {
 
 make_image() {
   echo "${yellow}=> ${normal}Building BlueOcean docker development image ${tag_name}"
-  (cd "$HERE/blueocean-docker-dev-image/target/docker-dev-image" && docker build -t "$tag_name" . )
+  (cd "$PROJECT_ROOT/blueocean-docker-dev-image/target/docker-dev-image" && docker build -t "$tag_name" . )
 }
 
 build_commands="mvn clean install -B -DcleanNode -Dmaven.test.failure.ignore"

--- a/blueocean-docker-dev-image/pom.xml
+++ b/blueocean-docker-dev-image/pom.xml
@@ -27,7 +27,7 @@
     <!--
         If you need to debug this and doesn't want to wait for a full BlueOcean build, you can run
 
-             mvn -Pdocker-dev-image -pl .,blueocean-docker-dev-image package
+             mvn -pl .,blueocean-docker-dev-image package
     -->
 
     <build>
@@ -67,6 +67,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- We don't want this module to be deployed, it doesn't make sense -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/blueocean-docker-dev-image/pom.xml
+++ b/blueocean-docker-dev-image/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.jenkins.blueocean</groupId>
+        <artifactId>blueocean-parent</artifactId>
+        <version>1.0.0-b07-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>blueocean-docker-dev-image</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Module :: BlueOcean :: Docker development image</name>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blueocean</artifactId>
+            <version>${project.version}</version>
+            <type>hpi</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <!--
+        If you need to debug this and doesn't want to wait for a full BlueOcean build, you can run
+
+             mvn -Pdocker-dev-image -pl .,blueocean-docker-dev-image package
+    -->
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <version>1.119</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bundle-plugins</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/docker-dev-image/plugins</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>distro-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>docker-dev-image</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/assembly/docker-dev-image.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/blueocean-docker-dev-image/src/assembly/docker-dev-image.xml
+++ b/blueocean-docker-dev-image/src/assembly/docker-dev-image.xml
@@ -1,0 +1,16 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>docker-dev-image</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>src/main/docker</directory>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/blueocean-docker-dev-image/src/main/docker/Dockerfile
+++ b/blueocean-docker-dev-image/src/main/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM jenkinsci/jenkins:2.17
+
+USER root
+
+# See JENKINS-34035 - disable upgrade wizard
+RUN echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state  && \
+    echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.InstallUtil.lastExecVersion
+
+COPY plugins /usr/share/jenkins/ref/plugins/
+
+# Force use of latest blueocean plugin, until this one is published and users can rely on update center for updates
+RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.hpi; do mv "$f" "$f.override"; done
+
+USER jenkins

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.0</version>
+            <version>2.4</version>
         </dependency>
 
         <!-- Not needed by blueocean runtime but adds to blueocean experience -->

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -99,12 +99,12 @@ build_inside() {
 }
 
 make_image() {
-  echo "${yellow}=> ${normal}Building BlueOcean docker image ${tag_name}"
-  (cd "$HERE" && docker build -t "$tag_name" . )
+  echo "${yellow}=> ${normal}Building BlueOcean docker development image ${tag_name}"
+  (cd "$HERE/blueocean-docker-dev-image/target/docker-dev-image" && docker build -t "$tag_name" . )
 }
 
 build_commands="mvn clean install -B -DcleanNode -Dmaven.test.failure.ignore"
-tag_name=blueocean-local
+tag_name="blueocean-dev:local"
 
 usage() {
 cat <<EOF

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.13</version>
+            <version>1.16</version>
         </dependency>
 
         <dependency>
@@ -292,4 +292,13 @@
 
     </plugins>
   </build>
+
+    <profiles>
+        <profile>
+            <id>docker-dev-image</id>
+            <modules>
+                <module>blueocean-docker-dev-image</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
     <module>blueocean-config</module>
     <module>blueocean</module>
     <module>blueocean-jwt</module>
+    <module>blueocean-docker-dev-image</module>
   </modules>
 
   <repositories>
@@ -292,13 +293,4 @@
 
     </plugins>
   </build>
-
-    <profiles>
-        <profile>
-            <id>docker-dev-image</id>
-            <modules>
-                <module>blueocean-docker-dev-image</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
# Description

See [JENKINS-37141](https://issues.jenkins-ci.org/browse/JENKINS-37141).

This is currently a work in progress to discuss the approach. Dependency resolution of plugins doesn't work correctly unfortunately. It's based on `install-plugins.sh` script for the official Jenkins image, but it seems this script suffers from some issues (see [JENKINS-36828](https://issues.jenkins-ci.org/browse/JENKINS-36828))

The main idea is to use Maven Assembly plugin to gather all BlueOcean plugins files in a folder used as a build context for Docker. Maven can't be used to resolve plugin dependencies from the POM because POM depends on JAR artifacts of plugins but not HPI one. When running Jenkins locally, dependency resolution is done by maven-hpi-plugin. Could be an option to add a new target to this plugin to copy dependent plugin to a folder used by the assembly.

@michaelneale @ndeloof