### PR TITLE
Dockerfile to build an image bundling BlueOcean

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,2 @@
 *
-!blueocean-commons/target/blueocean-commons.hpi
-!blueocean-dashboard/target/blueocean-dashboard.hpi
-!blueocean-plugin/target/blueocean.hpi
-!blueocean-rest/target/blueocean-rest.hpi
-!blueocean-rest-impl/target/blueocean-rest-impl.hpi
-!blueocean-web/target/blueocean-web.hpi
-!docker-demo/
+!download-plugins.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,10 @@
-FROM jenkinsci/jenkins:latest
+# Build a Docker image bundling BlueOcean plugins and dependencies
 
-COPY blueocean-commons/target/blueocean-commons.hpi /usr/share/jenkins/ref/plugins/
-COPY blueocean-dashboard/target/blueocean-dashboard.hpi /usr/share/jenkins/ref/plugins/
-COPY blueocean-plugin/target/blueocean.hpi /usr/share/jenkins/ref/plugins/blueocean-plugin.hpi
-COPY blueocean-rest/target/blueocean-rest.hpi /usr/share/jenkins/ref/plugins/
-COPY blueocean-rest-impl/target/blueocean-rest-impl.hpi /usr/share/jenkins/ref/plugins/
-COPY blueocean-web/target/blueocean-web.hpi /usr/share/jenkins/ref/plugins/
+FROM jenkinsci/jenkins:2.17
+ENV BLUEOCEAN_VERSION 1.0-alpha-6
 
 USER root
-
-RUN cd /usr/share/jenkins/ref/plugins/; \
-	install-plugins.sh blueocean-commons \
-                       blueocean-dashboard \
-                       blueocean-plugin \
-                       blueocean-rest \
-                       blueocean-web \
-                       workflow-aggregator \
-                       docker-workflow \
-                       pipeline-utility-steps	\
-                       pipeline-stage-view \
-                       git \
-                       antisamy-markup-formatter \
-                       matrix-auth # for security, you know
-
-# Force use of latest blueocean plugin, until this one is published and users can rely on update center for updates
-RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.hpi; do mv "$f" "$f.override"; done
-
-# See JENKINS-34035 - disable upgrade wizard
-RUN echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state  && \
-    echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.InstallUtil.lastExecVersion
+COPY download-plugins.sh /usr/local/bin
+RUN /usr/local/bin/download-plugins.sh
 
 USER jenkins

--- a/download-plugins.sh
+++ b/download-plugins.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -ex
+
+if [ -z "$BLUEOCEAN_VERSION" ]; then
+  echo "Please set BLUEOCEAN_VERSION environment variable"
+  exit 1
+fi
+
+WORKDIR=/tmp/download-plugins
+mkdir -p "$WORKDIR/maven"
+
+MAVEN_VERSION=3.3.9
+curl -fsSL http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+  | tar  xzf - -C "$WORKDIR/maven" --strip-components=1
+
+mkdir -p "$WORKDIR/fake-project"
+
+cat > "$WORKDIR/fake-project/pom.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>2.3</version>
+  </parent>
+
+  <artifactId>download-plugins</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.jenkins.blueocean</groupId>
+      <artifactId>blueocean</artifactId>
+      <version>$BLUEOCEAN_VERSION</version>
+      <type>hpi</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>1.119</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle-plugins</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>/usr/share/jenkins/ref/plugins</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+EOF
+
+(cd "$WORKDIR/fake-project" && "$WORKDIR/maven/bin/mvn" -Dmaven.repo.local="$WORKDIR/.m2" -q package)
+rm -rf "$WORKDIR"


### PR DESCRIPTION
# Description

See [JENKINS-36828](https://issues.jenkins-ci.org/browse/JENKINS-36828).

This PR proposes a different approach to fix JENKINS-36828 than the one in #393. It uses Maven to resolve plugins dependencies instead of `install-plugins.sh` script available in the Jenkins official image.

Maven has a better knowledge of the plugins dependency tree than `install-script.sh` script which doesn't take into account optional dependencies correctly. See #396 for more explanations on the script's limitation.

@ndeloof @michaelneale 