### PR TITLE
[JENKINS-37268] Fixed karoke + pipeline data bloat

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -44,7 +44,8 @@ export class RunDetailsPipeline extends Component {
         this.state = { followAlong: props && props.result && props.result.state !== 'FINISHED' };
         this.listener = {};
         this._handleKeys = this._handleKeys.bind(this);
-        this.onScrollHandler = this.onScrollHandler.bind(this);
+        this._onScrollHandler = this._onScrollHandler.bind(this);
+        this._onSseEvent = this._onSseEvent.bind(this);
     }
 
     componentWillMount() {
@@ -151,14 +152,14 @@ export class RunDetailsPipeline extends Component {
 
     // need to register handler to step out of karaoke mode
     // we bail out on scroll up
-    onScrollHandler(elem) {
+    _onScrollHandler(elem) {
         if (elem.deltaY < 0 && this.state.followAlong) {
             this.setState({ followAlong: false });
         }
     }
 
-      // Listen for pipeline flow node events.
-        // We filter them only for steps and the end event all other we let pass
+    // Listen for pipeline flow node events.
+    // We filter them only for steps and the end event all other we let pass
     _onSseEvent(event) {
         const { fetchNodes, fetchSteps } = this.props;
         const jenkinsEvent = event.jenkins_event;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -351,7 +351,6 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
         }
     }
 
-    @Exported(inline = true)
     @Navigable
     public Container<Resource> getActivities() {
         return Containers.fromResource(getLink(), Lists.newArrayList(Iterators.concat(getQueue().iterator(), getRuns().iterator())));

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineImpl.java
@@ -185,7 +185,6 @@ public class PipelineImpl extends BluePipeline {
 
     }
 
-    @Exported(inline = true)
     @Navigable
     public Container<Resource> getActivities() {
         return Containers.fromResource(getLink(),Lists.newArrayList(Iterators.concat(getQueue().iterator(), getRuns().iterator())));


### PR DESCRIPTION
# Description
Fixes 2 recent regressions with karoke mode and extra data in pipeline api.

See [JENKINS-37268](https://issues.jenkins-ci.org/browse/JENKINS-37268).

Gist of pipeline data https://gist.github.com/imeredith/05aa904a3a783ce729387ac46228168c

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

* `this` is now bound for _onSseEvent
* pipeline data now no longer inlines activies