### PR TITLE
Jenkins 36771 Developer should see an indeterminate progress bar when the step is loading

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -119,27 +119,33 @@ export class LogConsole extends Component {
             return null;
         }
 
-        return (<code
-          className="block"
-        >
-            { isLoading && <Progress />}
-            { hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
-                <a
-                  className="btn-secondary inverse"
-                  key={0}
-                  href={`?start=0#${prefix || ''}`}
-                >
-                Show complete log
-            </a>
+        return (<div>
+            { isLoading && <div className="loadingContainer">
+                <Progress />
             </div>}
-            { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
-                <a
-                  key={index + 1}
-                  href={`#${prefix || ''}log-${index + 1}`}
-                  name={`${prefix}log-${index + 1}`}
-                >{line}
-                </a>
-            </p>)}</code>);
+
+            { !isLoading && <code
+              className="block"
+            >
+                { hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
+                    <a
+                      className="btn-secondary inverse"
+                      key={0}
+                      href={`?start=0#${prefix || ''}`}
+                    >
+                        Show complete log
+                    </a>
+                </div>}
+                { lines.map((line, index) => <p key={index + 1} id={`${prefix}log-${index + 1}`}>
+                    <a
+                      key={index + 1}
+                      href={`#${prefix || ''}log-${index + 1}`}
+                      name={`${prefix}log-${index + 1}`}
+                    >{line}
+                    </a>
+                </p>)}</code>
+            }
+        </div>);
     }
 }
 

--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { Progress } from '@jenkins-cd/design-language';
 import { scrollHelper } from './ScrollHelper';
 
 const INITIAL_RENDER_CHUNK_SIZE = 100;
@@ -15,6 +16,7 @@ export class LogConsole extends Component {
         this.queuedLines = [];
         this.state = {
             lines: [],
+            isLoading: false,
         };
         // we have different timeouts in this component, each will take its own workspace
         this.timeouts = {};
@@ -51,6 +53,7 @@ export class LogConsole extends Component {
 
     // initial method to create lines to render
     _processLines(lines) {
+        this.setState({ isLoading: true });
         let newLines = lines;
         if (newLines && newLines.length > INITIAL_RENDER_CHUNK_SIZE) {
             // queue up all the lines and grab just the beginning to render for now
@@ -62,6 +65,7 @@ export class LogConsole extends Component {
             }, INITIAL_RENDER_DELAY);
         } else {
             this.scroll();
+            this.setState({ isLoading: false });
         }
 
         this.setState({
@@ -86,6 +90,8 @@ export class LogConsole extends Component {
             this.timeouts.render = setTimeout(() => {
                 this._processNextLines();
             }, RERENDER_DELAY);
+        } else {
+            this.setState({ isLoading: false });
         }
         this.scroll();
     }
@@ -107,7 +113,7 @@ export class LogConsole extends Component {
     }
 
     render() {
-        const lines = this.state.lines;
+        const { isLoading, lines } = this.state;
         const { prefix = '', hasMore = false } = this.props; // if hasMore true then show link to full log
         if (!lines) {
             return null;
@@ -116,11 +122,12 @@ export class LogConsole extends Component {
         return (<code
           className="block"
         >
+            { isLoading && <Progress />}
             { hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
                 <a
                   className="btn-secondary inverse"
                   key={0}
-                  href={`?start=0#${prefix || ''}log-${1}`}
+                  href={`?start=0#${prefix || ''}`}
                 >
                 Show complete log
             </a>

--- a/blueocean-dashboard/src/main/js/components/Step.jsx
+++ b/blueocean-dashboard/src/main/js/components/Step.jsx
@@ -91,19 +91,19 @@ export default class Node extends Component {
     render() {
         const { logs, nodesBaseUrl, fetchLog, followAlong } = this.props;
         const node = this.expandAnchor(this.props);
-        const fetchAll = node.fetchAll;
         // Early out
         if (!node || !fetchLog) {
             return null;
         }
         const { config = {} } = this.context;
         const {
-          isFocused = false,
+          fetchAll,
           title,
           durationInMillis,
           result,
           id,
           state,
+          isFocused = false,
         } = node;
 
         const resultRun = result === 'UNKNOWN' || !result ? state : result;

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -183,6 +183,12 @@ code div {
     justify-content: center;
 }
 
+div.loadingContainer {
+    background-color: #ffffff;
+    margin-top: -10px;
+    margin-bottom: -5px;
+}
+
 code div a{
     margin: 5px;
 }


### PR DESCRIPTION
# Description

Developer should see an indeterminate progress bar when the step is loading.

See [JENKINS-36771](https://issues.jenkins-ci.org/browse/JENKINS-36771).

Implemented behaviour is that the progressbar is visible while loading but the code block not.

See https://www.youtube.com/watch?v=LxwnlxcYTfw&feature=youtu.be for preview

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests - > https://github.com/jenkinsci/blueocean-acceptance-test/pull/23
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 
