### PR TITLE
[FIX JENKINS-38345] Wrong property to reset loading indicator classes

### DIFF
--- a/blueocean-dashboard/src/main/js/LoadingIndicator.js
+++ b/blueocean-dashboard/src/main/js/LoadingIndicator.js
@@ -49,7 +49,7 @@ export default {
             clearTimeouts();
             setLoaderClass('complete', 10);
             timeouts.push(setTimeout(() => {
-                document.getElementById('loadbar').classList = '';
+                document.getElementById('loadbar').className = '';
             }, 500));
         }
     },

--- a/blueocean-dashboard/src/main/js/LoadingIndicator.js
+++ b/blueocean-dashboard/src/main/js/LoadingIndicator.js
@@ -49,6 +49,7 @@ export default {
             clearTimeouts();
             setLoaderClass('complete', 10);
             timeouts.push(setTimeout(() => {
+                // clear all classes:
                 document.getElementById('loadbar').className = '';
             }, 500));
         }


### PR DESCRIPTION
# Description

See [JENKINS-38345](https://issues.jenkins-ci.org/browse/JENKINS-38345).

To test: use Safari, get the loading bar to show up, validate there is no javascript error when the loading bar disappears.

This is a simpler fix than https://github.com/jenkinsci/blueocean-plugin/pull/507

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

