### PR TITLE
JENKINS-39206 - BlueOcean Display URL Plugin

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -61,6 +61,12 @@
             <version>0.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>blueocean-display-url</artifactId>
+            <version>1.2</version>
+        </dependency>
+
         <!-- Test deps -->
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
# Description

Bundles the Blue Ocean display URL plugin. When this plugin is installed it replaces all the classic URIs issued in emails, hipchat, slack, etc with Blue Ocean URIs.

See [JENKINS-39206](https://issues.jenkins-ci.org/browse/JENKINS-39206).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 
