### PR TITLE
[JENKINS-38013] Set the Cache-Control header for static and adjunct resources

### DIFF
--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -26,6 +26,13 @@
             <artifactId>variant</artifactId>
             <version>1.0</version>
         </dependency>
+
+        <!-- test scope deps -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
@@ -14,6 +14,7 @@ public class BlueOceanUI {
 
     public BlueOceanUI(String rootPath) {
         this.urlBase = rootPath;
+        ResourceCacheControl.install();
     }
 
     /**

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
@@ -77,10 +77,15 @@ public final class ResourceCacheControl implements Filter {
             return;
         }
         INSTANCE = new ResourceCacheControl();
-        try {
-            PluginServletFilter.addFilter(INSTANCE);
-        } catch (ServletException e) {
-            throw new IllegalStateException("Unexpected Exception installing Blue Web Resource Adjunct cache control filter.", e);
+
+        // Don't add the filter if we are running with hpi:run. Otherwise, people need
+        // to do a hard reload (bypassing the cache), which may confuse people during dev.
+        if (!Boolean.getBoolean("hudson.hpi.run")) {
+            try {
+                PluginServletFilter.addFilter(INSTANCE);
+            } catch (ServletException e) {
+                throw new IllegalStateException("Unexpected Exception installing Blue Web Resource Adjunct cache control filter.", e);
+            }
         }
     }
 

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.blueocean;
+
+import hudson.util.PluginServletFilter;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resource cache-control filter.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public final class ResourceCacheControl implements Filter {
+
+    private static ResourceCacheControl INSTANCE;
+
+    private final List<String> resourcePrefixes = new ArrayList<>();
+
+    private ResourceCacheControl() {
+        // Add paths to resources that we want to set the
+        // cache-control header.
+        addPath(Jenkins.RESOURCE_PATH); // "/static/VERSION" resources - e.g. JDL assets (fonts etc)
+        addPath(Jenkins.getInstance().getAdjuncts("").rootURL);
+    }
+
+    private void addPath(String path) {
+        // Make sure the paths always start and end with a slash.
+        // This simplifies later comparison with the request path.
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        if (!path.endsWith("/")) {
+            path =  path + "/";
+        }
+        resourcePrefixes.add(path);
+    }
+
+    public static synchronized void install() {
+        if (INSTANCE != null) {
+            return;
+        }
+        INSTANCE = new ResourceCacheControl();
+        try {
+            PluginServletFilter.addFilter(INSTANCE);
+        } catch (ServletException e) {
+            throw new IllegalStateException("Unexpected Exception installing Blue Web Resource Adjunct cache control filter.", e);
+        }
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // Check the request path and set the cache-control header if we find
+        // it matches what we're looking for.
+        if (request instanceof HttpServletRequest) {
+            if (isCacheableResourceRequest((HttpServletRequest)request)) {
+                //
+                // Set the expiry to one year.
+                //
+                // Note that this does NOT mean that the browser will never send a request
+                // for these resources. If you click reload in the browser (def in Chrome) it will
+                // send an If-Modified-Since request to the server (at a minimum), which means you at
+                // least have the request overhead even if it results in a 304 response. Setting the
+                // Cache-Control header helps for normal browsing (clicking on links, bookmarks etc),
+                // in which case the local cache is fully used (no If-Modified-Since requests for
+                // non-stale resources).
+                //
+                ((HttpServletResponse)response).setHeader("Cache-Control", "public, max-age=31536000");
+            }
+        }
+        // continue to execute the filer chain as normal
+        chain.doFilter(request, response);
+    }
+
+    private boolean isCacheableResourceRequest(HttpServletRequest request) {
+        String requestPath = request.getPathInfo();
+        for (String resourcePrefix : resourcePrefixes) {
+            if (requestPath.startsWith(resourcePrefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
@@ -53,14 +53,10 @@ public final class ResourceCacheControl implements Filter {
 
     private final List<String> resourcePrefixes = new ArrayList<>();
 
-    private ResourceCacheControl() {
-        // Add paths to resources that we want to set the
-        // cache-control header.
-        addPath(Jenkins.RESOURCE_PATH); // "/static/VERSION" resources - e.g. JDL assets (fonts etc)
-        addPath(Jenkins.getInstance().getAdjuncts("").rootURL);
+    ResourceCacheControl() {
     }
 
-    private void addPath(String path) {
+    String addPath(String path) {
         // Make sure the paths always start and end with a slash.
         // This simplifies later comparison with the request path.
         if (!path.startsWith("/")) {
@@ -70,6 +66,8 @@ public final class ResourceCacheControl implements Filter {
             path =  path + "/";
         }
         resourcePrefixes.add(path);
+
+        return path;
     }
 
     public static synchronized void install() {
@@ -82,8 +80,13 @@ public final class ResourceCacheControl implements Filter {
         // to do a hard reload (bypassing the cache), which may confuse people during dev.
         if (!Boolean.getBoolean("hudson.hpi.run")) {
             try {
+                // Add paths to resources that we want to set the
+                // cache-control header.
+                INSTANCE.addPath(Jenkins.RESOURCE_PATH); // "/static/VERSION" resources - e.g. JDL assets (fonts etc)
+                INSTANCE.addPath(Jenkins.getInstance().getAdjuncts("").rootURL);
+
                 PluginServletFilter.addFilter(INSTANCE);
-            } catch (ServletException e) {
+            } catch (Exception e) {
                 throw new IllegalStateException("Unexpected Exception installing Blue Web Resource Adjunct cache control filter.", e);
             }
         }

--- a/blueocean-web/src/test/java/io/jenkins/blueocean/ResourceCacheControlTest.java
+++ b/blueocean-web/src/test/java/io/jenkins/blueocean/ResourceCacheControlTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.blueocean;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class ResourceCacheControlTest {
+
+    private ResourceCacheControl resourceCacheControl;
+    private HttpServletRequest servletRequest;
+    private HttpServletResponse servletResponse;
+    private FilterChain filterChain;
+
+    @Test
+    public void test_addPath() {
+        ResourceCacheControl resourceCacheControl = new ResourceCacheControl();
+
+        Assert.assertEquals("/a/b/", resourceCacheControl.addPath("a/b"));
+        Assert.assertEquals("/a/b/", resourceCacheControl.addPath("/a/b"));
+        Assert.assertEquals("/a/b/", resourceCacheControl.addPath("a/b/"));
+        Assert.assertEquals("/a/b/", resourceCacheControl.addPath("/a/b/"));
+    }
+
+    @Before
+    public void before() throws IOException, ServletException {
+        resourceCacheControl = new ResourceCacheControl();
+
+        resourceCacheControl.addPath("a/b");
+        resourceCacheControl.addPath("c/d");
+
+        servletRequest = Mockito.mock(HttpServletRequest.class);
+        servletResponse = Mockito.mock(HttpServletResponse.class);
+        filterChain = Mockito.mock(FilterChain.class);
+    }
+
+    @Test
+    public void test_cache_control_set() throws IOException, ServletException {
+        Mockito.when(servletRequest.getPathInfo()).thenReturn("/a/b/c.js");
+        resourceCacheControl.doFilter(servletRequest, servletResponse, filterChain);
+        Mockito.verify(servletResponse).setHeader("Cache-Control", "public, max-age=31536000");
+    }
+
+    @Test
+    public void test_cache_control_not_set() throws IOException, ServletException {
+        Mockito.when(servletRequest.getPathInfo()).thenReturn("/a/bc.js");
+        resourceCacheControl.doFilter(servletRequest, servletResponse, filterChain);
+        Mockito.verify(servletResponse, Mockito.never()).setHeader("Cache-Control", "public, max-age=31536000");
+    }}

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,13 @@
             <version>1.4.9</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
       <dependency> <!-- TODO pending https://github.com/jenkinsci/jenkins-test-harness/pull/2 -->
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>


### PR DESCRIPTION
# Description

See [JENKINS-38013](https://issues.jenkins-ci.org/browse/JENKINS-38013).

Will see about writing a unit test.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

Fyi, before making this change it would always make an `If-Modified-Since` request to the browser, resulting in at least an empty requests/response sequence, which can be costly if you live in the boonies in Australia. E.g. .... see the following wireshark log from before the change (activity page - with "Regular 3G" throttling enabled in the dev tools - rough mimic of slow connection) ....

![screenshot 2016-10-04 15 16 38](https://cloud.githubusercontent.com/assets/429311/19078597/a2f99bb2-8a48-11e6-8cc1-c2687b1ab2f2.png)

After making this change, those `If-Modified-Since` requests were eliminated for normal browsing (note these are sill present if you hit the reload button in the browser - in Chrome anyway) 
...

![screenshot 2016-10-04 15 28 42](https://cloud.githubusercontent.com/assets/429311/19078666/d56e275c-8a48-11e6-95f4-34cff30ee742.png)

