### PR TITLE
JENKINS-37837# Provider specific authentication object handling

### DIFF
--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtAuthenticationStore.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtAuthenticationStore.java
@@ -1,0 +1,34 @@
+package io.jenkins.blueocean.auth.jwt;
+
+import org.acegisecurity.Authentication;
+
+import java.util.Map;
+
+/**
+ * An authentication store for Jwt, authentication provider implements this extension point to store enough information
+ * in JWT claim so that later on when the token verification happens, using this same claims this authentication object
+ * can be re-created.
+ *
+ * @author Vivek Pandey
+ *
+ * @see Authentication
+ */
+public interface JwtAuthenticationStore{
+
+    /**
+     * Given JWT claim give the authentication object
+     *
+     * @param claims JWT claim
+     *
+     * @return Authentication object, always non-null
+     */
+    Authentication getAuthentication(Map<String,Object> claims);
+
+
+    /**
+     * Store authentication related information in JWT claims
+     *
+     * @param claims JWT claim
+     */
+    void store(Authentication authentication, Map<String,Object> claims);
+}

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtAuthenticationStoreFactory.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtAuthenticationStoreFactory.java
@@ -1,0 +1,42 @@
+package io.jenkins.blueocean.auth.jwt;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import org.acegisecurity.Authentication;
+
+import java.util.Map;
+
+/**
+ * An authentication provider implements this extension point to store enough information in JWT claim so that later on
+ * when the token verification happens, using this same claims this authentication object can be re-created.
+ *
+ * @author Vivek Pandey
+ *
+ * @see Authentication
+ */
+public abstract class JwtAuthenticationStoreFactory implements ExtensionPoint{
+
+    /**
+     * Resolves {@link JwtAuthenticationStore} for given {@link Authentication} instance.
+     *
+     * @param claims JWT claims
+     *
+     * @return JwtAuthenitcationStore, can be null
+     */
+    public abstract  JwtAuthenticationStore getJwtAuthenticationStore(Map<String,Object> claims);
+
+    /**
+     * Resolves {@link JwtAuthenticationStore} for given {@link Authentication} instance.
+     *
+     * @param authentication {@link Authentication} instance
+     *
+     * @return JwtAuthenitcationStore, can be null
+     */
+    public abstract  JwtAuthenticationStore getJwtAuthenticationStore(Authentication authentication);
+
+
+    public static ExtensionList<JwtAuthenticationStoreFactory> all(){
+        return ExtensionList.lookup(JwtAuthenticationStoreFactory.class);
+    }
+
+}

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtImpl.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtImpl.java
@@ -21,9 +21,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Vivek Pandey
@@ -34,8 +32,6 @@ public class JwtImpl extends JwtAuthenticationService {
     private static int DEFAULT_EXPIRY_IN_SEC = 1800;
     private static int DEFAULT_MAX_EXPIRY_TIME_IN_MIN = 480;
     private static int DEFAULT_NOT_BEFORE_IN_SEC = 30;
-
-    private final Map<String, Authentication> authenticationMap = new ConcurrentHashMap<>();
 
     @Override
     public JwtToken getToken(@Nullable @QueryParameter("expiryTimeInMins") Integer expiryTimeInMins, @Nullable @QueryParameter("maxExpiryTimeInMins") Integer maxExpiryTimeInMins) {

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SimpleJwtAuthenticationStore.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SimpleJwtAuthenticationStore.java
@@ -8,6 +8,7 @@ import org.acegisecurity.Authentication;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Stores authentication map and makes them available in memory.
@@ -16,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Extension(ordinal = 0)
 public class SimpleJwtAuthenticationStore extends JwtAuthenticationStoreFactory implements JwtAuthenticationStore {
-    private final Map<String, Authentication> authenticationMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Authentication> authenticationMap = new ConcurrentHashMap<>();
 
     public void add(String id, Authentication authentication){
         if(authenticationMap.get(id) == null){
@@ -45,10 +46,7 @@ public class SimpleJwtAuthenticationStore extends JwtAuthenticationStoreFactory 
     @Override
     public void store(Authentication authentication, Map<String,Object> claims) {
         String authenticationId = String.valueOf(authentication.hashCode());
-        if(authenticationMap.get(authenticationId) == null){
-            authenticationMap.put(authenticationId, authentication);
-        }
-
+        authenticationMap.putIfAbsent(authenticationId, authentication);
         JSONObject provider = new JSONObject();
 
         provider.put("id", authenticationId);

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SimpleJwtAuthenticationStore.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SimpleJwtAuthenticationStore.java
@@ -1,0 +1,71 @@
+package io.jenkins.blueocean.auth.jwt.impl;
+
+import hudson.Extension;
+import io.jenkins.blueocean.auth.jwt.JwtAuthenticationStore;
+import io.jenkins.blueocean.auth.jwt.JwtAuthenticationStoreFactory;
+import net.sf.json.JSONObject;
+import org.acegisecurity.Authentication;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Stores authentication map and makes them available in memory.
+ *
+ * @author Vivek Pandey
+ */
+@Extension(ordinal = 0)
+public class SimpleJwtAuthenticationStore extends JwtAuthenticationStoreFactory implements JwtAuthenticationStore {
+    private final Map<String, Authentication> authenticationMap = new ConcurrentHashMap<>();
+
+    public void add(String id, Authentication authentication){
+        if(authenticationMap.get(id) == null){
+            authenticationMap.put(id, authentication);
+        }
+    }
+
+    public Authentication get(String id){
+        return authenticationMap.get(id);
+    }
+
+    @Override
+    public Authentication getAuthentication(Map<String,Object> claims) {
+        Map context = (Map) claims.get("context");
+        if(context != null && context.get("authProvider") != null){
+            Map authProvider = (Map) context.get("authProvider");
+
+            if(authProvider.get("id") != null){
+                String id = (String) authProvider.get("id");
+                return authenticationMap.get(id);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void store(Authentication authentication, Map<String,Object> claims) {
+        String authenticationId = String.valueOf(authentication.hashCode());
+        if(authenticationMap.get(authenticationId) == null){
+            authenticationMap.put(authenticationId, authentication);
+        }
+
+        JSONObject provider = new JSONObject();
+
+        provider.put("id", authenticationId);
+        claims.put("authProvider", provider);
+    }
+
+    @Override
+    public JwtAuthenticationStore getJwtAuthenticationStore(Map<String,Object> claims) {
+        Map context = (Map) claims.get("context");
+        if(context != null && context.get("authProvider") != null){
+            return this;
+        }
+        return null;
+    }
+
+    @Override
+    public JwtAuthenticationStore getJwtAuthenticationStore(Authentication authentication) {
+        return this;
+    }
+}


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-37837

## To test locally
* Install github auth plugin and configure it after setting up github oauth app
* launch blueocean locally, with logged in github user you should be able to see all pipelines, drill in there etc.
* log out and as anonymous user you should be able to see all pipelines

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

Triggered https://ci.blueocean.io/job/Acceptance%20Tests%20Param/66/ fails but locally running ATH is success.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@jenkinsci/code-reviewers @reviewbybees 

- Provided extension point for provider to decide their own way by which they can store authentication
  instance specific info in token and later on using the same cliams re-create the same authentication instance.
- Default implementation use in-memory store for each auth object