### PR TITLE
JENKINS-37744# Support for Kyoto plugin

### DIFF
--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.8</version>
+            <version>2.13</version>
         </dependency>
 
         <dependency>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
@@ -5,8 +5,10 @@ import com.google.inject.Inject;
 import com.google.inject.Module;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
+import hudson.security.Permission;
 import io.jenkins.blueocean.BlueOceanUI;
 import io.jenkins.blueocean.commons.BlueOceanConfigProperties;
+import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -59,6 +61,10 @@ public class BlueOceanRootAction implements UnprotectedRootAction, StaplerProxy 
             SecurityContextHolder.setContext(securityContext);
 
             //TODO: implement this as filter, see PluginServletFilter to clear the context
+        }else{
+            //If user doesn't have overall Jenkins read permission then return 403, which results in classic UI redirecting
+            // user to login page
+            Jenkins.getInstance().checkPermission(Permission.READ);
         }
         return app;
     }

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -53,6 +53,14 @@
             <artifactId>blueocean-config</artifactId>
         </dependency>
 
+        <!-- Bundled plugins for improved out of the box experience -->
+        <!-- Kyoto feature -->
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>0.1</version>
+        </dependency>
+
         <!-- Test deps -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <java.level>7</java.level>
     <jackson.version>2.2.3</jackson.version>
-    <jenkins.version>2.2</jenkins.version>
+    <jenkins.version>2.7.3</jenkins.version>
     <node.version>5.8.0</node.version>
     <npm.version>3.7.3</npm.version>
   </properties>


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-37744.

- cd blueocean && mvn hpi:run
- Create a kyoto style pipeline, you can clone vivek/hellokyoto
- Run this pipeline all stages and parallels should appear well
- Create legacy pipeline and all should work well
- Make sure anonymous read is disabled (default on fresh install), access http://localhost:8080/jenkins/blue or any other path inside blue should result in redirection to login page.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

Ran ATH master branch locally, all tests pass.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

- Upgrades Jenkins core to 2.7.3 LTS
- Fixes regression where if JWT is disabled and anonymous read is not allowed access
  to /blue/... results in 403, resulting in to classic redirecting user to login page