### PR TITLE
JENKINS-38136# capability map API changed to POST

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -16,10 +16,14 @@ import jenkins.scm.api.actions.ChangeRequestAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.export.Exported;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+
 /**
  * @author Vivek Pandey
  */
-@Capability({"io.jenkins.blueocean.rest.model.BlueBranch","org.jenkinsci.plugins.workflow.job.WorkflowJob", "io.jenkins.blueocean.rest.impl.pipeline.PullReuqest"})
+@Capability({BLUE_BRANCH, JENKINS_WORKFLOW_JOB, PULL_REQUEST})
 public class BranchImpl extends PipelineImpl {
 
     private static final String PULL_REQUEST = "pullRequest";

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MatrixProjectImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MatrixProjectImpl.java
@@ -19,10 +19,12 @@ import io.jenkins.blueocean.service.embedded.rest.AbstractRunImpl;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.PipelineFolderImpl;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_MATRIX_PROJECT;
+
 /**
  * @author Vivek Pandey
  */
-@Capability("hudson.matrix.MatrixProject")
+@Capability(JENKINS_MATRIX_PROJECT)
 public class MatrixProjectImpl extends PipelineFolderImpl {
 
     private final MatrixProject matrixProject;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -49,12 +49,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_MULTI_BRANCH_PROJECT;
 import static io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl.isRunning;
 
 /**
  * @author Vivek Pandey
  */
-@Capability({"jenkins.branch.MultiBranchProject"})
+@Capability({JENKINS_MULTI_BRANCH_PROJECT})
 public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     /*package*/ final MultiBranchProject mbp;
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
@@ -11,10 +11,12 @@ import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+
 /**
  * @author Kohsuke Kawaguchi
  */
-@Capability({"org.jenkinsci.plugins.workflow.job.WorkflowJob"})
+@Capability({JENKINS_WORKFLOW_JOB})
 public class PipelineImpl extends AbstractPipelineImpl {
     protected PipelineImpl(Job job) {
         super(job);
@@ -36,7 +38,7 @@ public class PipelineImpl extends AbstractPipelineImpl {
             if(context == target && target instanceof WorkflowJob) {
                 return getPipeline(target,parent);
             }
-            
+
             return null;
         }
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -30,12 +30,14 @@ import org.kohsuke.stapler.export.Exported;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_RUN;
+
 /**
  * Pipeline Run
  *
  * @author Vivek Pandey
  */
-@Capability("org.jenkinsci.plugins.workflow.job.WorkflowRun")
+@Capability(JENKINS_WORKFLOW_RUN)
 public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
     public PipelineRunImpl(WorkflowRun run, Link parent) {
         super(run, parent);

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static io.jenkins.blueocean.rest.model.BlueRun.DATE_FORMAT_STRING;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.*;
 import static org.junit.Assert.*;
 
 /**
@@ -790,11 +791,11 @@ public class MultiBranchTest extends PipelineBaseTest {
         Assert.assertNotNull(response);
 
         List<String> classes = (List<String>) response.get("classes");
-        Assert.assertTrue(classes.contains("hudson.model.Job")
-            && classes.contains("org.jenkinsci.plugins.workflow.job.WorkflowJob")
-            && classes.contains("io.jenkins.blueocean.rest.model.BlueBranch")
-            && classes.contains("io.jenkins.blueocean.rest.model.BluePipeline")
-            && classes.contains("io.jenkins.blueocean.rest.impl.pipeline.PullReuqest"));
+        Assert.assertTrue(classes.contains(JENKINS_JOB)
+            && classes.contains(JENKINS_WORKFLOW_JOB)
+            && classes.contains(BLUE_BRANCH)
+            && classes.contains(BLUE_PIPELINE)
+            && classes.contains(PULL_REQUEST));
     }
 
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -43,12 +43,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_JOB;
+
 /**
  * Pipeline abstraction implementation. Use it to extend other kind of jenkins jobs
  *
  * @author Vivek Pandey
  */
-@Capability("hudson.model.Job")
+@Capability(JENKINS_JOB)
 public class AbstractPipelineImpl extends BluePipeline {
     private final Job job;
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ExtensionClassContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ExtensionClassContainerImpl.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.Extension;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.commons.stapler.JsonBody;
 import io.jenkins.blueocean.rest.ApiHead;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueExtensionClass;
@@ -10,8 +11,10 @@ import io.jenkins.blueocean.rest.model.BlueExtensionClassMap;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.QueryParameter;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,36 +44,59 @@ public class ExtensionClassContainerImpl extends BlueExtensionClassContainer {
             };
         }
 
-        final Map<String, BlueExtensionClass> classMap = new HashMap<>();
+        List<String> classList = new ArrayList<>();
         for(String p:param.split(",")){
             p = p.trim();
-            classMap.put(p, new ExtensionClassImpl(getClazz(p), this));
+            classList.add(p.trim());
         }
 
-        return new BlueExtensionClassMap() {
-            @Override
-            public Link getLink() {
-                return ExtensionClassContainerImpl.this.getLink().rel("?q="+param);
-            }
-
-            @Override
-            public Map<String, BlueExtensionClass> getMap() {
-                return classMap;
-            }
-        };
+        return new BlueExtensionClassMapImpl(classList, ExtensionClassContainerImpl.this.getLink().rel("?q="+param));
 
     }
+
+    @Override
+    public BlueExtensionClassMap getMap(@JsonBody Map<String, List<String>> request) {
+        List<String> cl = request.get("q")!=null ? request.get("q") : Collections.<String>emptyList();
+        return new BlueExtensionClassMapImpl(cl, ExtensionClassContainerImpl.this.getLink());
+    }
+
 
     @Override
     public Link getLink() {
         return ApiHead.INSTANCE().getLink().rel(getUrlName());
     }
 
-    private Class getClazz(String name){
+
+    private static Class getClazz(String name){
         try {
             return Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass(name);
         } catch (ClassNotFoundException e) {
             throw new ServiceException.NotFoundException(String.format("Class %s is not known", name));
+        }
+    }
+
+    public static class BlueExtensionClassMapImpl extends BlueExtensionClassMap{
+
+        private final Map<String, BlueExtensionClass> classMap = new HashMap<>();
+        private final Link self;
+
+        public BlueExtensionClassMapImpl(List<String> classList, Link self) {
+            for(String c:classList){
+                classMap.put(c, new ExtensionClassImpl(getClazz(c), this));
+            }
+            this.self = self;
+        }
+
+        @Override
+        public Link getLink() {
+            return self;
+        }
+
+
+
+        @Override
+        public Map<String, BlueExtensionClass> getMap() {
+            return classMap;
         }
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
@@ -16,12 +16,14 @@ import org.kohsuke.stapler.QueryParameter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_FREE_STYLE_BUILD;
+
 /**
  * FreeStyleRunImpl can add it's own element here
  *
  * @author Vivek Pandey
  */
-@Capability("hudson.model.FreeStyleBuild")
+@Capability(JENKINS_FREE_STYLE_BUILD)
 public class FreeStyleRunImpl extends AbstractRunImpl<FreeStyleBuild> {
     public FreeStyleRunImpl(FreeStyleBuild run, Link parent) {
         super(run, parent);

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.service.embedded;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.Extension;
@@ -40,6 +41,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import org.kohsuke.stapler.export.Exported;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -508,9 +510,8 @@ public class PipelineApiTest extends BaseTest {
         Assert.assertEquals("io.jenkins.blueocean.rest.annotation.test.TestPipelineExample", classes.get(1));
     }
 
-
     @Test
-    public void testClassesQuery(){
+    public void testClassesQueryWithPost(){
         // get classes for given class
         Map resp = get("/classes/"+TestPipelineImpl.class.getName());
         Assert.assertNotNull(resp);
@@ -519,17 +520,17 @@ public class PipelineApiTest extends BaseTest {
 
 
         // should return empty map
-        resp = get("/classes/");
+        resp = post("/classes/", Collections.EMPTY_MAP);
         Assert.assertNotNull(resp);
         Map m = (Map) resp.get("map");
         Assert.assertTrue(m.isEmpty());
 
-        // get classes map for given classes in the query
-        resp = get("/classes/?q=io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl,"+TestPipelineImpl.class.getName());
+        resp = post("/classes/", ImmutableMap.of("q", ImmutableList.of("io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl",TestPipelineImpl.class.getName())));
         Assert.assertNotNull(resp);
         m = (Map) resp.get("map");
         Assert.assertNotNull(m);
         Assert.assertEquals(2, m.size());
+
 
         Map v = (Map) m.get("io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl");
         Assert.assertNotNull(v);
@@ -543,6 +544,7 @@ public class PipelineApiTest extends BaseTest {
         classes = (List<String>) v.get("classes");
         Assert.assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
     }
+
 
     @Test
     public void PipelineUnsecurePermissionTest() throws IOException {

--- a/blueocean-rest/README.md
+++ b/blueocean-rest/README.md
@@ -217,7 +217,7 @@ Frontend can use _class in resource and classes API to serve UI based on class o
 
 ### Get detailed map of all given classes
 
-    curl -v -X GET  http://localhost:8080/jenkins/blue/rest/classes/?q=io.jenkins.blueocean.service.embedded.rest.PipelineImpl,io.jenkins.blueocean.service.embedded.rest.MultiBranchPipelineImpl 
+    curl -v -X POST  http://localhost:8080/jenkins/blue/rest/classes/ -d '{"q":["io.jenkins.blueocean.service.embedded.rest.PipelineImpl","io.jenkins.blueocean.service.embedded.rest.MultiBranchPipelineImpl"] 
 
     {
       "_class" : "io.jenkins.blueocean.service.embedded.rest.ExtensionClassContainerImpl$1",

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueExtensionClass.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueExtensionClass.java
@@ -5,12 +5,14 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.Collection;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_EXTENSION_CLASS;
+
 /**
  * Abstraction that defines a class extending Jenkins
  *
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueExtensionClass")
+@Capability(BLUE_EXTENSION_CLASS)
 public abstract class BlueExtensionClass extends Resource {
     private static final String CLASSES="classes";
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueExtensionClassContainer.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueExtensionClassContainer.java
@@ -1,12 +1,17 @@
 package io.jenkins.blueocean.rest.model;
 
 import hudson.ExtensionPoint;
+import io.jenkins.blueocean.commons.stapler.JsonBody;
 import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.ApiRoutable;
 import io.jenkins.blueocean.rest.Reachable;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Map representaion of {@link BlueExtensionClass}es
@@ -37,9 +42,25 @@ public abstract class BlueExtensionClassContainer implements ApiRoutable, Extens
      */
     @GET
     @WebMethod(name= "")
-//    @JsonResponse
     @TreeResponse
     public abstract BlueExtensionClassMap getMap(@QueryParameter("q") String param);
+
+
+    /**
+     * Gives Map of given class in the query to {@link BlueExtensionClass}
+     *
+     * @param request POST body with query element with value as list of classes e.g.
+     *                {'q':['class1', 'class2', 'class3']}
+     *
+     *
+     * @return Map of given class in the query to {@link BlueExtensionClass}. If given class in the parameter is not
+     *         known then 400, BadRequest should be returned
+     */
+    @POST
+    @WebMethod(name= "")
+    @TreeResponse
+    public abstract BlueExtensionClassMap getMap(@JsonBody Map<String,List<String>> request);
+
 
     @Override
     public String getUrlName() {

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueFavorite.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueFavorite.java
@@ -4,6 +4,8 @@ import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_FAVORITE;
+
 /**
  * A favorite item. The item itself must be JSON serializable bean
  *
@@ -11,7 +13,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * @author Vivek Pandey
  */
 @ExportedBean
-@Capability("io.jenkins.blueocean.rest.model.BlueFavorite")
+@Capability(BLUE_FAVORITE)
 public abstract class BlueFavorite extends Resource{
     private static final String ITEM = "item";
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueMultiBranchPipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueMultiBranchPipeline.java
@@ -9,12 +9,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_MULTI_BRANCH_PIPELINE;
+
 /**
  * Multi-branch pipeline model
  *
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueMultiBranchPipeline")
+@Capability(BLUE_MULTI_BRANCH_PIPELINE)
 public abstract class BlueMultiBranchPipeline extends BluePipelineFolder{
     public static final String TOTAL_NUMBER_OF_BRANCHES="totalNumberOfBranches";
     public static final String NUMBER_OF_FAILING_BRANCHES="numberOfFailingBranches";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueOrganization.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueOrganization.java
@@ -4,12 +4,14 @@ import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_ORGANIZATION;
+
 /**
  * API endpoint for an organization that houses all the pipelines.
  *
  * @author Kohsuke Kawaguchi
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueOrganization")
+@Capability(BLUE_ORGANIZATION)
 public abstract class BlueOrganization extends Resource {
     public static final String NAME="name";
     public static final String PIPELINES="pipelines";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
@@ -11,12 +11,14 @@ import org.kohsuke.stapler.verb.PUT;
 import java.util.Collection;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE;
+
 /**
  * Defines pipeline state and its routing
  *
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BluePipeline")
+@Capability(BLUE_PIPELINE)
 public abstract class BluePipeline extends Resource {
     public static final String ORGANIZATION="organization";
     public static final String NAME="name";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineFolder.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineFolder.java
@@ -3,6 +3,9 @@ package io.jenkins.blueocean.rest.model;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_ABSTRACT_FOLDER;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE_FOLDER;
+
 /**
  * Folder  has pipelines, could also hold another BluePipelineFolders.
  *
@@ -15,7 +18,7 @@ import org.kohsuke.stapler.export.Exported;
  *
  * @see BluePipelineContainer
  */
-@Capability({"io.jenkins.blueocean.rest.model.BluePipelineFolder","com.cloudbees.hudson.plugins.folder.AbstractFolder"})
+@Capability({BLUE_PIPELINE_FOLDER, JENKINS_ABSTRACT_FOLDER})
 public abstract class BluePipelineFolder extends BluePipeline {
 
     private static final String NUMBER_OF_PIPELINES = "numberOfPipelines";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineNode.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineNode.java
@@ -7,6 +7,8 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.List;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE_NODE;
+
 /**
  * Abstraction of Pipeline run node.
  *
@@ -52,7 +54,7 @@ import java.util.List;
  *</pre>
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BluePipelineNode")
+@Capability(BLUE_PIPELINE_NODE)
 public abstract class BluePipelineNode extends BluePipelineStep{
     /**
      * @return Steps inside a Pipeline Stage or Parallel branch

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineStep.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineStep.java
@@ -9,13 +9,14 @@ import java.util.Collection;
 import java.util.Date;
 
 import static io.jenkins.blueocean.rest.model.BlueRun.STATE;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE_STEP;
 
 /**
  * Pipeline Step resource
  *
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BluePipelineStep")
+@Capability(BLUE_PIPELINE_STEP)
 public abstract class BluePipelineStep extends Resource{
     public static final String DISPLAY_NAME="displayName";
     public static final String RESULT = "result";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueQueueItem.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueQueueItem.java
@@ -9,6 +9,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import static io.jenkins.blueocean.commons.JsonConverter.DATE_FORMAT_STRING;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_QUEUE_ITEM;
 
 
 /**
@@ -17,7 +18,7 @@ import static io.jenkins.blueocean.commons.JsonConverter.DATE_FORMAT_STRING;
  *
  * @author Ivan Meredith
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueQueueItem")
+@Capability(BLUE_QUEUE_ITEM)
 public abstract class BlueQueueItem extends Resource {
 
     public static final String QUEUED_TIME = "queuedTime";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueRun.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueRun.java
@@ -14,6 +14,8 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_RUN;
+
 /**
  * BlueOCean Run model.
  *
@@ -22,7 +24,7 @@ import java.util.Date;
  *
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueRun")
+@Capability(BLUE_RUN)
 public abstract class BlueRun extends Resource {
     public static final String ORGANIZATION="organization";
     public static final String ID="id";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
@@ -3,13 +3,15 @@ package io.jenkins.blueocean.rest.model;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_USER;
+
 /**
  * API endpoint for a user
  *
  * @author Kohsuke Kawaguchi
  * @author Vivek Pandey
  */
-@Capability("io.jenkins.blueocean.rest.model.BlueUser")
+@Capability(BLUE_USER)
 public abstract class BlueUser extends Resource {
     public static final String ID="id";
     public static final String FULL_NAME="fullName";

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/GenericResource.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/GenericResource.java
@@ -15,11 +15,13 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.GENERIC_RESOURCE;
+
 /**
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
-@Capability("io.jenkins.blueocean.rest.model.GenericResource")
+@Capability(GENERIC_RESOURCE)
 public class GenericResource<T> extends Resource {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericResource.class);
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/KnownCapabilities.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/KnownCapabilities.java
@@ -1,0 +1,31 @@
+package io.jenkins.blueocean.rest.model;
+
+/**
+ * @author Vivek Pandey
+ */
+public class KnownCapabilities {
+    public static final String RESOURCE="io.jenkins.blueocean.rest.model.Resource";
+    public static final String GENERIC_RESOURCE="io.jenkins.blueocean.rest.model.GenericResource";
+    public static final String BLUE_USER="io.jenkins.blueocean.rest.model.BlueUser";
+    public static final String BLUE_RUN="io.jenkins.blueocean.rest.model.BlueRun";
+    public static final String BLUE_QUEUE_ITEM="io.jenkins.blueocean.rest.model.BlueQueueItem";
+    public static final String BLUE_PIPELINE_STEP="io.jenkins.blueocean.rest.model.BluePipelineStep";
+    public static final String BLUE_PIPELINE_NODE="io.jenkins.blueocean.rest.model.BluePipelineNode";
+    public static final String BLUE_PIPELINE_FOLDER="io.jenkins.blueocean.rest.model.BluePipelineFolder";
+    public static final String BLUE_PIPELINE="io.jenkins.blueocean.rest.model.BluePipeline";
+    public static final String BLUE_ORGANIZATION="io.jenkins.blueocean.rest.model.BlueOrganization";
+    public static final String BLUE_MULTI_BRANCH_PIPELINE="io.jenkins.blueocean.rest.model.BlueMultiBranchPipeline";
+    public static final String BLUE_FAVORITE="io.jenkins.blueocean.rest.model.BlueFavorite";
+    public static final String BLUE_EXTENSION_CLASS="io.jenkins.blueocean.rest.model.BlueExtensionClass";
+    public static final String BLUE_BRANCH="io.jenkins.blueocean.rest.model.BlueBranch";
+    public static final String PULL_REQUEST="io.jenkins.blueocean.rest.model.PullRequest";
+
+    /** Jenkins core/plugin capabilities */
+    public static final String JENKINS_WORKFLOW_JOB ="org.jenkinsci.plugins.workflow.job.WorkflowJob";
+    public static final String JENKINS_WORKFLOW_RUN ="org.jenkinsci.plugins.workflow.job.WorkflowRun";
+    public static final String JENKINS_ABSTRACT_FOLDER ="com.cloudbees.hudson.plugins.folder.AbstractFolder";
+    public static final String JENKINS_JOB ="hudson.model.Job";
+    public static final String JENKINS_MATRIX_PROJECT="hudson.matrix.MatrixProject";
+    public static final String JENKINS_MULTI_BRANCH_PROJECT="jenkins.branch.MultiBranchProject";
+    public static final String JENKINS_FREE_STYLE_BUILD="hudson.model.FreeStyleBuild";
+}

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/Resource.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/Resource.java
@@ -9,13 +9,15 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.verb.GET;
 
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.RESOURCE;
+
 /**
  * Stapler-bound object that defines REST endpoint.
  *
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
-@Capability("io.jenkins.blueocean.rest.model.Resource")
+@Capability(RESOURCE)
 public abstract class Resource implements Reachable{
     /**
      * Returns the DTO object that gets databound to Json/XML etc. for state transfer


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-38136

To test classes map functionality:

`curl -v -X POST  http://localhost:8080/jenkins/blue/rest/classes/ -d '{"q":["io.jenkins.blueocean.service.embedded.rest.PipelineImpl","io.jenkins.blueocean.service.embedded.rest.MultiBranchPipelineImpl"]`

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

Can't run ATH it started failing with "Error: Signature author is required." If reviewer can run, will be great.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

- Also pulls in well known capabilities in to a class as constant
- Fixes typo in PullRequest capability