### PR TITLE
JENKINS-38036# Regression fix with anonymous read permission on loadi…

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
@@ -8,10 +8,8 @@ import com.google.inject.Module;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.remoting.Base64;
-import hudson.security.Permission;
 import io.jenkins.blueocean.BlueOceanUI;
 import io.jenkins.blueocean.commons.BlueOceanConfigProperties;
-import io.jenkins.blueocean.commons.ServiceException;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
@@ -21,10 +19,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 
 /**
@@ -87,7 +82,7 @@ public class BlueOceanRootAction implements UnprotectedRootAction, StaplerProxy 
         }else{
             //If user doesn't have overall Jenkins read permission then return 403, which results in classic UI redirecting
             // user to login page
-            Jenkins.getInstance().checkPermission(Permission.READ);
+            Jenkins.getInstance().checkPermission(Jenkins.READ);
         }
 
         return app;


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-38036

* Install github auth plugin, enable it along with grant anonymous read rights under github authorization strategy. See JIRA ticket for details
* Access localhost:8080/jenkins/blue/ and it should render the dashboard without asking to login.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
Not practical to write unit test.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

…ng BO UI