### PR TITLE
[JENKINS-36171] Steps with no logs should not be expandable

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Step.jsx
+++ b/blueocean-dashboard/src/main/js/components/Step.jsx
@@ -125,6 +125,8 @@ export default class Node extends Component {
             key: id,
             prefix: `step-${id}-`,
         };
+
+        const { hasLogs } = node;
         if (log) {
             // in follow along the Full Log button should not be shown, since you see everything already
             if (followAlong) {
@@ -136,6 +138,12 @@ export default class Node extends Component {
         }
 
         const logConsoleClass = `logConsole step-${id}`;
+        let children = null;
+        if (log) {
+            children = <LogConsole {...logProps} />;
+        } else if (!log && hasLogs) {
+            children = <span>&nbsp;</span>;
+        }
 
         return (<div className={logConsoleClass}>
             <ResultItem
@@ -146,11 +154,8 @@ export default class Node extends Component {
               onExpand={getLogForNode}
               durationMillis={durationInMillis}
             >
-                { log && <LogConsole {...logProps} /> }
+                {children}
 
-                { !log && <span>
-                    &nbsp;
-                </span> }
             </ResultItem>
       </div>);
     }

--- a/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
+++ b/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
@@ -31,6 +31,9 @@ export const getNodesInformation = (nodes) => {
         const isFailingNode = errorNodes.indexOf(item.id) > -1;
         const isRunningNode = runningNodes.indexOf(item.id) > -1;
 
+        // FIXME: TS I need to talk to cliffMeyers how we can refactor the following code to use capabilities
+        // the problem I see ATM is that we would need to ask the c-API everytime for each action, whether this
+        // action has the capability for logging
         const hasLogs = item.actions ? item.actions
                 .filter(action => action._class === 'org.jenkinsci.plugins.workflow.support.actions.LogActionImpl').length > 0
             : false;

--- a/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
+++ b/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
@@ -31,6 +31,9 @@ export const getNodesInformation = (nodes) => {
         const isFailingNode = errorNodes.indexOf(item.id) > -1;
         const isRunningNode = runningNodes.indexOf(item.id) > -1;
 
+        const hasLogs = item.actions ? item.actions
+                .filter(action => action._class === 'org.jenkinsci.plugins.workflow.support.actions.LogActionImpl').length > 0
+            : false;
         const modelItem = {
             key: index,
             id: item.id,
@@ -41,6 +44,7 @@ export const getNodesInformation = (nodes) => {
             startTime: item.startTime,
             result: item.result,
             state: item.state,
+            hasLogs,
         };
         if (item.type === 'WorkflowRun') {
             modelItem.estimatedDurationInMillis = item.estimatedDurationInMillis;


### PR DESCRIPTION
# Description

Steps with no logs should not be expandable

See [JENKINS-36171](https://issues.jenkins-ci.org/browse/JENKINS-36171) especially the comment about steps that can have logs but do not have them. The PR covers those that do not provide the possibility to have logs (no more 404 for those logs urls)

TESTS: https://github.com/jenkinsci/blueocean-acceptance-test/pull/24

![screenshot from 2016-08-16 17-39-18](https://cloud.githubusercontent.com/assets/596701/17705377/6bea5c42-63d8-11e6-8efd-e2d6099bb6b7.png)


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

…not do not make the resultItem expandable.