### PR TITLE
[FIX JENKINS-37017] Github Org folder projects detail screen missing org name in path

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
@@ -27,10 +27,16 @@ class RunDetailsHeader extends Component {
 
     render() {
         const { data: run, pipeline: { fullName = '' } } = this.props;
+        // pipeline name
+        const displayName = decodeURIComponent(run.pipeline);
         // enable folder path
         const nameArray = fullName.split('/');
-        // last part is same as run.pipeline so getting rid of it
-        nameArray.pop();
+
+        // we want the full path for folder based projects
+        if (nameArray[nameArray.length - 1] === displayName) {
+            // last part is same as run.pipeline so getting rid of it
+            nameArray.pop();
+        }
         // cleanName is in case of no folder empty
         const cleanFullName = nameArray.join(' / ');
         // Grab author from each change, run through a set for uniqueness
@@ -39,7 +45,6 @@ class RunDetailsHeader extends Component {
         const status = run.getComputedResult();
         const durationMillis = run.isRunning() ?
             moment().diff(moment(run.startTime)) : run.durationInMillis;
-        const displayName = decodeURIComponent(run.pipeline);
         const onAuthorsClick = () => this.handleAuthorsClick();
         return (
         <div className="pipeline-result">


### PR DESCRIPTION
# Description

See [JENKINS-37017](https://issues.jenkins-ci.org/browse/JENKINS-37017).

# BO

![screenshot from 2016-09-30 12-44-30](https://cloud.githubusercontent.com/assets/596701/18989436/463e4574-870c-11e6-85ce-13abd143bd81.png)

# classic

![screenshot from 2016-09-30 12-50-13](https://cloud.githubusercontent.com/assets/596701/18989483/8d6765e8-870c-11e6-8ffd-0c96542fb5c1.png)

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

