### PR TITLE
[JENKINS-38252] Updated SSE Gateway plugin to 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.9</version>
+            <version>1.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.10-SNAPSHOT</version>
+            <version>1.10</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Description

Depends on https://github.com/jenkinsci/sse-gateway-plugin/pull/11

See [JENKINS-38252](https://issues.jenkins-ci.org/browse/JENKINS-38252).

Test would be to just make sure e.g. the run button pops up the STARTED toast. Other than that, we need to see if SSE config still appears in the list of blocked requests when BO comes under load.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

