### PR TITLE
JENKINS-36377 Adds method to FavouriteUtil to check if the user has a…

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -73,12 +73,8 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
 
-        Job job = mbp.getItem("master");
-        if(job == null) {
-            throw new ServiceException.BadRequestExpception("no master branch to favorite");
-        }
-
-        FavoriteUtil.favoriteJob(mbp.getFullName(), favoriteAction.isFavorite());
+        Job job = FavoriteUtil.resolveDefaultBranch(mbp);
+        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
 
         return new FavoriteImpl(new BranchImpl(job,getLink().rel("branches")), getLink().rel("favorite"));
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -73,11 +73,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
         Job job = FavoriteUtil.resolveDefaultBranch(mbp);
-        if (favoriteAction.isFavorite()) {
-            FavoriteUtil.setFavorite(job);
-        } else {
-            FavoriteUtil.unsetFavorite(job);
-        }
+        FavoriteUtil.toggle(favoriteAction, job);
         return new FavoriteImpl(new BranchImpl(job,getLink().rel("branches")), getLink().rel("favorite"));
     }
 
@@ -362,7 +358,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
         public BlueFavorite resolve(Item item, Reachable parent) {
             if(item instanceof MultiBranchProject){
                 MultiBranchProject project = (MultiBranchProject) item;
-                Job job = project.getItem("master");
+                Job job = FavoriteUtil.resolveDefaultBranch(project);
                 if(job != null){
                     Resource resource = BluePipelineFactory.resolve(job);
                     Link l = LinkResolver.resolveLink(project);

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -72,10 +72,12 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
         if(favoriteAction == null) {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
-
         Job job = FavoriteUtil.resolveDefaultBranch(mbp);
-        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
-
+        if (favoriteAction.isFavorite()) {
+            FavoriteUtil.setFavorite(job);
+        } else {
+            FavoriteUtil.unsetFavorite(job);
+        }
         return new FavoriteImpl(new BranchImpl(job,getLink().rel("branches")), getLink().rel("favorite"));
     }
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import hudson.Util;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
+import hudson.plugins.favorite.Favorites;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import hudson.plugins.git.util.BuildData;
 import hudson.scm.ChangeLogSet;
@@ -560,7 +561,7 @@ public class MultiBranchTest extends PipelineBaseTest {
         c = (String) branch.get("_class");
         Assert.assertEquals(BranchImpl.class.getName(), c);
 
-        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/p/favorite/", getHrefFromLinks((Map)l.get(0), "self"));
+        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/p/branches/master/favorite/", getHrefFromLinks((Map)l.get(0), "self"));
 
         String ref = getHrefFromLinks((Map)l.get(0), "self");
 
@@ -681,12 +682,7 @@ public class MultiBranchTest extends PipelineBaseTest {
         WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
         j.waitUntilNoActivity();
 
-        FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
-        if (fup == null) {
-            user.addProperty(new FavoriteUserProperty());
-            fup = user.getProperty(FavoriteUserProperty.class);
-        }
-        fup.toggleFavorite(mp.getFullName());
+        Favorites.toggleFavorite(user, p);
         user.save();
 
         String token = getJwtToken(j.jenkins,"alice", "alice");
@@ -706,7 +702,7 @@ public class MultiBranchTest extends PipelineBaseTest {
         Assert.assertEquals(BranchImpl.class.getName(), c);
 
         String href = getHrefFromLinks((Map)l.get(0), "self");
-        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/p/favorite/", href);
+        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/p/branches/master/favorite/", href);
 
 
 

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
-            <version>1.17-SNAPSHOT</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
-            <version>1.16</version>
+            <version>1.17-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -68,6 +68,11 @@
             <artifactId>junit</artifactId>
             <version>1.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>5.12</version>
         </dependency>
 
     </dependencies>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
-            <version>2.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -13,6 +13,7 @@ import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.User;
+import hudson.plugins.favorite.Favorites;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Navigable;
@@ -129,11 +130,7 @@ public class AbstractPipelineImpl extends BluePipeline {
         if(favoriteAction == null) {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
-        if (favoriteAction.isFavorite()) {
-            FavoriteUtil.setFavorite(job);
-        } else {
-            FavoriteUtil.unsetFavorite(job);
-        }
+        FavoriteUtil.toggle(favoriteAction, job);
         return FavoriteUtil.getFavorite(job, new Reachable() {
             @Override
             public Link getLink() {
@@ -267,12 +264,7 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     public boolean isFavorite() {
         User user = User.current();
-        if(user != null) {
-            FavoriteUserProperty prop = user.getProperty(FavoriteUserProperty.class);
-            return prop != null && prop.isJobFavorite(job.getFullName());
-        }
-
-        return false;
+        return user != null && Favorites.isFavorite(user, job);
     }
 
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -129,8 +129,11 @@ public class AbstractPipelineImpl extends BluePipeline {
         if(favoriteAction == null) {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
-
-        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
+        if (favoriteAction.isFavorite()) {
+            FavoriteUtil.setFavorite(job);
+        } else {
+            FavoriteUtil.unsetFavorite(job);
+        }
         return FavoriteUtil.getFavorite(job, new Reachable() {
             @Override
             public Link getLink() {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -130,7 +130,7 @@ public class AbstractPipelineImpl extends BluePipeline {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
 
-        FavoriteUtil.favoriteJob(job.getFullName(), favoriteAction.isFavorite());
+        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
         return FavoriteUtil.getFavorite(job, new Reachable() {
             @Override
             public Link getLink() {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -1,7 +1,7 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.model.Item;
-import hudson.plugins.favorite.user.FavoriteUserProperty;
+import hudson.plugins.favorite.Favorites;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
@@ -28,27 +28,20 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
     @Override
     public BlueFavorite get(String name) {
         name = FavoriteUtil.decodeFullName(name);
-        if(user.isFavorite(name)){
-            Item item = Jenkins.getInstance().getItemByFullName(name);
-            if(item != null){
-                return FavoriteUtil.getFavorite(item, this);
-            }
+        Item item = Jenkins.getInstance().getItemByFullName(name);
+        if(item != null && Favorites.isFavorite(user.user, item)){
+            return FavoriteUtil.getFavorite(item, this);
         }
         return null;
     }
 
     @Override
     public Iterator<BlueFavorite> iterator() {
-        FavoriteUserProperty prop = user.getFavoriteProperty();
         List<BlueFavorite> favorites = new ArrayList<>();
         Jenkins j = Jenkins.getInstance();
 
-        for(final String favorite: prop.getFavorites()){
-            Item i = j.getItemByFullName(favorite, Item.class);
-            if(i == null){
-                continue;
-            }
-            BlueFavorite blueFavorite = FavoriteUtil.getFavorite(i);
+        for(final Item favorite: Favorites.getFavorites(user.user)){
+            BlueFavorite blueFavorite = FavoriteUtil.getFavorite(favorite);
             if(blueFavorite != null){
                 favorites.add(blueFavorite);
             }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -99,19 +99,7 @@ public class PipelineFolderImpl extends BluePipelineFolder {
 
     @Override
     public BlueFavorite favorite(@JsonBody BlueFavoriteAction favoriteAction) {
-        if(favoriteAction == null) {
-            throw new ServiceException.BadRequestExpception("Must provide pipeline name");
-        }
-        if (!(folder instanceof AbstractFolder)) {
-            throw new ServiceException.BadRequestExpception("Not a folder");
-        }
-        Job job = FavoriteUtil.resolveDefaultBranch((AbstractFolder) folder);
-        if (favoriteAction.isFavorite()) {
-            FavoriteUtil.setFavorite(job);
-        } else {
-            FavoriteUtil.unsetFavorite(job);
-        }
-        return FavoriteUtil.getFavorite(folder.getFullName(), this);
+        throw new ServiceException.MethodNotAllowedException("Cannot favorite a folder");
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -1,9 +1,11 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Job;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
@@ -100,8 +102,11 @@ public class PipelineFolderImpl extends BluePipelineFolder {
         if(favoriteAction == null) {
             throw new ServiceException.BadRequestExpception("Must provide pipeline name");
         }
-
-        FavoriteUtil.favoriteJob(folder.getFullName(), favoriteAction.isFavorite());
+        if (!(folder instanceof AbstractFolder)) {
+            throw new ServiceException.BadRequestExpception("Not a folder");
+        }
+        Job job = FavoriteUtil.resolveDefaultBranch((AbstractFolder) folder);
+        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
         return FavoriteUtil.getFavorite(folder.getFullName(), this);
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -106,7 +106,11 @@ public class PipelineFolderImpl extends BluePipelineFolder {
             throw new ServiceException.BadRequestExpception("Not a folder");
         }
         Job job = FavoriteUtil.resolveDefaultBranch((AbstractFolder) folder);
-        FavoriteUtil.favoriteJob(job, favoriteAction.isFavorite());
+        if (favoriteAction.isFavorite()) {
+            FavoriteUtil.setFavorite(job);
+        } else {
+            FavoriteUtil.unsetFavorite(job);
+        }
         return FavoriteUtil.getFavorite(folder.getFullName(), this);
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -20,7 +20,7 @@ import java.util.Collections;
  * @author Vivek Pandey
  */
 public class UserImpl extends BlueUser {
-    private final User user;
+    protected final User user;
 
     private final Reachable parent;
     public UserImpl(User user, Reachable parent) {
@@ -58,16 +58,6 @@ public class UserImpl extends BlueUser {
 
         Mailer.UserProperty p = user.getProperty(Mailer.UserProperty.class);
         return p != null ? p.getAddress() : null;
-    }
-
-    protected boolean isFavorite(final String name) {
-        FavoriteUserProperty prop = user.getProperty(FavoriteUserProperty.class);
-        return prop != null && prop.isJobFavorite(name);
-    }
-
-
-    protected FavoriteUserProperty getFavoriteProperty(){
-        return user.getProperty(FavoriteUserProperty.class);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
@@ -1,16 +1,12 @@
 package io.jenkins.blueocean.service.embedded.util;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.TopLevelItem;
 import hudson.model.User;
-import hudson.plugins.favorite.FavoritePlugin;
 import hudson.plugins.favorite.Favorites;
 import hudson.plugins.favorite.Favorites.FavoriteException;
-import hudson.plugins.favorite.user.FavoriteUserProperty;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
@@ -22,10 +18,8 @@ import io.jenkins.blueocean.service.embedded.rest.BlueFavoriteResolver;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.Stapler;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
@@ -36,19 +30,19 @@ public class FavoriteUtil {
 
     private static final String DEFAULT_BRANCH = "master";
 
-    public static void setFavorite(Job job) {
-        try {
-            Favorites.addFavorite(getUser(), job);
-        } catch (FavoriteException e) {
-            throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
-        }
-    }
-
-    public static void unsetFavorite(Job job) {
-        try {
-            Favorites.addFavorite(getUser(), job);
-        } catch (FavoriteException e) {
-            throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
+    public static void toggle(BlueFavoriteAction action, Item item) {
+        if (action.isFavorite()) {
+            try {
+                Favorites.addFavorite(getUser(), item);
+            } catch (FavoriteException e) {
+                throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
+            }
+        } else {
+            try {
+                Favorites.removeFavorite(getUser(), item);
+            } catch (FavoriteException e) {
+                throw new ServiceException.UnexpectedErrorException("Something went wrong removing the favorite", e);
+            }
         }
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
@@ -35,26 +35,19 @@ public class FavoriteUtil {
 
     private static final String DEFAULT_BRANCH = "master";
 
-    public static void favoriteJob(Job job, boolean favorite) {
-        User user = User.current();
-        if(user == null) {
-            throw new ServiceException.ForbiddenException("Must be logged in to use set favorites");
+    public static void setFavorite(Job job) {
+        try {
+            Favorites.addFavorite(getUser(), job);
+        } catch (FavoriteException e) {
+            throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
         }
-        favoriteJob(job, user, favorite);
     }
 
-    public static void favoriteJob(Job job, User user, boolean favorite) {
-        boolean set = false;
-        FavoriteUserProperty fup = user.getProperty(FavoriteUserProperty.class);
-        if(fup != null) {
-            set = fup.isJobFavorite(job.getFullName());
-        }
-        if(favorite != set) {
-            try {
-                Favorites.toggleFavorite(user, job);
-            } catch (FavoriteException e) {
-                throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
-            }
+    public static void unsetFavorite(Job job) {
+        try {
+            Favorites.addFavorite(getUser(), job);
+        } catch (FavoriteException e) {
+            throw new ServiceException.UnexpectedErrorException("Something went wrong setting the favorite", e);
         }
     }
 
@@ -145,5 +138,13 @@ public class FavoriteUtil {
             throw new ServiceException.MethodNotAllowedException(DEFAULT_BRANCH + " is not a job");
         }
         return (Job) job;
+    }
+
+    private static User getUser() {
+        User user = User.current();
+        if(user == null) {
+            throw new ServiceException.ForbiddenException("Must be logged in to use set favorites");
+        }
+        return user;
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
@@ -16,6 +16,7 @@ import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
+import io.jenkins.blueocean.rest.model.BlueFavoriteAction;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.service.embedded.rest.BlueFavoriteResolver;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
@@ -56,21 +57,6 @@ public class FavoriteUtil {
             return URLDecoder.decode(URLDecoder.decode(name, "UTF-8"), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new ServiceException.UnexpectedErrorException("Something went wrong URL decoding fullName: "+name, e);
-        }
-    }
-
-    /**
-     * Checks if the user has a favorite entry for this job
-     * e.g. this is true when the user has favoriteted or unfavoriteted a job
-     * but not true for when a job has not been favorited by this user
-     * @param job path
-     * @return favorite
-     */
-    public static boolean hasFavourite(User user, Job job) {
-        try {
-            return Favorites.hasFavorite(user, job);
-        } catch (FavoriteException e) {
-            throw new ServiceException.UnexpectedErrorException(e.getMessage(), e);
         }
     }
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
@@ -222,34 +222,19 @@ public class ProfileApiTest extends BaseTest{
         Assert.assertEquals(0, l.size());
 
 
-        map = new RequestBuilder(baseUrl)
+        new RequestBuilder(baseUrl)
             .put("/organizations/jenkins/pipelines/folder1/favorite/")
             .jwtToken(token)
             .data(ImmutableMap.of("favorite", true))
+            .status(405)
             .build(Map.class);
 
-        validateFolder(folder1, (Map) map.get("item"));
-        l = new RequestBuilder(baseUrl)
-            .get("/users/"+user.getId()+"/favorites/")
-            .jwtToken(token)
-            .build(List.class);
-
-        Assert.assertEquals(1, l.size());
-        Map folder = (Map)((Map)l.get(0)).get("item");
-
-        validateFolder(folder1, folder);
-
-        href = getHrefFromLinks((Map)l.get(0),"self");
-
-        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/folder1/favorite/", href);
-
-        map = new RequestBuilder(baseUrl)
-            .put(href.substring("/blue/rest".length()))
+        new RequestBuilder(baseUrl)
+            .put("/organizations/jenkins/pipelines/folder1/favorite/")
             .jwtToken(token)
             .data(ImmutableMap.of("favorite", false))
+            .status(405)
             .build(Map.class);
-
-        validateFolder(folder1, (Map) map.get("item"));
 
         l = new RequestBuilder(baseUrl)
             .get("/users/"+user.getId()+"/favorites/")
@@ -257,14 +242,6 @@ public class ProfileApiTest extends BaseTest{
             .build(List.class);
 
         Assert.assertEquals(0, l.size());
-
-
-
-        new RequestBuilder(baseUrl)
-            .get("/users/"+user.getId()+"/favorites/")
-            .jwtToken(getJwtToken(j.jenkins,"bob","bob"))
-            .status(403)
-            .build(String.class);
 
     }
 


### PR DESCRIPTION
# Description

See [JENKINS-36377](https://issues.jenkins-ci.org/browse/JENKINS-36377).

Depends on https://github.com/jenkinsci/favorite-plugin/pull/4

To test: fire up Blue Ocean and favourite pipelines and freestyle projects from the dashboard. Favourite branches. Unfavourite things. Refresh the page lots.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

… favorite entry for a job. Moves API from strings to Job/Folder objects.