### PR TITLE
JENKINS-38335# Slow search API response fix

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -1,10 +1,8 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import hudson.Extension;
-import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Result;
@@ -35,7 +33,6 @@ import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import jenkins.branch.MultiBranchProject;
-import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.actions.ChangeRequestAction;
 import org.kohsuke.stapler.json.JsonBody;
@@ -50,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_MULTI_BRANCH_PROJECT;
-import static io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl.isRunning;
 
 /**
  * @author Vivek Pandey
@@ -90,28 +86,6 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     @Override
     public Map<String, Boolean> getPermissions() {
         return AbstractPipelineImpl.getPermissions(mbp);
-    }
-
-    @Override
-    public int getNumberOfRunningPipelines() {
-        int count=0;
-        Collection<Job> jobs = mbp.getAllJobs();
-        for(Job j :jobs){
-            count += Iterables.size(j.getBuilds().filter(isRunning));
-        }
-        return count;
-    }
-
-    @Override
-    public int getNumberOfQueuedPipelines() {
-        int count=0;
-        Collection<Job> jobs = mbp.getAllJobs();
-        for(Job j :jobs) {
-            if (j instanceof BuildableItem) {
-                return Iterables.size(Jenkins.getInstance().getQueue().getItems((BuildableItem) j));
-            }
-        }
-        return count;
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -2,19 +2,16 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Action;
-import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.User;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
-import hudson.util.RunList;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
@@ -31,7 +28,6 @@ import io.jenkins.blueocean.rest.model.Container;
 import io.jenkins.blueocean.rest.model.Containers;
 import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
-import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.json.JsonBody;
@@ -213,20 +209,6 @@ public class AbstractPipelineImpl extends BluePipeline {
             }
             return null;
         }
-    }
-
-    @Override
-    public int getNumberOfRunningPipelines(){
-        RunList runningJobs =  job.getBuilds().filter(isRunning);
-        return Iterators.size(runningJobs.iterator());
-    }
-
-    @Override
-    public int getNumberOfQueuedPipelines() {
-        if(job instanceof BuildableItem) {
-            return Iterables.size(Jenkins.getInstance().getQueue().getItems((BuildableItem)job));
-        }
-        return 0;
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -109,16 +109,6 @@ public class PipelineFolderImpl extends BluePipelineFolder {
     }
 
     @Override
-    public int getNumberOfRunningPipelines() {
-        return 0; //Folder is not represented itself as main item on dashboard so its left as 0
-    }
-
-    @Override
-    public int getNumberOfQueuedPipelines() {
-        return 0; //Folder is not represented itself as main item on dashboard so its left as 0
-    }
-
-    @Override
     public Link getLink() {
         return OrganizationImpl.INSTANCE.getLink().rel("pipelines").rel(AbstractPipelineImpl.getRecursivePathFromFullName(this));
     }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -47,9 +47,6 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.ExecutionException;
 
-import static io.jenkins.blueocean.rest.model.BluePipeline.NUMBER_OF_QUEUED_PIPELINES;
-import static io.jenkins.blueocean.rest.model.BluePipeline.NUMBER_OF_RUNNING_PIPELINES;
-
 /**
  * @author Vivek Pandey
  */
@@ -431,10 +428,6 @@ public class PipelineApiTest extends BaseTest {
         Assert.assertEquals(queue.size(),2);
         Assert.assertEquals(((Map) queue.get(0)).get("expectedBuildNumber"), 4);
         Assert.assertEquals(((Map) queue.get(1)).get("expectedBuildNumber"), 3);
-        Map resp = request().get("/organizations/jenkins/pipelines/pipeline1/").build(Map.class);
-
-        Assert.assertEquals(2, resp.get(NUMBER_OF_RUNNING_PIPELINES));
-        Assert.assertEquals(2, resp.get(NUMBER_OF_QUEUED_PIPELINES));
     }
 
     @Test

--- a/blueocean-rest/README.md
+++ b/blueocean-rest/README.md
@@ -340,9 +340,7 @@ Gives authenticated user, gives HTTP 404 error if there is no authenticated user
           "startTime": "2016-04-11T17:44:28.344+1000",
           "state": "FINISHED",
           "type": "WorkflowRun",
-          "commitId": null,
-          "numberOfQueuedPipelines" : 1,
-          "numberOfRunningPipelines" : 2
+          "commitId": null
         }
     }
 
@@ -443,9 +441,7 @@ Use __organization__ query parameter to get flattened pipelines in that organiza
             "numberOfPipelines" : 0,
             "name" : "bo1",
             "numberOfFolders" : 0,
-            "numberOfSuccessfulPullRequests" : 0,
-            "numberOfQueuedPipelines" : 0,
-            "numberOfRunningPipelines" : 2,
+            "numberOfSuccessfulPullRequests" : 0,     
             "actions" : [],
             "branchNames" : []
          }
@@ -479,9 +475,7 @@ Use __organization__ query parameter to get flattened pipelines in that organiza
       "name" : "test2",
       "fullName" : "test2",      
       "organization" : "jenkins",
-      "weatherScore" : 100,
-      "numberOfQueuedPipelines" : 0,
-      "numberOfRunningPipelines" : 0
+      "weatherScore" : 100
     }
     
 ## Get nested Folder and Pipeline
@@ -536,9 +530,7 @@ Each branch in the repo with Jenkins file will appear as a branch in this pipeli
         "numberOfSuccessfulBranches": 0,
         "numberOfSuccessfulPullRequests": 0,
         "totalNumberOfBranches": 3,
-        "totalNumberOfPullRequests": 0,
-        "numberOfQueuedPipelines" : 0,
-        "numberOfRunningPipelines" : 2
+        "totalNumberOfPullRequests": 0
     }
 
     
@@ -578,9 +570,7 @@ activity.
             "organization": "jenkins",
             "weatherScore": 100,
             "pullRequest": null,
-            "totalNumberOfPullRequests": 0,
-            "numberOfQueuedPipelines" : 0,
-            "numberOfRunningPipelines" : 2
+            "totalNumberOfPullRequests": 0
         },
         {
             "displayName": "master",
@@ -617,9 +607,7 @@ activity.
             "organization": "jenkins",
             "weatherScore": 100,
             "pullRequest": null,
-            "totalNumberOfPullRequests": 0,
-            "numberOfQueuedPipelines" : 0,
-            "numberOfRunningPipelines" : 2            
+            "totalNumberOfPullRequests": 0           
         },
         {
             "displayName": "feature1",
@@ -649,9 +637,7 @@ activity.
             "organization": "jenkins",
             "weatherScore": 100,
             "pullRequest": null,
-            "totalNumberOfPullRequests": 0,
-            "numberOfQueuedPipelines" : 0,
-            "numberOfRunningPipelines" : 2            
+            "totalNumberOfPullRequests": 0           
         }
     ]
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
@@ -43,12 +43,6 @@ public abstract class BluePipeline extends Resource {
     /** stop pipeline run */
     public static final String STOP_PERMISSION = "stop";
 
-    /** Number of running jobs of this pipeline */
-    public static final String NUMBER_OF_RUNNING_PIPELINES = "numberOfRunningPipelines";
-
-    /** Number of queued jobs of this pipeline */
-    public static final String NUMBER_OF_QUEUED_PIPELINES = "numberOfQueuedPipelines";
-
     /**
      * @return name of the organization
      */
@@ -155,17 +149,4 @@ public abstract class BluePipeline extends Resource {
      */
     @Exported(name = PERMISSIONS)
     public abstract Map<String, Boolean> getPermissions();
-
-    /**
-     * @return Gives number of running jobs in this pipeline
-     */
-    @Exported(name = NUMBER_OF_RUNNING_PIPELINES)
-    public abstract int getNumberOfRunningPipelines();
-
-
-    /**
-     * @return Gives number of queued jobs in this pipeline
-     */
-    @Exported(name = NUMBER_OF_QUEUED_PIPELINES)
-    public abstract int getNumberOfQueuedPipelines();
 }


### PR DESCRIPTION
# Description

See [JENKINS-38335](https://issues.jenkins-ci.org/browse/JENKINS-38335).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

Running ATH locally fails. If @michaelneale can give it shot will be great otherwise will try it tomorrow and ask for help around.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

numberOfRunningPipelines is very expensive call, pretty much results in to
iteraring over all builds in the pipeline. With Search API, it gets worse as we
recursively iterate over each job/pipeline and determine if its running or not.
There is no esay way in Jenkins to compute this value optimally.

There is no UI code that needs this field and also numberOfQueuedPipelines field
is not used. As part of this fix, I am removing these fields from Pipeline API response.