### PR TITLE
[FIX JENKINS-38811] Fix IE adjunt loading

### DIFF
--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/incompatibleie.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/incompatibleie.jelly
@@ -25,7 +25,7 @@
       <!-- Jenkins Design Language -->
       <link rel="stylesheet" href="${resURL}/plugin/blueocean-web/assets/css/jenkins-design-language.css" type="text/css"/>
       <link rel="stylesheet" href="${rootURL}/${j.getAdjuncts('').rootURL}/io/jenkins/blueocean/blueocean.css" type="text/css"/>
-      <link rel="stylesheet" href="${rootURL}/${j.getAdjuncts('').rootURL}/org/jenkins/ui/jsmodules/blueocean_dashboard/extensions.css" type="text/css"/>
+      <link rel="stylesheet" href="${rootURL}/${j.getAdjuncts('').rootURL}/org/jenkins/ui/jsmodules/blueocean-dashboard/extensions.css" type="text/css"/>
     </head>
 
     <body>

--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -28,7 +28,7 @@
                 <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1"></meta>
                 <script src="${resURL}/plugin/blueocean-web/scripts/ie-detect.js"></script>
                 <script src="${resURL}/plugin/blueocean-web/scripts/html5shiv-printshiv.min.js"></script>
-                <st:adjunct includes="org.jenkins.ui.jsmodules.blueocean_web.iepolyfills"/>
+                <st:adjunct includes="org.jenkins.ui.jsmodules.blueocean-web.iepolyfills"/>
             </j:if>
             <st:adjunct includes="org.jenkinsci.plugins.ssegateway.sse.EventSource" />
             <j:set var="assetsPath" value="${resURL}/plugin/blueocean-web/assets" />


### PR DESCRIPTION
# Description

See [JENKINS-38811](https://issues.jenkins-ci.org/browse/JENKINS-38811).

This broke because of a change we made in js-builder a few weeks ago wrt how it generates the paths to bundle assets.

@jenkinsci/code-reviewers @reviewbybees 