### PR TITLE
Trigger the ATH, with matching branch name support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,16 @@ node {
         sh "node checkdeps.js"
         step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
         step([$class: 'ArtifactArchiver', artifacts: '*/target/*.hpi'])
+
+        // Trigger the ATH, but don't wait for it.
+        try {
+          echo "Will attempt to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'.".
+          build (job: "ATH-Jenkinsfile/${env.BRANCH_NAME}", parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
+        } catch (Exception e) {
+          echo "Failed to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'. Will try running the ATH 'master' branch.".
+          build (job: 'ATH-Jenkinsfile/master', parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
+        }
+
       } catch(err) {
         currentBuild.result = "FAILURE"
       } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,12 +11,15 @@ node {
         step([$class: 'ArtifactArchiver', artifacts: '*/target/*.hpi'])
 
         // Trigger the ATH, but don't wait for it.
+        def postBuildResult = currentBuild.result;
         try {
           echo "Will attempt to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'.".
           build (job: "ATH-Jenkinsfile/${env.BRANCH_NAME}", parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
         } catch (Exception e) {
           echo "Failed to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'. Will try running the ATH 'master' branch.".
           build (job: 'ATH-Jenkinsfile/master', parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
+          // Reset the build status in case the first attempt to build the branch failed.
+          currentBuild.result = postBuildResult;
         }
 
       } catch(err) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,18 +12,7 @@ node {
         step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
         step([$class: 'ArtifactArchiver', artifacts: '*/target/*.hpi'])
 
-        // Trigger the ATH, but don't wait for it.
-        def postBuildResult = currentBuild.result;
-        try {
-          echo "Will attempt to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'.".
-          build (job: "ATH-Jenkinsfile/${env.BRANCH_NAME}", parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
-        } catch (Exception e) {
-          echo "Failed to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'. Will try running the ATH 'master' branch.".
-          build (job: 'ATH-Jenkinsfile/master', parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
-          // Reset the build status in case the first attempt to build the branch failed.
-          currentBuild.result = postBuildResult;
-        }
-
+        triggerATH();
       } catch(err) {
         currentBuild.result = "FAILURE"
       } finally {
@@ -32,6 +21,17 @@ node {
       }
     }
   }
+}
+
+def triggerATH() {
+    // Trigger the ATH, but don't wait for it.
+    try {
+        echo "Will attempt to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'."
+        build(job: "ATH-Jenkinsfile/${env.BRANCH_NAME}", parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
+    } catch (e1) {
+        echo "Failed to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'. Will try running the ATH 'master' branch."
+        build(job: 'ATH-Jenkinsfile/master', parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}")], wait: false)
+    }
 }
 
 def sendhipchat() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!groovy
+
 node {
   deleteDir()
   checkout scm


### PR DESCRIPTION
# Description

See [JENKINS-37918](https://issues.jenkins-ci.org/browse/JENKINS-37918).

So when a branch is pushed to Blue Ocean and it builds successfully, this change will try trigger the ATH, first trying to trigger a branch of the same name, falling back to master if there is none.

Lets see if https://ci.blueocean.io/job/blueocean/job/trigger-ath/ triggers https://ci.blueocean.io/job/ATH-Jenkinsfile/job/trigger-ath/

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests. __N/A__
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below. __N/A__
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

