### PR TITLE
feature/JENKINS-38321-js-extensions

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -40,9 +40,11 @@ export default class Pipelines extends Component {
                             { organization && ' / ' }
                             { organization && orgLink }
                         </h1>
-                        <a target="_blank" className="btn-secondary inverse" href={newJobUrl}>
-                            New Pipeline
-                        </a>
+                        <Extensions.Renderer extensionPoint="jenkins.pipeline.create.action">
+                            <a target="_blank" className="btn-secondary inverse" href={newJobUrl}>
+                                New Pipeline
+                            </a>
+                        </Extensions.Renderer>
                     </Title>
                 </PageHeader>
                 <main>

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -40,11 +40,9 @@ export default class Pipelines extends Component {
                             { organization && ' / ' }
                             { organization && orgLink }
                         </h1>
-                        <Extensions.Renderer extensionPoint="jenkins.pipeline.create.action">
-                            <a target="_blank" className="btn-secondary inverse" href={newJobUrl}>
-                                New Pipeline
-                            </a>
-                        </Extensions.Renderer>
+                        <a target="_blank" className="btn-secondary inverse" href={newJobUrl}>
+                            New Pipeline
+                        </a>
                     </Title>
                 </PageHeader>
                 <main>

--- a/checkdeps.js
+++ b/checkdeps.js
@@ -12,7 +12,10 @@
 
     Any conflicting PROD dependencies will be printed on STDERR, and it will exit(1)
 
-    If no conflicts, or only PEER/DEV conflicts, normal exit(0)
+    Any conflicting DEV or PEER dependencies for packages in @jenkins-cd/ npm group will be printed on STDERR,
+    and it will exit(1)
+
+    If no conflicts, or only non-jenkins PEER/DEV conflicts, normal exit(0)
 
 **********************************************************************************************
 *********************************************************************************************/
@@ -43,23 +46,26 @@ packageFiles.push(require("./blueocean-dashboard/package.json"));
 packageFiles.push(require("./blueocean-web/package.json"));
 packageFiles.push(require("./blueocean-personalization/package.json"));
 packageFiles.push(require("./blueocean-config/package.json"));
+packageFiles.push(require("./js-extensions/package.json"));
 
 // Add some expected dependencies, so we go another level deep just for these
 packageFiles.push(require("./blueocean-dashboard/node_modules/@jenkins-cd/design-language/package.json"));
-packageFiles.push(require("./blueocean-dashboard/node_modules/@jenkins-cd/js-extensions/package.json"));
 
 packageFiles.forEach(packageFile => {
 
-    addDependencies("prod", packageFile.dependencies);
-    // addDependencies("dev", packageFile.devDependencies);
-    // addDependencies("peer", packageFile.peerDependencies);
+    addDependencies("prod", packageFile.dependencies, true);
+    addDependencies("dev", packageFile.devDependencies, false);
+    addDependencies("peer", packageFile.peerDependencies, false);
 
-    function addDependencies(kind, deps) {
+    function addDependencies(kind, deps, includeNonJenkins) {
+
         if (deps) {
             Object.keys(deps).forEach(dependency => {
-                const version = deps[dependency];
-                initEntry(dependency, version);
-                allDependencies[dependency][version].push(packageFile.name + " (" + kind + ")");
+                if (includeNonJenkins || dependency.startsWith("@jenkins-cd")) {
+                    const version = deps[dependency];
+                    initEntry(dependency, version);
+                    allDependencies[dependency][version].push(packageFile.name + " (" + kind + ")");
+                }
             });
         }
     }

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.24",
+  "version": "0.0.25-beta1",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [
@@ -10,8 +10,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rm -rf dist && mkdir dist && npm install && babel --presets es2015,react src -d dist && npm run test",
+    "build": "rm -rf dist && mkdir dist && npm install && npm run compile && npm run test",
+    "compile": "babel --presets es2015,react src -d dist",
     "test": "gulp test",
+    "compile-test": "npm run compile && npm run test",
     "lint": "gulp lint"
   },
   "author": "Tom Fennelly <tom.fennelly@gmail.com> (https://github.com/tfennelly)",
@@ -27,11 +29,13 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "chai": "^3.5.0",
+    "enzyme": "^2.4.1",
     "eslint": "2.8.0",
     "eslint-plugin-react": "^5.0.1",
     "gulp": "^3.9.1",
     "gulp-mocha": "^2.2.0",
-    "chai": "^3.5.0",
+    "jsdom": "^9.5.0",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   },
@@ -40,8 +44,6 @@
     "envify": "3.4.1"
   },
   "peerDependencies": {
-    "@jenkins-cd/js-builder": "^0.0.40",
-    "@jenkins-cd/js-modules": "^0.0.8",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   }

--- a/js-extensions/spec/ExtensionRenderer-spec.js
+++ b/js-extensions/spec/ExtensionRenderer-spec.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const React = require('react');
+const jsTest = require('@jenkins-cd/js-test');
+const assert = require('chai').assert;
+const mount = require('enzyme').mount;
+const jsdom = require('jsdom');
+const ExtensionRenderer = require('../dist/ExtensionRenderer.js').ExtensionRenderer;
+const extensionStoreInstance = require('../dist/ExtensionStore.js').instance;
+
+const $ = React.createElement;
+
+function mockExtension(props) {
+    return (
+        $('h1', {}, 'Extension is a H1')
+    );
+}
+
+const extensionPointMetadata = {
+    ep1: [
+        mockExtension
+    ]
+};
+
+const mockExtensionStore = {
+    getExtensions: function(extensionPoint, filters, onLoad) {
+        onLoad = onLoad || filters;
+        onLoad(extensionPointMetadata[extensionPoint] || []);
+    }
+};
+
+const mockResourceLoadTracker = {
+    onMount: function() {
+        // Don't care
+    },
+
+    onUnmount: function() {
+        // Don't care
+    }
+};
+
+describe('ExtensionRenderer', function () {
+
+    var oldDocument;
+    var oldWindow;
+
+    var oldExtensionStore;
+    var oldResourceLoadTracker;
+
+    before(function() {
+
+        oldDocument = global.document;
+        oldWindow = global.window;
+
+        const doc = jsdom.jsdom('<!doctype html><html><body></body></html>');
+        global.document = doc;
+        global.window = doc.defaultView;
+    });
+
+    beforeEach(function () {
+        oldExtensionStore = ExtensionRenderer.ExtensionStore;
+        oldResourceLoadTracker = ExtensionRenderer.ResourceLoadTracker;
+
+        ExtensionRenderer.ExtensionStore = mockExtensionStore;
+        ExtensionRenderer.ResourceLoadTracker = mockResourceLoadTracker;
+    });
+
+    afterEach(function () {
+        ExtensionRenderer.ExtensionStore = oldExtensionStore;
+        ExtensionRenderer.ResourceLoadTracker = oldResourceLoadTracker;
+    });
+
+    after(function () {
+        global.document = oldDocument;
+        global.window = oldWindow;
+    });
+
+    it('should do nothing interesting by default', function () {
+        const result = mount($(ExtensionRenderer, {extensionPoint: 'foo.bar.baz'}));
+        assert.isTrue(result.is('ExtensionRenderer'), 'should be ExtensionRenderer');
+        assert.equal(result.length, 1, 'length');
+        assert.equal(result.children().length, 0, 'children.length');
+        assert.equal(result.html(), '<div></div>', 'html');
+        // Fixme: ^^^^ figure out how to test the rendered element name other than html() string comparison
+    });
+
+    it('should show default children if no extension found', function () {
+        const result = mount($(ExtensionRenderer, {extensionPoint: 'foo.bar.baz'}, 'Default text node'));
+        assert.isTrue(result.is('ExtensionRenderer'), 'should be ExtensionRenderer');
+        assert.equal(result.length, 1, 'length');
+        assert.equal(result.html(), '<div>Default text node</div>', 'html output');
+    });
+
+    it('should change the wrapping element', function () {
+        const result = mount($(ExtensionRenderer, {extensionPoint: 'ep1', wrappingElement: 'section'}));
+        assert.equal(result.html(), '<section><div><h1>Extension is a H1</h1></div></section>', 'html output');
+    });
+
+    it('should render the extension', function () {
+        const result = mount($(ExtensionRenderer, {extensionPoint: 'ep1'}));
+        assert.equal(result.html(), '<div><div><h1>Extension is a H1</h1></div></div>', 'html output');
+    });
+
+    it('should should not show default children when extension is present', function () {
+        const result = mount($(ExtensionRenderer, {extensionPoint: 'ep1'}, 'Default text node'));
+        assert.equal(result.html(), '<div><div><h1>Extension is a H1</h1></div></div>', 'html output');
+    });
+
+
+});


### PR DESCRIPTION
# Description

Updates ExtensionRenderer to show children as a default when no extensions are present for the specified ExtensionPoint. 

Also includes a small fix to checkdeps to make it a little more strict, but only when checking dependencies on jenkins-cd projects

*NB* This is not yet published to npm (hence the version bump and -beta)

See [JENKINS-38321](https://issues.jenkins-ci.org/browse/JENKINS-38321).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

 * Update ExtensionRenderer to show children as placeholders if no extensions are present
 * Tests for ExtensionRenderer, and a few tweaks for testability because JS
 * Improvements to checkdeps script backported from editor branch