### PR TITLE
Don't run hpi:assemble-dependencies again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ def triggerATH() {
     // Assemble and archive the HPI plugins that the ATH should use.
     // The ATH build can copy this artifact and use it, saving the time it
     // would otherwise spend building and assembling again.
-    sh 'cd blueocean && mvn hpi:assemble-dependencies && tar -czvf target/ath-plugins.tar.gz target/plugins'
+    sh 'cd blueocean && tar -czvf target/ath-plugins.tar.gz target/plugins'
     archiveArtifacts artifacts: 'blueocean/target/ath-plugins.tar.gz'
 
     // Trigger the ATH, but don't wait for it.


### PR DESCRIPTION
It's not necessary to run hpi:assemble-dependencies to prepare the ATH plugin archive. It's already done in https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/pom.xml#L132 to make plugins available for building the development Docker image.

This should reduce build time by 1 minute.

@jenkinsci/code-reviewers @reviewbybees 

