### PR TITLE
Jenkins can abort but take a while for state to be finalised, so no u…

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -312,7 +312,6 @@ public class PipelineApiTest extends BaseTest {
 
         Map resp = put("/organizations/jenkins/pipelines/p1/runs/"+b.getId()+"/stop/?blocking=true&timeOutInSecs=2", Map.class);
         Assert.assertEquals("ABORTED", resp.get("result"));
-        Assert.assertEquals("FINISHED", resp.get("state"));
     }
 
 


### PR DESCRIPTION
# Description

A build can be aborted but still be running for a bit. It seems pointless to test the running status. 

cc @cliffmeyers  (just FYI in case you didn't know this fact). 

This test line frequently breaks various builds for no good reason (and nothing to do with blue ocean).

@reviewbybees 

