### PR TITLE
Assemble and archive plugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def triggerATH() {
     // The ATH build can copy this artifact and use it, saving the time it
     // would otherwise spend building and assembling again.
     sh 'cd blueocean && mvn hpi:assemble-dependencies && tar -czvf target/ath-plugins.tar.gz target/plugins'
-    archiveArtifacts artifacts: 'target/ath-plugins.tar.gz'
+    archiveArtifacts artifacts: 'blueocean/target/ath-plugins.tar.gz'
 
     // Trigger the ATH, but don't wait for it.
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,13 +37,13 @@ def triggerATH() {
         echo "Will attempt to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'."
         build(job: "ATH-Jenkinsfile/${env.BRANCH_NAME}",
                 parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}"),
-                             string(name: 'TRIGGERED_BY_JOB_NAME', value: "${env.JOB_NAME}"), string(name: 'TRIGGERED_BY_BUILD_NUM', value: "${env.BUILD_NUMBER}")],
+                             string(name: 'TRIGGERED_BY_BUILD_NUM', value: "${env.BUILD_NUMBER}")],
                 wait: false)
     } catch (e1) {
         echo "Failed to run the ATH with the same branch name i.e. '${env.BRANCH_NAME}'. Will try running the ATH 'master' branch."
         build(job: "ATH-Jenkinsfile/master",
                 parameters: [string(name: 'BLUEOCEAN_BRANCH_NAME', value: "${env.BRANCH_NAME}"),
-                             string(name: 'TRIGGERED_BY_JOB_NAME', value: "${env.JOB_NAME}"), string(name: 'TRIGGERED_BY_BUILD_NUM', value: "${env.BUILD_NUMBER}")],
+                             string(name: 'TRIGGERED_BY_BUILD_NUM', value: "${env.BUILD_NUMBER}")],
                 wait: false)
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,7 @@ def triggerATH() {
     // Assemble and archive the HPI plugins that the ATH should use.
     // The ATH build can copy this artifact and use it, saving the time it
     // would otherwise spend building and assembling again.
-    sh 'mvn hpi:assemble-dependencies'
-    sh 'tar -czvf target/ath-plugins.tar.gz target/plugins'
+    sh 'cd blueocean && mvn hpi:assemble-dependencies && tar -czvf target/ath-plugins.tar.gz target/plugins'
     archiveArtifacts artifacts: 'target/ath-plugins.tar.gz'
 
     // Trigger the ATH, but don't wait for it.


### PR DESCRIPTION
# Description

[JENKINS-37918](https://issues.jenkins-ci.org/browse/JENKINS-37918)

Assemble a tar of the plugins needed by BO and the ATH to run, saving the ATH run a lot of overhead/ See https://github.com/jenkinsci/blueocean-acceptance-test/pull/47

@jenkinsci/code-reviewers @reviewbybees 
