### PR TITLE
[WiP] Execute query from a specific item root

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunSearch.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunSearch.java
@@ -2,6 +2,8 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import com.google.common.collect.ImmutableList;
 import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TopLevelItem;
@@ -33,14 +35,14 @@ public class RunSearch extends OmniSearch<BlueRun> {
     }
 
     @Override
-    public Pageable<BlueRun> search(Query q) {
+    public Pageable<BlueRun> search(Query q, ItemGroup<?> root) {
 
         String pipeline = q.param("pipeline", false);
 
         boolean latestOnly = q.param("latestOnly", Boolean.class);
-
+        
         if(pipeline != null){
-            TopLevelItem p = Jenkins.getActiveInstance().getItem(pipeline);
+            Item p = root.getItem(pipeline);
             if(latestOnly){
                 BlueRun r = getLatestRun((Job)p);
                 if(r != null) {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserSearch.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserSearch.java
@@ -1,7 +1,8 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.Extension;
- import io.jenkins.blueocean.rest.OmniSearch;
+import hudson.model.ItemGroup;
+import io.jenkins.blueocean.rest.OmniSearch;
 import io.jenkins.blueocean.rest.Query;
 import io.jenkins.blueocean.rest.model.BlueUser;
 import io.jenkins.blueocean.rest.pageable.Pageable;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserSearch.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserSearch.java
@@ -1,7 +1,7 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.Extension;
-import io.jenkins.blueocean.rest.OmniSearch;
+ import io.jenkins.blueocean.rest.OmniSearch;
 import io.jenkins.blueocean.rest.Query;
 import io.jenkins.blueocean.rest.model.BlueUser;
 import io.jenkins.blueocean.rest.pageable.Pageable;
@@ -21,9 +21,9 @@ public class UserSearch extends OmniSearch<BlueUser> {
     }
 
     @Override
-    public Pageable<BlueUser> search(Query q) {
+    public Pageable<BlueUser> search(Query q, ItemGroup<?> root) {
         List<BlueUser> users = new ArrayList<>();
-        for(hudson.model.User u:hudson.model.User.getAll()){
+        for(hudson.model.User u: hudson.model.User.getAll()){
             users.add(new UserImpl(u));
         }
         return Pageables.wrap(users);

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/ApiHead.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/ApiHead.java
@@ -10,6 +10,8 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.pageable.Pageable;
 import io.jenkins.blueocean.rest.pageable.Pageables;
 import io.jenkins.blueocean.rest.pageable.PagedResponse;
+import jenkins.model.Jenkins;
+
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -50,11 +52,7 @@ public final class ApiHead implements RootRoutable, Reachable  {
      */
     @WebMethod(name="search") @GET @PagedResponse
     public Pageable<?> search(@QueryParameter("q") Query query) {
-        for (OmniSearch os : OmniSearch.all()) {
-            if (os.getType().equals(query.type))
-                return os.search(query);
-        }
-        return Pageables.empty();
+        return OmniSearch.query(query, Jenkins.getInstance());
     }
 
     /**

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/OmniSearch.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/OmniSearch.java
@@ -1,8 +1,14 @@
 package io.jenkins.blueocean.rest;
 
+import java.util.List;
+
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.TopLevelItem;
 import io.jenkins.blueocean.rest.pageable.Pageable;
+import io.jenkins.blueocean.rest.pageable.Pageables;
 
 /**
  * Extension point to contribute the search capability
@@ -15,9 +21,21 @@ public abstract class OmniSearch<T> implements ExtensionPoint {
 
     public abstract String getType();
 
-    public abstract Pageable<T> search(Query q);
+    public abstract Pageable<T> search(Query q, ItemGroup<?> root);
 
     public static ExtensionList<OmniSearch> all() {
         return ExtensionList.lookup(OmniSearch.class);
+    }
+
+    /**
+     * Executes the given query against the given
+     * item container
+     */
+    public static Pageable<?> query(Query query, ItemGroup<?> root) {
+        for (OmniSearch os : all()) {
+            if (os.getType().equals(query.type))
+                return os.search(query, root);
+        }
+        return Pageables.empty();
     }
 }


### PR DESCRIPTION
For discussion.

I ran into the need to add filtering to arbitrary results from the BO API. Unfortunately, the current query API wouldn't be particularly useful/easy to add that sort of thing to. Also, it's not currently composable, from what I can tell. With a few modifications, maybe we could consolidate things:

1. execute a query from an item root rather than always global Jenkins
1. add/change a way to *filter* items rather than only finding them (this doesn't work for all query results - e.g. Users)

@vivek PTAL
