### PR TITLE
[FIX JENKINS-38300] Fix pull requests within an org folder

### DIFF
--- a/blueocean-dashboard/src/main/js/components/PullRequest.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequest.jsx
@@ -35,13 +35,13 @@ export default class PullRequest extends Component {
                 router,
                 location,
                 pipeline: {
-                    name: pipelineName,
+                    fullName,
                     organization,
             },
                 },
         } = this;
         const open = () => {
-            location.pathname = buildRunDetailsUrl(organization, pipelineName, decodeURIComponent(pipeline), id, 'pipeline');
+            location.pathname = buildRunDetailsUrl(organization, fullName, decodeURIComponent(pipeline), id, 'pipeline');
             router.push(location);
         };
 

--- a/blueocean-dashboard/src/test/js/pullRequest-spec.js
+++ b/blueocean-dashboard/src/test/js/pullRequest-spec.js
@@ -40,3 +40,24 @@ describe('PullRequest should not render', () => {
         assert.isNull(tree.getRenderOutput());
     });
 });
+
+describe('PullRequest', () => {
+    it('opens correctly', (done) => {
+        const immData = new RunsRecord(pr[0]);
+        const tree = sd.shallowRender(<PullRequest pr={immData} />, {
+                router: {push: function(url) {
+                    assert(url.pathname == '/organizations/jenkins/asdf%2Fblah/detail/PR-6/1/pipeline', "Incorrect URL for pull request");
+                    done();
+                }
+            },
+            pipeline: {
+                fullName: 'asdf/blah',
+                organization: 'jenkins',
+            },
+            location: {},
+        });
+        
+        let tr = tree.subTree('tr');
+        tr.props.onClick();
+    });
+});


### PR DESCRIPTION
# Description

Create a GH org with pull requests, click to open the latest run for a pull request. You can use `kzantow` as the org, then filter repositories to `failure-project`. 

See [JENKINS-38300](https://issues.jenkins-ci.org/browse/JENKINS-38300).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

