### PR TITLE
Update es6-promise to 3.3.1

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/sse-gateway": "0.0.9",
-    "es6-promise": "3.2.1",
+    "es6-promise": "3.3.1",
     "isomorphic-fetch": "2.2.1",
     "jsonwebtoken": "7.1.9",
     "pem-jwk": "1.5.1",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -1944,9 +1944,9 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-promise": {
-      "version": "3.2.1",
-      "from": "es6-promise@3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+      "version": "3.3.1",
+      "from": "es6-promise@3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
     },
     "es6-set": {
       "version": "0.1.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "@jenkins-cd/js-extensions": "0.0.25",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/sse-gateway": "0.0.9",
-    "es6-promise": "3.2.1",
+    "es6-promise": "3.3.1",
     "immutable": "3.8.1",
     "isomorphic-fetch": "2.2.1",
     "keymirror": "0.1.1",


### PR DESCRIPTION
# Description

Updating es6-promise to 3.3.1


See changelog at https://github.com/stefanpenner/es6-promise/blob/master/CHANGELOG.md#331

Difference between 3.2.1 and 3.3.1.