### PR TITLE
Prefer the displayName rather than the fullName for prettier display

### DIFF
--- a/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
@@ -45,7 +45,7 @@ export default class PipelineRowItem extends Component {
         const activitiesURL = `${baseUrl}/activity`;
 
         const pathInJob = fullName.split('/').slice(0, -1).join(' / ');
-        const formattedName = `${pathInJob? `${pathInJob} / ` : ''}${displayName ? displayName.split('/').join(' / ') : ''}`;
+        const formattedName = `${pathInJob ? `${pathInJob} / ` : ''}${displayName}`;
         const nameLink = (
             <Link to={activitiesURL}>
                 { showOrganization ?

--- a/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
@@ -33,6 +33,7 @@ export default class PipelineRowItem extends Component {
             numberOfFailingBranches,
             numberOfSuccessfulPullRequests,
             numberOfFailingPullRequests,
+            displayName,
             } = pipeline;
 
         const hasPullRequests = !simple && (
@@ -43,7 +44,7 @@ export default class PipelineRowItem extends Component {
         const pullRequestsURL = `${baseUrl}/pr`;
         const activitiesURL = `${baseUrl}/activity`;
 
-        const formattedName = fullName ? fullName.split('/').join(' / ') : '';
+        const formattedName = displayName ? displayName.split('/').join(' / ') : '';
         const nameLink = (
             <Link to={activitiesURL}>
                 { showOrganization ?

--- a/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRowItem.jsx
@@ -44,7 +44,8 @@ export default class PipelineRowItem extends Component {
         const pullRequestsURL = `${baseUrl}/pr`;
         const activitiesURL = `${baseUrl}/activity`;
 
-        const formattedName = displayName ? displayName.split('/').join(' / ') : '';
+        const pathInJob = fullName.split('/').slice(0, -1).join(' / ');
+        const formattedName = `${pathInJob? `${pathInJob} / ` : ''}${displayName ? displayName.split('/').join(' / ') : ''}`;
         const nameLink = (
             <Link to={activitiesURL}>
                 { showOrganization ?

--- a/blueocean-dashboard/src/test/js/pipeline-spec.js
+++ b/blueocean-dashboard/src/test/js/pipeline-spec.js
@@ -100,7 +100,7 @@ describe("pipeline component multiBranch rendering", () => {
       children = result.props.children;
 
     assert.equal(result.type, 'tr');
-    assert.equal(children[0].props.children.props.children, pipelineMulti.displayName.split('/').join(' / '));
+    assert.equal(children[0].props.children.props.children, "beersland / moreBeers");
     // simple element has no children
     assert.equal(children[2].type, 'td');
     assert.isObject(children[2].props);

--- a/blueocean-dashboard/src/test/js/pipeline-spec.js
+++ b/blueocean-dashboard/src/test/js/pipeline-spec.js
@@ -100,7 +100,7 @@ describe("pipeline component multiBranch rendering", () => {
       children = result.props.children;
 
     assert.equal(result.type, 'tr');
-    assert.equal(children[0].props.children.props.children, pipelineMulti.fullName.split('/').join(' / '));
+    assert.equal(children[0].props.children.props.children, pipelineMulti.displayName.split('/').join(' / '));
     // simple element has no children
     assert.equal(children[2].type, 'td');
     assert.isObject(children[2].props);
@@ -123,7 +123,7 @@ describe("pipeline component multiBranch rendering - success", () => {
       children = result.props.children;
 
     assert.equal(result.type, 'tr');
-    assert.equal(children[0].props.children.props.children, pipelineMultiSuccess.fullName);
+    assert.equal(children[0].props.children.props.children, pipelineMultiSuccess.displayName);
     // simple element has no children
     assert.equal(children[2].type, 'td');
     assert.isObject(children[2].props);


### PR DESCRIPTION
# Description

See [JENKINS-38042](https://issues.jenkins-ci.org/browse/JENKINS-38042).

There is no unit test as the displayed value of the `Link` in `PipelineRowItem` is not tested at this point. 

I "manually" validated the change: I created a job which I named `my-ugly-project` and set its __Display name__ to `My Beautiful project`. I also reacted another project without changing the __Display name__ to validate it didn't affect the current behavior. But as the `displayName` is filled with the `fullName` when it's not specified, then the front part of this plugin has no impact on this.

I couldn't run a complete build of the project as the current `master` branch has code inspections issues (lines being too longs) even before I coded my patch.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

