### PR TITLE
Update to use the new plugin parent pom (2.17)

### DIFF
--- a/blueocean-dashboard/.mvn_exec_node
+++ b/blueocean-dashboard/.mvn_exec_node
@@ -1,0 +1,1 @@
+Simple marker file to tell maven to execute node build profiles.

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -9,7 +9,9 @@
     "test": "gulp test",
     "test:watch": "gulp test:watch",
     "bundle": "gulp bundle",
-    "bundle:watch": "gulp bundle:watch"
+    "bundle:watch": "gulp bundle:watch",
+    "mvnbuild": "gulp bundle",
+    "mvntest": "gulp test lint"
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",

--- a/blueocean-personalization/.mvn_exec_node
+++ b/blueocean-personalization/.mvn_exec_node
@@ -1,0 +1,1 @@
+Simple marker file to tell maven to execute node build profiles.

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -9,7 +9,9 @@
     "test": "gulp test",
     "test:watch": "gulp test:watch",
     "bundle": "gulp bundle",
-    "bundle:watch": "gulp bundle:watch"
+    "bundle:watch": "gulp bundle:watch",
+    "mvnbuild": "gulp bundle",
+    "mvntest": "gulp test lint"
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",

--- a/blueocean-web/.mvn_exec_node
+++ b/blueocean-web/.mvn_exec_node
@@ -1,0 +1,1 @@
+Simple marker file to tell maven to execute node build profiles.

--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -11,6 +11,12 @@ var builder = require('@jenkins-cd/js-builder');
 
 // create a dummy revisionInfo so developmentFooter will not fail
 const revisionInfo = '// Do not edit, it is generated and will be on each build.\nexport default {};';
+
+// Create the dir path. This gets executed by mvn before the
+// Java src is compiled, so it's not already created for
+// the revisionInfo stuff below to work without write failures.
+builder.paths.mkdirp('target/classes/io/jenkins/blueocean');
+
 fs.writeFile('target/classes/io/jenkins/blueocean/revisionInfo.js', revisionInfo, err => {
   if (err) throw err;
 });

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -8,7 +8,9 @@
     "test": "gulp test",
     "test:watch": "gulp test:watch",
     "bundle": "gulp bundle",
-    "bundle:watch": "gulp bundle:watch"
+    "bundle:watch": "gulp bundle:watch",
+    "mvnbuild": "gulp bundle",
+    "mvntest": "gulp test lint"
   },
   "devDependencies": {
     "@jenkins-cd/js-builder": "0.0.40",

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.10</version>
+    <version>2.17</version>
   </parent>
 
   <groupId>io.jenkins.blueocean</groupId>
@@ -19,6 +19,7 @@
     <java.level>7</java.level>
     <jackson.version>2.2.3</jackson.version>
     <jenkins.version>2.7.1</jenkins.version> <!-- Should be kept in sync with Dockerfile FROM statement-->
+    <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <node.version>5.8.0</node.version>
     <npm.version>3.7.3</npm.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,28 @@
             </configuration>
         </plugin>
 
+        <!--
+        TODO: Remove/review this as part of solving https://issues.jenkins-ci.org/browse/JENKINS-38888
+        See comment below on argLine config.
+        -->
+        <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <systemProperties>
+                    <property>
+                        <name>hudson.udp</name>
+                        <value>33849</value>
+                    </property>
+                </systemProperties>
+                <reuseForks>true</reuseForks>
+                <forkCount>${concurrency}</forkCount>
+                <!--
+                The following line is the one that's a must. Without it, with get jacoco complexity failures.
+                -->
+                <argLine>-Djava.awt.headless=true</argLine>
+            </configuration>
+        </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
# Description

Update the build to use the new plugin parent pom (2.17). This involved a few small tweaks to some of the `package.json` files, adding `mvnbuild` and `mvntest` scripts (executed by the maven profiles).

@jenkinsci/code-reviewers @reviewbybees 

