### PR TITLE
Standardize dogfood and small fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
 !blueocean/target/plugins
-!docker-demo/
+!docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN install-plugins.sh antisamy-markup-formatter matrix-auth # for security, you
 # Force use of locally built blueocean plugin
 RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.jpi; do mv "$f" "$f.override"; done
 
+# let scripts customize the reference Jenkins folder. Used in bin/build-in-docker to inject the git build data
+COPY docker/ref /usr/share/jenkins/ref
+
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM jenkinsci/jenkins:latest
+#
+# Before building this Dockerfile, BlueOcean needs to be built locally using Maven
+# You can build everything needed and this Dockerfile by invoking `bin/build-in-docker.sh -m`
+#
+
+# Should be kept in sync with jenkins.properties of pom.xml (patch level doesn't count)
+FROM jenkins:2.7.4
 
 USER root
-
-# See JENKINS-34035 - disable upgrade wizard
-RUN echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state  && \
-    echo -n 2.0 > /usr/share/jenkins/ref/jenkins.install.InstallUtil.lastExecVersion
 
 COPY blueocean/target/plugins /usr/share/jenkins/ref/plugins/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # You can build everything needed and this Dockerfile by invoking `bin/build-in-docker.sh -m`
 #
 
-# Should be kept in sync with jenkins.properties of pom.xml (patch level doesn't count)
+# Should be kept in sync with jenkins.properties of pom.xml
+# Patch version is not to be considered, we prefer to base the image off the latest LTS of the line
+# and keep the dependency on the baseline in pom.xml
 FROM jenkins:2.7.4
 
 USER root

--- a/bin/build-in-docker.sh
+++ b/bin/build-in-docker.sh
@@ -185,12 +185,13 @@ if [[ $# -ne 0 ]]; then build_commands="$*"; fi
 
 setup_nice_output
 build_inside "cloudbees/java-build-tools"
-if [[ "$make_image" = true ]]; then
-  if [[ "$git_data" = true ]]; then
-    mkdir -p "$PROJECT_ROOT/docker/ref/init.groovy.d"
-    cat > "$PROJECT_ROOT/docker/ref/init.groovy.d/build_data.groovy" <<EOF
+if [[ "$git_data" = true ]]; then
+  mkdir -p "$PROJECT_ROOT/docker/ref/init.groovy.d"
+  cat > "$PROJECT_ROOT/docker/ref/init.groovy.d/build_data.groovy" <<EOF
 jenkins.model.Jenkins.instance.setSystemMessage('''$(build-git-description)''')
 EOF
-  fi
+fi
+
+if [[ "$make_image" = true ]]; then
   make_image
 fi

--- a/bin/build-in-docker.sh
+++ b/bin/build-in-docker.sh
@@ -114,7 +114,7 @@ build_inside() {
 
 build-git-description() {
   local head="$(git rev-parse --verify HEAD)"
-  echo "Built from commit <a href=\"https://github.com/jenkinsci/blueocean-plugin/commit/${head}\">${head}</a>"
+  echo "BlueOcean plugins built from commit <a href=\"https://github.com/jenkinsci/blueocean-plugin/commit/${head}\">${head}</a>"
   local pr="$(git show-ref | sed -n "s|^$head refs/remotes/.*/pr/\(.*\)$|\1|p")"
   if [[ ! -z $pr ]]; then
       echo ", <a href=\"https://github.com/jenkinsci/blueocean-plugin/pull/${pr}\">Pull Request ${pr}</a><br>"
@@ -187,8 +187,9 @@ setup_nice_output
 build_inside "cloudbees/java-build-tools"
 if [[ "$make_image" = true ]]; then
   if [[ "$git_data" = true ]]; then
-    cat > "$PROJECT_ROOT/docker/ref/git.groovy" <<EOF
-Jenkins.instance.setSystemMessage('''$(build-git-description)''')
+    mkdir -p "$PROJECT_ROOT/docker/ref/init.groovy.d"
+    cat > "$PROJECT_ROOT/docker/ref/init.groovy.d/build_data.groovy" <<EOF
+jenkins.model.Jenkins.instance.setSystemMessage('''$(build-git-description)''')
 EOF
   fi
   make_image

--- a/bin/build-in-docker.sh
+++ b/bin/build-in-docker.sh
@@ -112,6 +112,15 @@ build_inside() {
   stop_build_container
 }
 
+build-git-description() {
+  local head="$(git rev-parse --verify HEAD)"
+  echo "Built from commit <a href=\"https://github.com/jenkinsci/blueocean-plugin/commit/${head}\">${head}</a>"
+  local pr="$(git show-ref | sed -n "s|^$head refs/remotes/.*/pr/\(.*\)$|\1|p")"
+  if [[ ! -z $pr ]]; then
+      echo ", <a href=\"https://github.com/jenkinsci/blueocean-plugin/pull/${pr}\">Pull Request ${pr}</a><br>"
+  fi
+}
+
 make_image() {
   echo "${yellow}=> ${normal}Building BlueOcean docker development image ${tag_name}"
   (cd "$PROJECT_ROOT" && docker build -t "$tag_name" . )
@@ -122,11 +131,14 @@ tag_name="blueocean-dev:local"
 
 usage() {
 cat <<EOF
-usage: $(basename $0) [-c|--clean] [-m|--make-image[=tag_name]] [-h|--help] [BUILD_COMMAND]
+usage: $(basename $0) [-c|--clean] [-m|--make-image[=tag_name]] [-g|--git-data] [-h|--help] [BUILD_COMMAND]
 
   Build BlueOcean plugin suite locally like it would be in Jenkins, by isolating the build
   inside a Docker container. Requires a local Docker daemon to work.
-  Can also create a BlueOcean docker image if '-m' is passed.
+
+  Create a BlueOcean docker dev image with Dockerfile if '-m' is passed and inject git revision data
+  to it if '-g' is passed.
+
   In order to speed up builds, the build container is kept between builds in order to keep
   Maven / NPM caches. It can be cleaned up with '-c' option.
 
@@ -139,6 +151,7 @@ EOF
 
 clean=false
 make_image=false
+git_data=false
 
 for i in "$@"; do
     case $i in
@@ -158,6 +171,10 @@ for i in "$@"; do
         make_image=true
         shift # past argument=value
         ;;
+        -g|--git-data)
+        git_data=true
+        shift # past argument=value
+        ;;
         *)
         break
         ;;
@@ -169,5 +186,10 @@ if [[ $# -ne 0 ]]; then build_commands="$*"; fi
 setup_nice_output
 build_inside "cloudbees/java-build-tools"
 if [[ "$make_image" = true ]]; then
+  if [[ "$git_data" = true ]]; then
+    cat > "$PROJECT_ROOT/docker/ref/git.groovy" <<EOF
+Jenkins.instance.setSystemMessage('''$(build-git-description)''')
+EOF
+  fi
   make_image
 fi

--- a/bin/build-in-docker.sh
+++ b/bin/build-in-docker.sh
@@ -4,6 +4,20 @@ set -eu -o pipefail
 PROJECT_ROOT="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
 
 setup_nice_output() {
+
+  bold=""
+  underline=""
+  standout=""
+  normal=""
+  black=""
+  red=""
+  green=""
+  yellow=""
+  blue=""
+  magenta=""
+  cyan=""
+  white=""
+
   # check if stdout is a terminal...
   if [ -t 1 ]; then
 

--- a/bin/git-helper.sh
+++ b/bin/git-helper.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+PROJECT_ROOT="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+
+usage() {
+  cat <<EOF
+usage: $(basename "$0") COMMAND ARGS
+Helper script to query Git
+Commands:
+  pr-id      Find the Pull Request id
+             Assume that 'git fetch --progress https://github.com/jenkinsci/blueocean-plugin.git +refs/pull/*/head:refs/remotes/origin/pr/*' already ran
+
+EOF
+  exit 0
+}
+
+pr-id() {
+  local github_remote=origin
+  local head=$(git rev-parse --verify HEAD)
+  git show-ref | sed -n "s|^$head refs/remotes/${github_remote}/pr/\(.*\)$|\1|p"
+}
+
+command_name="$1"; shift; case "$command_name" in
+  pr-id)
+    pr-id "$@"
+    ;;
+  *)
+    usage
+esac

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <java.level>7</java.level>
     <jackson.version>2.2.3</jackson.version>
-    <jenkins.version>2.7.1</jenkins.version>
+    <jenkins.version>2.7.1</jenkins.version> <!-- Should be kept in sync with Dockerfile FROM statement-->
     <node.version>5.8.0</node.version>
     <npm.version>3.7.3</npm.version>
   </properties>


### PR DESCRIPTION
Replaces #523. I had to push my branch to jenkinsci repository in order to get it built by PR builder.

This is a follow-up to JENKINS-37141.

Depends on a fixed Jenkins LTS version instead of latest to ensure reproducible builds.
Don't bypass installation wizard by default as it's here to enforce security.

With this, Docker image built from master branch should be usable for dogfooding, which would make https://github.com/cloudbees/blueocean-docker-image obsolete

@jenkinsci/code-reviewers @reviewbybees 
