### PR TITLE
JENKINS-36980# Handle NPE from actions gracefully

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
@@ -5,6 +5,8 @@ import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Vivek Pandey
@@ -13,6 +15,8 @@ public class ActionProxiesImpl extends BlueActionProxy {
 
     private final Action action;
     private final Reachable parent;
+    private static final Logger logger = LoggerFactory.getLogger(ActionProxiesImpl.class);
+
     public ActionProxiesImpl(Action action, Reachable parent) {
         this.action = action;
         this.parent = parent;
@@ -30,7 +34,12 @@ public class ActionProxiesImpl extends BlueActionProxy {
 
     @Override
     public String getUrlName() {
-        return action.getUrlName();
+        try {
+            return action.getUrlName();
+        }catch (Exception e){
+            logger.error(String.format("Error calling %s.getUrlName(): %s", action.getClass().getName(), e.getMessage()),e);
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-36980

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests

Hard to reproduce, but following might reproduce:

* create a parameterized freestyle job with a parameter and run couple of builds
* install rebuild plugin, restart, try rebuilding the jobs by clicking 'rebuild last' link
* then call GET on http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/:jobName/runs/

If underlying plugin threw NPE reported in the JIRA ticket, the exception will be logged on console and a proper response will be returned instead of failure.

Alternatively you could click on the pipeline/job name link in blueocean UI and you should see all the runs listed properly, if underlying plugin threw exception it will be logged in the server log.

- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

https://ci.blueocean.io/job/Acceptance%20Tests%20Param/45/

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

