### PR TITLE
JENKINS-37917# Folder/MB permissions should include start and stop as…

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -1,6 +1,5 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -29,6 +28,7 @@ import io.jenkins.blueocean.rest.model.BlueRunContainer;
 import io.jenkins.blueocean.rest.model.Container;
 import io.jenkins.blueocean.rest.model.Containers;
 import io.jenkins.blueocean.rest.model.Resource;
+import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
 import io.jenkins.blueocean.service.embedded.rest.BlueFavoriteResolver;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
@@ -88,9 +88,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
 
     @Override
     public Map<String, Boolean> getPermissions() {
-        return ImmutableMap.of(
-            BluePipeline.CREATE_PERMISSION, mbp.getACL().hasPermission(Item.CREATE),
-            BluePipeline.READ_PERMISSION, mbp.getACL().hasPermission(Item.READ));
+        return AbstractPipelineImpl.getPermissions(mbp);
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -159,8 +159,8 @@ public class MultiBranchTest extends PipelineBaseTest {
         Map<String,Boolean> permissions = (Map<String, Boolean>) r.get("permissions");
         Assert.assertTrue(permissions.get("create"));
         Assert.assertTrue(permissions.get("read"));
-        Assert.assertNull(permissions.get("start"));
-        Assert.assertNull(permissions.get("stop"));
+        Assert.assertTrue(permissions.get("start"));
+        Assert.assertTrue(permissions.get("stop"));
 
 
 
@@ -197,8 +197,8 @@ public class MultiBranchTest extends PipelineBaseTest {
         Map<String,Boolean> permissions = (Map<String, Boolean>) r.get("permissions");
         Assert.assertFalse(permissions.get("create"));
         Assert.assertTrue(permissions.get("read"));
-        Assert.assertNull(permissions.get("start"));
-        Assert.assertNull(permissions.get("stop"));
+        Assert.assertFalse(permissions.get("start"));
+        Assert.assertFalse(permissions.get("stop"));
 
 
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -1,6 +1,5 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
-import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Item;
@@ -8,7 +7,6 @@ import hudson.model.ItemGroup;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
-import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteAction;
@@ -16,6 +14,7 @@ import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineContainer;
 import io.jenkins.blueocean.rest.model.BluePipelineFolder;
 import io.jenkins.blueocean.rest.model.Resource;
+import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import org.kohsuke.stapler.json.JsonBody;
 
 import java.util.Collection;
@@ -102,9 +101,7 @@ public class PipelineFolderImpl extends BluePipelineFolder {
     public Map<String, Boolean> getPermissions() {
         if(folder instanceof AbstractItem){
             AbstractItem item = (AbstractItem) folder;
-            return ImmutableMap.of(
-                BluePipeline.CREATE_PERMISSION, item.getACL().hasPermission(Item.CREATE),
-                BluePipeline.READ_PERMISSION, item.getACL().hasPermission(Item.READ));
+            return AbstractPipelineImpl.getPermissions(item);
         }else{
             return null;
         }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -582,8 +582,8 @@ public class PipelineApiTest extends BaseTest {
 
         permissions = (Map<String, Boolean>) response.get("permissions");
         Assert.assertFalse(permissions.get("create"));
-        Assert.assertNull(permissions.get("start"));
-        Assert.assertNull(permissions.get("stop"));
+        Assert.assertFalse(permissions.get("start"));
+        Assert.assertFalse(permissions.get("stop"));
         Assert.assertTrue(permissions.get("read"));
     }
 


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-37917

* Try getting list of pipelines (Mb, folder, branch, job) GET http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/:id
* Check permission element, it should list four permissions, read, create, start and stop with true or false based on user permission.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

… well