### PR TITLE
[JENKINS-36054] Page reload after hibernate

### DIFF
--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -146,3 +146,6 @@ function startApp(routes, stores) {
 Extensions.store.getExtensions(['jenkins.main.routes', 'jenkins.main.stores'], (routes = [], stores = []) => {
     startApp(routes, stores);
 });
+
+// Enable page reload.
+require('./reload');

--- a/blueocean-web/src/main/js/reload.js
+++ b/blueocean-web/src/main/js/reload.js
@@ -1,0 +1,22 @@
+// Page reload
+// See https://issues.jenkins-ci.org/browse/JENKINS-36054
+//
+// Simple timeout based window reload.
+//
+
+const CHECK_FREQUENCY = 1000;
+const TOLERANCE = CHECK_FREQUENCY + 2000; 
+let lastCheck = new Date();
+
+function check() {
+    setTimeout(() => {
+        const now = new Date();
+        if (now.getTime() - lastCheck.getTime() > TOLERANCE) {
+            window.location.reload(true);
+        } else {
+            lastCheck = now;
+            check();
+        }
+    }, CHECK_FREQUENCY);
+}
+check();


### PR DESCRIPTION
# Description

See [JENKINS-36054](https://issues.jenkins-ci.org/browse/JENKINS-36054).

To test ... open classic and BO UIs ... start builds in classic and see events kick activity in BO ui ... shut the lid on your laptop and leave it shut for 30 seconds or so ... reopen and check that the above still works and events trigger activity etc.

No real automated test possible.

@i386 It just does a reload atm and I think it's fine as a v1, but you might want to display something to the user of the form "Your connection to the server was lost. Please reload to continue ..." or whatever.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

