### PR TITLE
JENKINS-39296# Fix to show step's status correctly

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -297,6 +297,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
     @Override
     public List<BluePipelineStep> getPipelineNodeSteps(Link parent) {
+        if(run.getExecution() == null){
+            return Collections.emptyList();
+        }
         PipelineStepVisitor visitor = new PipelineStepVisitor(run, null);
         ForkScanner.visitSimpleChunks(run.getExecution().getCurrentHeads(), visitor, new StageChunkFinder());
         List<BluePipelineStep> steps = new ArrayList<>();
@@ -308,6 +311,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
     @Override
     public BluePipelineStep getPipelineNodeStep(String id, Link parent) {
+        if(run.getExecution() == null){
+            return null;
+        }
         PipelineStepVisitor visitor = new PipelineStepVisitor(run, null);
         ForkScanner.visitSimpleChunks(run.getExecution().getCurrentHeads(), visitor, new StageChunkFinder());
         FlowNodeWrapper node = visitor.getStep(id);

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
@@ -8,7 +8,6 @@ import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.MemoryFlowChunk;
 import org.jenkinsci.plugins.workflow.graphanalysis.StandardChunkVisitor;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.TimingInfo;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
@@ -112,12 +111,8 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
             if(times == null){
                 times = new TimingInfo();
             }
-            GenericStatus status = StatusAndTiming.computeChunkStatus(run, before, atomNode, atomNode, after);
-            if (status == null) {
-                status = GenericStatus.NOT_EXECUTED;
-            }
 
-            FlowNodeWrapper node = new FlowNodeWrapper(atomNode, new NodeRunStatus(status), times);
+            FlowNodeWrapper node = new FlowNodeWrapper(atomNode, new NodeRunStatus(atomNode), times);
             steps.push(node);
             stepMap.put(node.getId(), node);
         }


### PR DESCRIPTION
# Description

See [JENKINS-39296](https://issues.jenkins-ci.org/browse/JENKINS-39296).

To manually test, create pipeline job to create unstable run with steps that are successful. Also create job with failing and successful steps, each sep should demonstrate correct status.

**Please note:**

* Underlying Pipeline library (and bismuth library) doesn't give a ways to determine ABORTED or UNSTABLE result at individual Step FlowNode level. So if a Run is aborted, the step that gets aborted is reported as simply error. There is not status to say if its unstable.


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

Triggered https://ci.blueocean.io/job/ATH-Jenkinsfile/job/master/227/

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

