### PR TITLE
JENKINS-37104# Matrix project handling

### DIFF
--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -260,7 +260,7 @@ export const actions = {
         return (dispatch) => {
             const baseUrl = config.getAppURLBase();
             // TODO: update this code to call /search with organizationName once JENKINS-36273 is ready
-            const url = `${baseUrl}/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject`;
+            const url = `${baseUrl}/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject`;
 
             return dispatch(actions.generateData(
                 url,
@@ -281,7 +281,7 @@ export const actions = {
             const pipelines = getState().adminStore.pipelines;
             const baseUrl = config.getAppURLBase();
             // TODO: update this code to call /search with organizationName once JENKINS-36273 is ready
-            const url = `${baseUrl}/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject`;
+            const url = `${baseUrl}/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject`;
 
             if (!pipelines) {
                 return dispatch(actions.generateData(
@@ -848,7 +848,7 @@ export const actions = {
             ));
         };
     },
-    
+
     resetTestDetails() {
         return (dispatch) =>
             dispatch({

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MatrixProjectImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MatrixProjectImpl.java
@@ -1,0 +1,101 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+/**
+ * @author Vivek Pandey
+ */
+
+import hudson.Extension;
+import hudson.matrix.MatrixProject;
+import hudson.model.Item;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.annotation.Capability;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BluePipeline;
+import io.jenkins.blueocean.rest.model.BluePipelineContainer;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.rest.model.BlueRunContainer;
+import io.jenkins.blueocean.rest.model.Resource;
+import io.jenkins.blueocean.service.embedded.rest.AbstractRunImpl;
+import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
+import io.jenkins.blueocean.service.embedded.rest.PipelineFolderImpl;
+
+/**
+ * @author Vivek Pandey
+ */
+@Capability("hudson.matrix.MatrixProject")
+public class MatrixProjectImpl extends PipelineFolderImpl {
+
+    private final MatrixProject matrixProject;
+
+    public MatrixProjectImpl(MatrixProject folder, Link parent) {
+        super(folder, parent);
+        this.matrixProject = folder;
+    }
+
+    @Extension(ordinal = 1)
+    public static class PipelineFactoryImpl extends BluePipelineFactory{
+
+        @Override
+        public MatrixProjectImpl getPipeline(Item item, Reachable parent) {
+            if (item instanceof MatrixProject) {
+                return new MatrixProjectImpl((MatrixProject) item, parent.getLink());
+            }
+            return null;
+        }
+
+        @Override
+        public Resource resolve(Item context, Reachable parent, Item target) {
+            MatrixProjectImpl project = getPipeline(context, parent);
+            if (project!=null) {
+                if(context == target){
+                    return project;
+                }
+                Item nextChild = findNextStep(project.matrixProject,target);
+                for (BluePipelineFactory f : all()) {
+                    Resource answer = f.resolve(nextChild, project, target);
+                    if (answer!=null)
+                        return answer;
+                }
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public BluePipeline getDynamic(String name) {
+        return null;
+    }
+
+    @Override
+    public BluePipelineContainer getPipelines() {
+        return null;
+    }
+
+    @Override
+    public Integer getNumberOfFolders() {
+        return 0;
+    }
+
+    @Override
+    public Integer getNumberOfPipelines() {
+        return 0;
+    }
+
+    @Override
+    public Link getLink() {
+        return new Link("/"+ matrixProject.getUrl());
+    }
+
+    @Override
+    public BlueRunContainer getRuns() {
+        return null; //TODO: matrix build have run but we are not returning any for now. to be fixed when full matrix build support is defined.
+    }
+
+    @Override
+    public BlueRun getLatestRun() {
+        if(matrixProject.getLastBuild() == null){
+            return null;
+        }
+        return AbstractRunImpl.getBlueRun(matrixProject.getLastBuild(), this);
+    }
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
@@ -36,6 +36,7 @@ public class PipelineImpl extends AbstractPipelineImpl {
             if(context == target && target instanceof WorkflowJob) {
                 return getPipeline(target,parent);
             }
+            
             return null;
         }
     }

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -54,13 +54,6 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.6</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.2</version>
             <scope>test</scope>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -54,6 +54,13 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.2</version>
             <scope>test</scope>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -184,7 +184,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
         return AbstractPipelineImpl.getActionProxies(run.getAllActions(), this);
     }
 
-    protected static BlueRun getBlueRun(Run r, Reachable parent){
+    public static BlueRun getBlueRun(Run r, Reachable parent){
         for(BlueRunFactory runFactory:BlueRunFactory.all()){
             BlueRun blueRun = runFactory.getRun(r,parent);
             if(blueRun != null){


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-37104

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

- Create a matrix project mp1 with two axis with two values each and run it, you should get total of 4 builds, one for each combination and there should be build for mp1 as well.
- Do curl -v http://localhost:8080/jenkins/blue/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject to get list of pipelines, here we are asking not to inline MatrixProject children.
- The list of pipeline should have mp1 project with self href pointing to "/job/mp1/"
- curl -v http://localhost:8080/jenkins/blue/rest/classes/io.jenkins.blueocean.rest.impl.pipeline.MatrixProjectImpl/ should give list of capabilities that includes hudson.matrix.MatrixProject

- [x] Ran Acceptance Test Harness against PR changes.
https://ci.blueocean.io/job/Acceptance%20Tests%20Param/19/, it failed with unrelated error to download jquery2:

    [ERROR - 2016-08-17T01:17:57.972Z] Session [0f406550-6418-11e6-9fd4-d5cee85dbc1a] - page.onError - msg: Module load failure: Timed out waiting on module 'jquery-detached:jquery2' to load.

Triggered another: https://ci.blueocean.io/job/Acceptance%20Tests%20Param/20/


# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

- Bare minimum support for Matrix project. Ensures it doesn't break.
- For matrix project, self href points to classic URL path ("/job/:name")
- Adds hudson.matrix.MatrixProject capability
- UI to check hudson.matrix.MatrixProject capability and if present create a link using returned self href,
  so that when user clicks on it, he gets redirected to classic Matrix job page.