### PR TITLE
[FIX JENKINS-37714] js-builder bundle transform not taking dedupe into account when translating fullPaths to Ids

### DIFF
--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -12,7 +12,7 @@
     "rollbar-browser": "1.9.1"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.37",
+    "@jenkins-cd/js-builder": "0.0.38",
     "babel-eslint": "^6.1.2",
     "gulp": "3.9.1",
     "eslint-plugin-react": "^5.0.1"

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
     "@jenkins-cd/js-builder": "0.0.38",
-    "@jenkins-cd/js-test": "1.2.2",
+    "@jenkins-cd/js-test": "1.2.3",
     "@kadira/storybook": "1.19.0",
     "babel": "^6.5.2",
     "babel-core": "^6.7.6",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.37",
+    "@jenkins-cd/js-builder": "0.0.38",
     "@jenkins-cd/js-test": "1.2.2",
     "@kadira/storybook": "1.19.0",
     "babel": "^6.5.2",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.37",
+    "@jenkins-cd/js-builder": "0.0.38",
     "@jenkins-cd/js-test": "1.2.2",
     "@kadira/storybook": "1.34.0",
     "babel": "^6.5.2",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
     "@jenkins-cd/js-builder": "0.0.38",
-    "@jenkins-cd/js-test": "1.2.2",
+    "@jenkins-cd/js-test": "1.2.3",
     "@kadira/storybook": "1.34.0",
     "babel": "^6.5.2",
     "babel-core": "^6.7.6",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/js-builder": "0.0.38",
-    "@jenkins-cd/js-test": "1.2.2",
+    "@jenkins-cd/js-test": "1.2.3",
     "babel-eslint": "^6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-preset-es2015": "^6.6.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -11,7 +11,7 @@
     "bundle:watch": "gulp bundle:watch"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.37",
+    "@jenkins-cd/js-builder": "0.0.38",
     "@jenkins-cd/js-test": "1.2.2",
     "babel-eslint": "^6.0.2",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -25,7 +25,7 @@
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
     "@jenkins-cd/js-builder": "0.0.38",
     "@jenkins-cd/js-modules": "0.0.6",
-    "@jenkins-cd/js-test": "1.2.2",
+    "@jenkins-cd/js-test": "1.2.3",
     "babel-cli": "6.10.1",
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.37",
+    "@jenkins-cd/js-builder": "0.0.38",
     "@jenkins-cd/js-modules": "0.0.6",
     "@jenkins-cd/js-test": "1.2.2",
     "babel-cli": "6.10.1",


### PR DESCRIPTION
# Description

See [JENKINS-37714](https://issues.jenkins-ci.org/browse/JENKINS-37714).

This pulls in fixes from https://github.com/jenkinsci/js-builder/pull/8

No manual tests possible aside from making sure the plugins all build and the ATH runs, all of which is automated.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes. And running ATH on the CI server: https://ci.blueocean.io/job/Acceptance%20Test%20PR/34/

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 