### PR TITLE
[FIX JENKINS-37708] queued item regression

### DIFF
--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -366,6 +366,7 @@ export const actions = {
 
             // Only interested in the event if we have already loaded the runs for that job.
             if (eventJobRuns && event.job_run_queueId) {
+                let nextId = 0; // this is a terrible hack
                 for (let i = 0; i < eventJobRuns.length; i++) {
                     const run = eventJobRuns[i];
                     if (event.job_ismultibranch
@@ -379,11 +380,14 @@ export const actions = {
                         // run. No need to create another i.e. ignore this event.
                         return;
                     }
+                    if (parseInt(run.id) > nextId) { // need the estimated next id
+                         nextId = parseInt(run.id);
+                    }
                 }
 
                 // Create a new "dummy" entry in the runs list for the
                 // run that's been queued.
-                const newRun = {};
+                const newRun = { id: `${nextId+1}` };
 
                 // We keep the queueId so we can cross reference it with the actual
                 // run once it has been started.

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -447,7 +447,13 @@ export const actions = {
                             if (event.jenkins_event !== 'job_run_ended') {
                                 return { ...data,
                                     id: event.jenkins_object_id, // make sure the runId is set so we can find it later
-                                    state: 'RUNNING', // This is a horrible hack due to issues with QUEUED status
+                                    // here, we explicitly set to running. this is because
+                                    // pipeline runs get removed from the queue, a running event is sent
+                                    // but they are still queued in Jenkins, as they may not actually
+                                    // be executing anything. However, pipeline doesn't send any further
+                                    // events so we're never notified when it actually does start, so
+                                    // we just treat this subsequent runStateEvent as a start or a finish
+                                    state: 'RUNNING',
                                     result: 'UNKNOWN',
                                 };
                             }

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -370,7 +370,12 @@ export const actions = {
 
             // Only interested in the event if we have already loaded the runs for that job.
             if (eventJobRuns && event.job_run_queueId) {
-                let nextId = 0; // this is a terrible hack
+                // here, we're emulating the expectedBuildNumber in order to get a runId
+                // we need a runId so clicking to view the queued item shows the right page
+                // now that we are fetching a run 'directly', however it's important to note
+                // that this could still fail with a reload if the runs have not loaded and
+                // we don't have a matching queued item with the same runId
+                let nextId = 0;
                 for (let i = 0; i < eventJobRuns.length; i++) {
                     const run = eventJobRuns[i];
                     if (event.job_ismultibranch
@@ -384,7 +389,7 @@ export const actions = {
                         // run. No need to create another i.e. ignore this event.
                         return;
                     }
-                    if (parseInt(run.id, 10) > nextId) { // need the estimated next id
+                    if (parseInt(run.id, 10) > nextId) { // figure out the next id, expectedBuildNumber
                         nextId = parseInt(run.id, 10);
                     }
                 }

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -49,6 +49,10 @@ function tryToFixRunState(run, pipelineRuns) {
                 job_run_queueId: found.job_run_queueId,
             });
         }
+        return Object.assign({}, run, {
+            state: 'RUNNING',
+            result: 'UNKNOWN',
+        });
     }
     return run;
 }
@@ -380,14 +384,14 @@ export const actions = {
                         // run. No need to create another i.e. ignore this event.
                         return;
                     }
-                    if (parseInt(run.id) > nextId) { // need the estimated next id
-                         nextId = parseInt(run.id);
+                    if (parseInt(run.id, 10) > nextId) { // need the estimated next id
+                        nextId = parseInt(run.id, 10);
                     }
                 }
 
                 // Create a new "dummy" entry in the runs list for the
                 // run that's been queued.
-                const newRun = { id: `${nextId+1}` };
+                const newRun = { id: `${nextId + 1}` };
 
                 // We keep the queueId so we can cross reference it with the actual
                 // run once it has been started.
@@ -438,7 +442,7 @@ export const actions = {
                             if (event.jenkins_event !== 'job_run_ended') {
                                 return { ...data,
                                     id: event.jenkins_object_id, // make sure the runId is set so we can find it later
-                                    state: event.job_run_status, // This is a horrible hack due to issues with QUEUED status
+                                    state: 'RUNNING', // This is a horrible hack due to issues with QUEUED status
                                     result: 'UNKNOWN',
                                 };
                             }

--- a/blueocean-dashboard/src/main/js/util/UrlUtils.js
+++ b/blueocean-dashboard/src/main/js/util/UrlUtils.js
@@ -173,11 +173,12 @@ export function getRestUrl({ organization, pipeline, branch, runId }) {
     const jenkinsUrl = require('../config').getJenkinsRootURL();
     let url = `${jenkinsUrl}/blue/rest/organizations/${encodeURIComponent(organizationName)}`;
     if (pipelineName) {
-        // pipelineName might include a folder path, don't escape it
+        // pipelineName might include a folder path, don't encode it
         url += `/pipelines/${pipelineName}`;
     }
     if (branch) {
-        url += `/branches/${encodeURIComponent(branch)}`;
+        // JENKINS-37712 branch needs to be double-encoded for some reason
+        url += `/branches/${encodeURIComponent(encodeURIComponent(branch))}`;
     }
     if (runId) {
         url += `/runs/${encodeURIComponent(runId)}`;


### PR DESCRIPTION
# Description

See [JENKINS-37708](https://issues.jenkins-ci.org/browse/JENKINS-37708).

This needs an ATH test, JS tests are insufficient.

To test: set executors to 0, queue a freestyle build, click the queued item validate the 'item is waiting to run' page shows.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 
