### PR TITLE
JENKINS-38176# fix for steps API for incomplete parallels

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphBuilder.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphBuilder.java
@@ -184,6 +184,7 @@ public class PipelineNodeGraphBuilder {
     public List<FlowNode> getParallelBranchSteps(FlowNode p){
         List<FlowNode> steps = new ArrayList<>();
         int i = sortedNodes.indexOf(p);
+        FlowNode prev=p;
         if(i>=0 && isParallelBranch(p)){
             FlowNode end = PipelineNodeUtil.getStepEndNode(sortedNodes,p);
             for(int j=i+1; j < sortedNodes.size(); j++){
@@ -196,11 +197,12 @@ public class PipelineNodeGraphBuilder {
                     continue;
                 }
                 //we take only the legal children
-                if(!PipelineNodeUtil.isInBlock(p, end, c)){
+                if(!PipelineNodeUtil.isInBlock(p, end, c) && !isParentOf(c,prev)){
                     continue;
                 }
                 if(c instanceof StepAtomNode) {
                     steps.add(c);
+                    prev=c;
 
                     FlowNode endNode = PipelineNodeUtil.getStepEndNode(sortedNodes,c);
                     if (endNode != null) {
@@ -210,6 +212,15 @@ public class PipelineNodeGraphBuilder {
             }
         }
         return steps;
+    }
+
+    private boolean isParentOf(FlowNode node, FlowNode child){
+        for(FlowNode n:node.getParents()){
+            if(child.equals(n)){
+                return true;
+            }
+        }
+        return false;
     }
 
 


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-38176

* create pipeline project with script https://gist.github.com/vivek/5b8068b47aa6cae8e85383db4128ce1b
* Build it, check it in BO, you should see 2 parallels left and right
* Not modify the script with https://gist.github.com/vivek/ca1d45e71a781bcd0d4f362088c125cb and trigger build
* Now click on left you should see all its steps, last step being 'waiting for interactive input'
* Click on right nothing happens, thats bug https://issues.jenkins-ci.org/browse/JENKINS-37962

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

Couldn't run ATH locally, fails with signature failure. can reviewer try running?

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

