### PR TITLE
[FIX JENKINS-36054] Lengthen page reload time tolerance from 2 to 20 seconds

### DIFF
--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -149,3 +149,6 @@ function startApp(routes, stores) {
 Extensions.store.getExtensions(['jenkins.main.routes', 'jenkins.main.stores'], (routes = [], stores = []) => {
     startApp(routes, stores);
 });
+
+// Enable page reload.
+require('./reload');

--- a/blueocean-web/src/main/js/reload.js
+++ b/blueocean-web/src/main/js/reload.js
@@ -5,7 +5,7 @@
 //
 
 const CHECK_FREQUENCY = 1000;
-const TOLERANCE = CHECK_FREQUENCY + 2000; 
+const TOLERANCE = CHECK_FREQUENCY + 20000; 
 let lastCheck = new Date();
 
 function check() {

--- a/blueocean-web/src/main/js/reload.js
+++ b/blueocean-web/src/main/js/reload.js
@@ -1,0 +1,22 @@
+// Page reload
+// See https://issues.jenkins-ci.org/browse/JENKINS-36054
+//
+// Simple timeout based window reload.
+//
+
+const CHECK_FREQUENCY = 1000;
+const TOLERANCE = CHECK_FREQUENCY + 2000; 
+let lastCheck = new Date();
+
+function check() {
+    setTimeout(() => {
+        const now = new Date();
+        if (now.getTime() - lastCheck.getTime() > TOLERANCE) {
+            window.location.reload(true);
+        } else {
+            lastCheck = now;
+            check();
+        }
+    }, CHECK_FREQUENCY);
+}
+check();


### PR DESCRIPTION
# Description

See [JENKINS-36054](https://issues.jenkins-ci.org/browse/JENKINS-36054).

A rerun of earlier attempt to handle machine hibernation ... reverting the revert and lengthening the time tolerance from 2 to 20 seconds.

The risk of having it too long is that someone could, in theory, bring a machine into and out of hibernation fast enough for us to ignore it (< 20s ?).

If this does not work then we're going to have try a more complex solution, pinging the server with a request that contains a UUID of some sort, asking the server to try send it back to us over SSE and if we don't get that we then reload, assuming SSE `EventSource` is clobbered and can't be recovered. There are risks that that might not work perfectly either because it too will depend on a time tolerance.

@jenkinsci/code-reviewers @reviewbybees 
