### PR TITLE
JENKINS-37722 - SSE updates were matching against runId only

### DIFF
--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -417,11 +417,14 @@ export const actions = {
     },
 
     updateRunState(event, config) {
+        const matchesEvent = o =>
+            o.job_run_queueId === event.job_run_queueId
+            || (isRun(o) && o.id === event.jenkins_object_id && event.blueocean_job_branch_name === o.pipeline);
         return (dispatch, getState) => {
             debugLog('updateRunState:', event);
             let found = false;
             findAndUpdate(getState().adminStore, o => {
-                if (!found && o.job_run_queueId === event.job_run_queueId || (isRun(o) && o.id === event.jenkins_object_id)) {
+                if (!found && matchesEvent(o)) {
                     debugLog('found:', o);
                     found = true;
                 }
@@ -434,7 +437,7 @@ export const actions = {
                     if (data.$pending) return;
                     debugLog('Updating run: ', data);
                     dispatchFindAndUpdate(dispatch, run => {
-                        if (run.job_run_queueId === event.job_run_queueId || (isRun(run) && run.id === event.jenkins_object_id)) {
+                        if (matchesEvent(run)) {
                             if (event.jenkins_event !== 'job_run_ended') {
                                 return { ...data,
                                     id: event.jenkins_object_id, // make sure the runId is set so we can find it later


### PR DESCRIPTION
# Description

See [JENKINS-37722](https://issues.jenkins-ci.org/browse/JENKINS-37722).

To test, create a new Github org folder, build a project with multiple branches, and ensure the activity is updated properly, rather than all to exactly the same branch at the end. A test repo is here: git@github.com:kzantow/failure-project.git

Not really sure how to get this set up in tests, being dependent on a repo with multiple branches.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

