### PR TITLE
[FIX JENKINS-38044] Following runs in Blue Ocean doesn't show console output

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Step.jsx
+++ b/blueocean-dashboard/src/main/js/components/Step.jsx
@@ -43,7 +43,7 @@ export default class Node extends Component {
                 // we may have a streaming log
                 const number = Number(log.newStart);
                 // in case we doing karaoke we want to see more logs
-                if (number > 0 && followAlong) {
+                if ((number > 0 || !log.logArray) && followAlong) {
                     mergedConfig.newStart = log.newStart;
                     // kill current  timeout if any
                     this.clearThisTimeout();


### PR DESCRIPTION
# Description

See [JENKINS-38044](https://issues.jenkins-ci.org/browse/JENKINS-38044).

In some cases the log returned without logArray which then stopped refetching the log. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees @rtyler 

…ry to fetch again