### PR TITLE
fix tests that began failing in 38023 / 38013

### DIFF
--- a/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
+++ b/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
@@ -29,7 +29,7 @@ describe('DashboardCards', () => {
         testUtils.unbindAll();
     });
 
-    xit('renders without error for empty props', () => {
+    it('renders without error for empty props', () => {
         const wrapper = shallow(
             <DashboardCards />
         );

--- a/blueocean-personalization/src/test/js/data/favorites.json
+++ b/blueocean-personalization/src/test/js/data/favorites.json
@@ -30,6 +30,7 @@
             "actions": [],
             "displayName": "UX-301",
             "estimatedDurationInMillis": 73248,
+            "fullDisplayName": "blueocean/UX-301",
             "fullName": "blueocean/UX-301",
             "lastSuccessfulRun": null,
             "latestRun": {
@@ -116,6 +117,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "jenkinsfile-experiments/master",
             "fullName": "jenkinsfile-experiments/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/jenkinsfile-experiments/branches/master/runs/95/",
             "latestRun": {
@@ -207,6 +209,7 @@
             "actions": [],
             "displayName": "test-branch-1",
             "estimatedDurationInMillis": 105538,
+            "fullDisplayName": "jenkinsfile-experiments/test-branch-1",
             "fullName": "jenkinsfile-experiments/test-branch-1",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/jenkinsfile-experiments/branches/test-branch-1/runs/53/",
             "latestRun": {
@@ -298,6 +301,7 @@
             "actions": [],
             "displayName": "docker-test",
             "estimatedDurationInMillis": 390126,
+            "fullDisplayName": "jdl1/docker-test",
             "fullName": "jdl1/docker-test",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/jdl1/branches/docker-test/runs/3/",
             "latestRun": {
@@ -378,6 +382,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test1/master",
             "fullName": "test1/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test1/branches/master/runs/95/",
             "latestRun": {
@@ -469,6 +474,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test2/master",
             "fullName": "test2/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test2/branches/master/runs/95/",
             "latestRun": {
@@ -560,6 +566,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test3/master",
             "fullName": "test3/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test3/branches/master/runs/95/",
             "latestRun": {
@@ -651,6 +658,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test4/master",
             "fullName": "test4/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test4/branches/master/runs/95/",
             "latestRun": {
@@ -742,6 +750,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test5/master",
             "fullName": "test5/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test5/branches/master/runs/95/",
             "latestRun": {
@@ -833,6 +842,7 @@
             "actions": [],
             "displayName": "docker-test",
             "estimatedDurationInMillis": 433724,
+            "fullDisplayName": "jdl1/docker-test2",
             "fullName": "jdl1/docker-test2",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jankins/pipelines/jdl1/branches/docker-test/runs/4/",
             "latestRun": {
@@ -913,6 +923,7 @@
             "actions": [],
             "displayName": "master",
             "estimatedDurationInMillis": 105302,
+            "fullDisplayName": "test6/master",
             "fullName": "test6/master",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/test6/branches/master/runs/95/",
             "latestRun": {
@@ -1004,6 +1015,7 @@
             "actions": [],
             "displayName": "docker-test",
             "estimatedDurationInMillis": 390126,
+            "fullDisplayName": "jdl2/docker-test",
             "fullName": "jdl2/docker-test",
             "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/runs/3/",
             "latestRun": {


### PR DESCRIPTION
# Description
- These tests began failing in JENKINS-38023 but due to a gulp / mocha config issues, the failures were not reported in CI. 38013 exposed the failures but somehow were merged to master. This PR fixes the failures.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 