### PR TITLE
[hotfix/JENKINS-37704] fix typo when things were renamed

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -68,12 +68,12 @@ export class RunDetailsPipeline extends Component {
     componentDidMount() {
         const { result } = this.props;
 
-        if (!result.isQueued()) {
+        if (!result.isQueued()) {// FIXME: when https://issues.jenkins-ci.org/browse/JENKINS-37708 is fixed, test whether it breaks karaoke on freestyle
             // determine scroll area
             const domNode = ReactDOM.findDOMNode(this.refs.scrollArea);
-            // add both listemer, one to the scroll area and another to the whole document
+            // add both listener, one to the scroll area and another to the whole document
             if (domNode) {
-                domNode.addEventListener('wheel', this.onScrollHandler, false);
+                domNode.addEventListener('wheel', this._onScrollHandler, false);
             }
             document.addEventListener('keydown', this._handleKeys, false);
         }
@@ -130,6 +130,13 @@ export class RunDetailsPipeline extends Component {
         }
     }
 
+    // we bail out on arrow_up key
+    _handleKeys(event) {
+        if (event.keyCode === 38 && this.state.followAlong) {
+            this.setState({ followAlong: false });
+        }
+    }
+
     // Listen for pipeline flow node events.
     // We filter them only for steps and the end event all other we let pass
     _onSseEvent(event) {
@@ -176,13 +183,6 @@ export class RunDetailsPipeline extends Component {
             if (e.message !== 'exit') {
                 throw e;
             }
-        }
-    }
-
-    // we bail out on arrow_up key
-    _handleKeys(event) {
-        if (event.keyCode === 38 && this.state.followAlong) {
-            this.setState({ followAlong: false });
         }
     }
 


### PR DESCRIPTION
# Description

See [JENKINS-37704](https://issues.jenkins-ci.org/browse/JENKINS-37704).

Scroll up handler were never subscribed. To reproduce go to a running build and scroll up with the mouse, before this PR that did nothing, now it should be the same behaviour as pressing the arrow-up (which works fine before and after): stopping karaoke mode.

The AT is covering the key up but not the scrollUp since we would need to simulate that.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

