### PR TITLE
Fix: Unbuilt stages of a run are showing the wrong indicator

### DIFF
--- a/blueocean-dashboard/.eslintrc
+++ b/blueocean-dashboard/.eslintrc
@@ -2,6 +2,7 @@
   "extends": "@jenkins-cd/jenkins/react",
   "rules": {
     "react/jsx-no-bind": 0,
+    "eqeqeq": ["error", "smart"],
     "no-unused-vars": [2, {"varsIgnorePattern": "^React$"}],
     "max-len": [1, 160, 4]
   }

--- a/blueocean-dashboard/src/test/js/pipeline-graph-converter-spec.js
+++ b/blueocean-dashboard/src/test/js/pipeline-graph-converter-spec.js
@@ -5,9 +5,9 @@ import path from 'path';
 import {convertJenkinsNodeGraph} from '../../main/js/components/PipelineRunGraph.jsx';
 
 import {StatusIndicator} from '@jenkins-cd/design-language';
-const validResultValues = StatusIndicator.validResultValues; 
+const validResultValues = StatusIndicator.validResultValues;
 
-describe("pipeline graph data converter", () => {
+describe("pipeline graph data converter /", () => {
 
     let jsonDir = null;
 
@@ -15,12 +15,17 @@ describe("pipeline graph data converter", () => {
         jsonDir = path.resolve(__dirname, "../json/pipeline-graph-converter/");
     });
 
-    describe("for empty input of", () => {
+    describe("for empty input of /", () => {
 
         function expectEmptyArrayFor(label, input) {
-            describe(label, () => {
-                it("returns an empty array", () => {
-                    let result = convertJenkinsNodeGraph(input);
+            describe(label + ' /', () => {
+                it("returns an empty array when not finished", () => {
+                    let result = convertJenkinsNodeGraph(input, false);
+                    assert(Array.isArray(result), "result should be array");
+                    assert.equal(result.length, 0, "result should be empty");
+                });
+                it("returns an empty array when finished", () => {
+                    let result = convertJenkinsNodeGraph(input, true);
                     assert(Array.isArray(result), "result should be array");
                     assert.equal(result.length, 0, "result should be empty");
                 });
@@ -32,7 +37,7 @@ describe("pipeline graph data converter", () => {
         expectEmptyArrayFor("[]", []);
     });
 
-    describe("for single-node.json", () => {
+    describe("for single-node.json /", () => {
 
         let testDataJSON = null;
         let testData = null;
@@ -48,7 +53,7 @@ describe("pipeline graph data converter", () => {
         });
 
         it("produces the correct result", () => {
-            let result = convertJenkinsNodeGraph(testData);
+            let result = convertJenkinsNodeGraph(testData, false);
             assert(Array.isArray(result), "result should be array");
             assert.equal(result.length, 1, "result.length");
 
@@ -61,7 +66,7 @@ describe("pipeline graph data converter", () => {
         });
     });
 
-    describe("for three-nodes.json", () => {
+    describe("for three-nodes.json /", () => {
 
         let testDataJSON = null;
         let testData = null;
@@ -77,7 +82,7 @@ describe("pipeline graph data converter", () => {
         });
 
         it("produces the correct result", () => {
-            let result = convertJenkinsNodeGraph(testData);
+            let result = convertJenkinsNodeGraph(testData, false);
             assert(Array.isArray(result), "result should be array");
             assert.equal(result.length, 3, "result.length");
 
@@ -104,7 +109,7 @@ describe("pipeline graph data converter", () => {
         });
     });
 
-    describe("for pipeline-nodes-example.json", () => {
+    describe("for pipeline-nodes-example.json /", () => {
 
         let testDataJSON = null;
         let testData = null;
@@ -121,7 +126,7 @@ describe("pipeline graph data converter", () => {
 
         it("produces the correct result", () => {
             // Or it gets the hose again
-            let result = convertJenkinsNodeGraph(testData);
+            let result = convertJenkinsNodeGraph(testData, false);
             assert(Array.isArray(result), "result should be array");
             assert.equal(result.length, 3, "result.length");
 
@@ -164,7 +169,7 @@ describe("pipeline graph data converter", () => {
         });
     });
 
-    describe("for ends-with-parallel.json", () => {
+    describe("for ends-with-parallel.json /", () => {
 
         let testDataJSON = null;
         let testData = null;
@@ -180,7 +185,7 @@ describe("pipeline graph data converter", () => {
         });
 
         it("produces the correct result", () => {
-            let result = convertJenkinsNodeGraph(testData);
+            let result = convertJenkinsNodeGraph(testData, false);
             assert(Array.isArray(result), "result should be array");
             assert.equal(result.length, 2, "result.length");
 
@@ -216,7 +221,7 @@ describe("pipeline graph data converter", () => {
         });
     });
 
-    describe("for every-result.json", () => {
+    describe("for every-result.json /", () => {
 
         let testDataJSON = null;
         let testData = null;
@@ -231,52 +236,63 @@ describe("pipeline graph data converter", () => {
             assert.isAtLeast(testData.length, 1, "testData should not be empty");
         });
 
-        it("produces the correct result", () => {
-            let result = convertJenkinsNodeGraph(testData);
-            assert(Array.isArray(result), "result should be array");
-            assert.equal(result.length, 6, "result.length");
-
-            assert.equal(result[0].name, "First", "result[0].name");
-            assert.equal(result[0].id, "3", "result[0].id");
-            assert.equal(result[0].state, validResultValues.success, "result[0].state");
-            assert.equal(result[0].completePercent, 100, "result[0].completePercent");
-            assert(Array.isArray(result[0].children), "result[0].children should be array");
-            assert.equal(result[0].children.length, 0, "result[0] should have no children");
-
-            assert.equal(result[1].name, "Second", "result[1].name");
-            assert.equal(result[1].id, "13", "result[1].id");
-            assert.equal(result[1].state, validResultValues.running, "result[1].state");
-            assert.equal(result[1].completePercent, 50, "result[1].completePercent");
-            assert(Array.isArray(result[1].children), "result[1].children should be array");
-            assert.equal(result[1].children.length, 0, "result[1] should have no children");
-
-            assert.equal(result[2].name, "Third", "result[2].name");
-            assert.equal(result[2].id, "27", "result[2].id");
-            assert.equal(result[2].state, validResultValues.queued, "result[2].state");
-            assert.equal(result[2].completePercent, 0, "result[2].completePercent");
-            assert(Array.isArray(result[2].children), "result[2].children should be array");
-            assert.equal(result[2].children.length, 0, "result[2] should have no children");
-
-            assert.equal(result[3].name, "Fourth", "result[3].name");
-            assert.equal(result[3].id, "28", "result[3].id");
-            assert.equal(result[3].state, validResultValues.failure, "result[3].state");
-            assert.equal(result[3].completePercent, 100, "result[3].completePercent");
-            assert(Array.isArray(result[3].children), "result[3].children should be array");
-            assert.equal(result[3].children.length, 0, "result[3] should have no children");
-
-            assert.equal(result[4].name, "Steve", "result[4].name");
-            assert.equal(result[4].id, "29", "result[4].id");
-            assert.equal(result[4].state, validResultValues.not_built, "result[4].state");
-            assert.equal(result[4].completePercent, 0, "result[4].completePercent");
-            assert(Array.isArray(result[4].children), "result[4].children should be array");
-            assert.equal(result[4].children.length, 0, "result[4] should have no children");
-
-            assert.equal(result[5].name, "Unknown-Null", "result[5].name");
-            assert.equal(result[5].id, "33", "result[5].id");
-            assert.equal(result[5].state, validResultValues.queued, "result[5].state");
-            assert.equal(result[5].completePercent, 0, "result[5].completePercent");
-            assert(Array.isArray(result[5].children), "result[5].children should be array");
-            assert.equal(result[5].children.length, 0, "result[5] should have no children");
+        describe ("when completed /", function () {
+            testWithCompleted(true);
         });
+
+        describe ("when not completed /", function () {
+            testWithCompleted(false);
+        });
+
+        function testWithCompleted(isCompleted) {
+            it("produces the correct result", () => {
+                let result = convertJenkinsNodeGraph(testData, isCompleted);
+                assert(Array.isArray(result), "result should be array");
+                assert.equal(result.length, 6, "result.length");
+
+                assert.equal(result[0].name, "First", "result[0].name");
+                assert.equal(result[0].id, "3", "result[0].id");
+                assert.equal(result[0].state, validResultValues.success, "result[0].state");
+                assert.equal(result[0].completePercent, 100, "result[0].completePercent");
+                assert(Array.isArray(result[0].children), "result[0].children should be array");
+                assert.equal(result[0].children.length, 0, "result[0] should have no children");
+
+                assert.equal(result[1].name, "Second", "result[1].name");
+                assert.equal(result[1].id, "13", "result[1].id");
+                assert.equal(result[1].state, validResultValues.running, "result[1].state");
+                assert.equal(result[1].completePercent, 50, "result[1].completePercent");
+                assert(Array.isArray(result[1].children), "result[1].children should be array");
+                assert.equal(result[1].children.length, 0, "result[1] should have no children");
+
+                assert.equal(result[2].name, "Third", "result[2].name");
+                assert.equal(result[2].id, "27", "result[2].id");
+                assert.equal(result[2].state, validResultValues.queued, "result[2].state");
+                assert.equal(result[2].completePercent, 0, "result[2].completePercent");
+                assert(Array.isArray(result[2].children), "result[2].children should be array");
+                assert.equal(result[2].children.length, 0, "result[2] should have no children");
+
+                assert.equal(result[3].name, "Fourth", "result[3].name");
+                assert.equal(result[3].id, "28", "result[3].id");
+                assert.equal(result[3].state, validResultValues.failure, "result[3].state");
+                assert.equal(result[3].completePercent, 100, "result[3].completePercent");
+                assert(Array.isArray(result[3].children), "result[3].children should be array");
+                assert.equal(result[3].children.length, 0, "result[3] should have no children");
+
+                assert.equal(result[4].name, "Steve", "result[4].name");
+                assert.equal(result[4].id, "29", "result[4].id");
+                assert.equal(result[4].state, validResultValues.not_built, "result[4].state");
+                assert.equal(result[4].completePercent, 0, "result[4].completePercent");
+                assert(Array.isArray(result[4].children), "result[4].children should be array");
+                assert.equal(result[4].children.length, 0, "result[4] should have no children");
+
+                assert.equal(result[5].name, "Unknown-Null", "result[5].name");
+                assert.equal(result[5].id, "33", "result[5].id");
+                const expectedResultForNullInput = isCompleted ? validResultValues.not_built : validResultValues.queued;
+                assert.equal(result[5].state, expectedResultForNullInput, "result[5].state");
+                assert.equal(result[5].completePercent, 0, "result[5].completePercent");
+                assert(Array.isArray(result[5].children), "result[5].children should be array");
+                assert.equal(result[5].children.length, 0, "result[5] should have no children");
+            });
+        }
     });
 });


### PR DESCRIPTION
# Description

Fix to show null node results as "not built" instead of "queued" on completed runs.

See [JENKINS-38247](https://issues.jenkins-ci.org/browse/JENKINS-38247).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

    josh/JENKINS-38247-notbuilt-indicator * Lint
    josh/JENKINS-38247-notbuilt-indicator * Fix the bug when watching a live build transition to failed, and add
    josh/JENKINS-38247-notbuilt-indicator * Fixed when loading, but not yet when watching a build go from running -> finished