### PR TITLE
[FIX JENKINS-39587] refactor to not use context but use standard properties

### DIFF
--- a/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
+++ b/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
@@ -13,17 +13,6 @@ import * as pushEventUtil from './util/push-event-util';
 const { object, array, func, node, string } = PropTypes;
 
 class OrganizationPipelines extends Component {
-    // FIXME: get rid of context use
-    getChildContext() {
-        if (this._getOrganizationName()) {
-            return {
-                pipelines: this.props.organizationPipelines,
-            };
-        }
-        return {
-            pipelines: this.props.allPipelines,
-        };
-    }
 
     componentWillMount() {
         const config = this.context.config;
@@ -132,10 +121,17 @@ class OrganizationPipelines extends Component {
      components and get rid of the seperate connect in each subcomponents -> see RunDetailsPipeline
      */
     render() {
-        if (!this.props.allPipelines && !this.props.organizationPipelines) {
+        const { allPipelines, organizationPipelines } = this.props;
+        let pipelines = null;
+        if (!allPipelines && !organizationPipelines) {
             return null;
         }
-        return this.props.children;
+        if (allPipelines && allPipelines.$success) {
+            pipelines = allPipelines;
+        } else if (organizationPipelines && organizationPipelines.$success) {
+            pipelines = organizationPipelines;
+        }
+        return React.cloneElement(this.props.children, { pipelines, ...this.props });
     }
 }
 
@@ -160,10 +156,6 @@ OrganizationPipelines.propTypes = {
     location: object, // From react-router
     allPipelines: array,
     organizationPipelines: array,
-};
-
-OrganizationPipelines.childContextTypes = {
-    pipelines: array,
 };
 
 const selectors = createSelector([allPipelinesSelector, organizationPipelinesSelector],

--- a/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
+++ b/blueocean-dashboard/src/main/js/OrganizationPipelines.jsx
@@ -131,7 +131,7 @@ class OrganizationPipelines extends Component {
         } else if (organizationPipelines && organizationPipelines.$success) {
             pipelines = organizationPipelines;
         }
-        return React.cloneElement(this.props.children, { pipelines, ...this.props });
+        return React.cloneElement(this.props.children, { pipelines });
     }
 }
 

--- a/blueocean-dashboard/src/main/js/components/Branches.jsx
+++ b/blueocean-dashboard/src/main/js/components/Branches.jsx
@@ -16,26 +16,21 @@ export default class Branches extends Component {
         this.state = { isVisible: false };
     }
     render() {
-        const { data } = this.props;
+        const { data, pipeline } = this.props;
         // early out
-        if (!data || !this.context.pipeline) {
+        if (!data || !pipeline) {
             return null;
         }
         const {
-            context: {
-                router,
-                location,
-                pipeline: {
-                    fullName,
-                    organization,
-                    },
-                },
-            } = this;
+            router,
+            location,
+        } = this.context;
         const {
             latestRun: { id, result, startTime, endTime, changeSet, state, commitId, estimatedDurationInMillis },
             weatherScore,
             name: branchName,
         } = data;
+        const  { fullName, organization } = pipeline;
 
         const cleanBranchName = decodeURIComponent(branchName);
         const url = buildRunDetailsUrl(organization, fullName, cleanBranchName, id, 'pipeline');

--- a/blueocean-dashboard/src/main/js/components/Branches.jsx
+++ b/blueocean-dashboard/src/main/js/components/Branches.jsx
@@ -30,7 +30,7 @@ export default class Branches extends Component {
             weatherScore,
             name: branchName,
         } = data;
-        const  { fullName, organization } = pipeline;
+        const { fullName, organization } = pipeline;
 
         const cleanBranchName = decodeURIComponent(branchName);
         const url = buildRunDetailsUrl(organization, fullName, cleanBranchName, id, 'pipeline');
@@ -80,11 +80,11 @@ export default class Branches extends Component {
 
 Branches.propTypes = {
     data: object.isRequired,
+    pipeline: object,
 };
 
 Branches.contextTypes = {
     store: object,
-    pipeline: object,
     router: object.isRequired, // From react-router
     location: object,
 };

--- a/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
@@ -51,7 +51,7 @@ EmptyState.propTypes = {
 
 export class MultiBranch extends Component {
     componentWillMount() {
-        if (this.context.pipeline && this.context.params && !pipelineBranchesUnsupported(this.context.pipeline)) {
+        if (this.props.pipeline && this.context.params && !pipelineBranchesUnsupported(this.props.pipeline)) {
             this.props.fetchBranches({
                 organizationName: this.context.params.organization,
                 pipelineName: this.context.params.pipeline,
@@ -65,9 +65,9 @@ export class MultiBranch extends Component {
 
 
     render() {
-        const { branches } = this.props;
+        const { branches, pipeline } = this.props;
 
-        if (!branches || (!branches.$pending && pipelineBranchesUnsupported(this.context.pipeline))) {
+        if (!branches || (!branches.$pending && pipelineBranchesUnsupported(pipeline))) {
             return (<NotSupported />);
         }
 
@@ -99,6 +99,7 @@ export class MultiBranch extends Component {
                         {branches.length > 0 && branches.map((run, index) => {
                             const result = new RunsRecord(run);
                             return (<Branches
+                              pipeline={pipeline}
                               key={index}
                               data={result}
                             />);
@@ -120,7 +121,6 @@ export class MultiBranch extends Component {
 MultiBranch.contextTypes = {
     config: object.isRequired,
     params: object.isRequired,
-    pipeline: object,
 };
 
 MultiBranch.propTypes = {
@@ -128,6 +128,7 @@ MultiBranch.propTypes = {
     fetchBranches: func,
     clearBranchData: func,
     children: any,
+    pipeline: object,
 };
 
 const selectors = createSelector([branchSelector], (branches) => ({ branches }));

--- a/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
@@ -44,11 +44,6 @@ const classicConfigLink = (pipeline) => {
 
 
 export class PipelinePage extends Component {
-    getChildContext() {
-        return {
-            pipeline: this.props.pipeline,
-        };
-    }
 
     componentWillMount() {
         if (this.props.params) {
@@ -93,7 +88,7 @@ export class PipelinePage extends Component {
                         <Extensions.Renderer
                           extensionPoint="jenkins.pipeline.detail.header.action"
                           store={this.context.store}
-                          pipeline={this.props.pipeline}
+                          pipeline={pipeline}
                         />
                         {classicConfigLink(pipeline)}
                     </Title>
@@ -112,7 +107,6 @@ export class PipelinePage extends Component {
     }
 }
 
-
 PipelinePage.propTypes = {
     children: PropTypes.any,
     fetchPipeline: PropTypes.func.isRequired,
@@ -126,10 +120,6 @@ PipelinePage.contextTypes = {
     config: PropTypes.object.isRequired,
     location: PropTypes.object,
     store: PropTypes.object,
-};
-
-PipelinePage.childContextTypes = {
-    pipeline: PropTypes.any,
 };
 
 const selectors = createSelector([pipelineSelector],

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -16,7 +16,7 @@ export class Pipelines extends Component {
     }
 
     render() {
-        const { pipelines } = this.context;
+        const { pipelines } = this.props;
         const { organization } = this.context.params;
 
         const orgLink = organization ?
@@ -88,13 +88,14 @@ const { array, func, object } = PropTypes;
 Pipelines.contextTypes = {
     config: object,
     params: object,
-    pipelines: array,
     store: object,
     router: object,
 };
 
 Pipelines.propTypes = {
     setTitle: func,
+    pipelines: array,
+ 
 };
 
 export default documentTitle(Pipelines);

--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -95,7 +95,6 @@ Pipelines.contextTypes = {
 Pipelines.propTypes = {
     setTitle: func,
     pipelines: array,
- 
 };
 
 export default documentTitle(Pipelines);

--- a/blueocean-dashboard/src/main/js/components/PullRequest.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequest.jsx
@@ -9,7 +9,7 @@ const { object } = PropTypes;
 
 export default class PullRequest extends Component {
     render() {
-        const { pr, pipeline: contextPipeline} = this.props;
+        const { pr, pipeline: contextPipeline } = this.props;
         if (!pr || !pr.pullRequest || !pr.latestRun || !contextPipeline) {
             return null;
         }
@@ -70,10 +70,10 @@ export default class PullRequest extends Component {
 
 PullRequest.propTypes = {
     pr: object,
+    pipeline: object,
 };
 
 PullRequest.contextTypes = {
-    pipeline: object,
     router: object.isRequired, // From react-router
     location: object,
 };

--- a/blueocean-dashboard/src/main/js/components/PullRequest.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequest.jsx
@@ -9,8 +9,8 @@ const { object } = PropTypes;
 
 export default class PullRequest extends Component {
     render() {
-        const { pr } = this.props;
-        if (!pr || !pr.pullRequest || !pr.latestRun || !this.context.pipeline) {
+        const { pr, pipeline: contextPipeline} = this.props;
+        if (!pr || !pr.pullRequest || !pr.latestRun || !contextPipeline) {
             return null;
         }
         const {
@@ -31,15 +31,10 @@ export default class PullRequest extends Component {
         } = pr;
         const result = resultString === 'UNKNOWN' ? state : resultString;
         const {
-            context: {
-                router,
-                location,
-                pipeline: {
-                    fullName,
-                    organization,
-            },
-                },
-        } = this;
+            router,
+            location,
+        } = this.context;
+        const { fullName, organization } = contextPipeline;
         const open = () => {
             location.pathname = buildRunDetailsUrl(organization, fullName, decodeURIComponent(pipeline), id, 'pipeline');
             router.push(location);

--- a/blueocean-dashboard/src/main/js/components/PullRequests.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequests.jsx
@@ -48,7 +48,7 @@ EmptyState.propTypes = {
 
 export class PullRequests extends Component {
     componentWillMount() {
-        if (this.context.pipeline && this.context.params && !pipelineBranchesUnsupported(this.context.pipeline)) {
+        if (this.props.pipeline && this.context.params && !pipelineBranchesUnsupported(this.props.pipeline)) {
             this.props.fetchPullRequests({
                 organizationName: this.context.params.organization,
                 pipelineName: this.context.params.pipeline,
@@ -61,9 +61,9 @@ export class PullRequests extends Component {
     }
 
     render() {
-        const { pullRequests } = this.props;
+        const { pullRequests, pipeline } = this.props;
 
-        if (!pullRequests || (!pullRequests.$pending && pipelineBranchesUnsupported(this.context.pipeline))) {
+        if (!pullRequests || (!pullRequests.$pending && pipelineBranchesUnsupported(pipeline))) {
             return (<NotSupported />);
         }
 
@@ -97,6 +97,7 @@ export class PullRequests extends Component {
                         {pullRequests.map((run, index) => {
                             const result = new RunsRecord(run);
                             return (<PullRequest
+                              pipeline={pipeline}
                               key={index}
                               pr={result}
                             />);
@@ -116,13 +117,13 @@ export class PullRequests extends Component {
 PullRequests.contextTypes = {
     config: object.isRequired,
     params: object.isRequired,
-    pipeline: object,
 };
 
 PullRequests.propTypes = {
     pullRequests: array,
     clearPRData: func,
     fetchPullRequests: func,
+    pipeline: object,
 };
 
 const selectors = createSelector([pullRequestSelector], (pullRequests) => ({ pullRequests }));

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -115,15 +115,15 @@ class RunDetails extends Component {
             return null;
         }
 
-        if (this.props.run.$pending || this.context.pipeline.$pending) {
+        const { router, location, params } = this.context;
+        const { pipeline, run,  setTitle } = this.props;
+
+        if (run.$pending || pipeline.$pending) {
             return <PageLoading />;
         }
 
-        const { router, location, params, pipeline = {} } = this.context;
-
         const baseUrl = buildRunDetailsUrl(params.organization, params.pipeline, params.branch, params.runId);
 
-        const { run, setTitle } = this.props;
         const currentRun = new RunRecord(run);
         const status = currentRun.getComputedResult() || '';
 
@@ -207,7 +207,6 @@ RunDetails.contextTypes = {
     params: object,
     router: object.isRequired, // From react-router
     location: object.isRequired, // From react-router
-    pipeline: object,
 };
 
 RunDetails.propTypes = {

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -116,7 +116,7 @@ class RunDetails extends Component {
         }
 
         const { router, location, params } = this.context;
-        const { pipeline, run,  setTitle } = this.props;
+        const { pipeline, run, setTitle } = this.props;
 
         if (run.$pending || pipeline.$pending) {
             return <PageLoading />;

--- a/blueocean-dashboard/src/main/js/components/Runs.jsx
+++ b/blueocean-dashboard/src/main/js/components/Runs.jsx
@@ -24,18 +24,13 @@ export default class Runs extends Component {
     }
     render() {
         // early out
-        if (!this.props.result || !this.context.pipeline) {
+        if (!this.props.result || !this.props.pipeline) {
             return null;
         }
         const {
             context: {
                 router,
                 location,
-                pipeline: {
-                    _class: pipelineClass,
-                    fullName,
-                    organization,
-                },
             },
             props: {
                 result: {
@@ -48,6 +43,11 @@ export default class Runs extends Component {
                     startTime,
                     endTime,
                     commitId,
+                },
+                pipeline: {
+                    _class: pipelineClass,
+                    fullName,
+                    organization,
                 },
                 changeset,
             },
@@ -97,14 +97,13 @@ export default class Runs extends Component {
 }
 
 Runs.propTypes = {
-    run: PropTypes.object,
-    pipeline: PropTypes.object,
+    run: object,
+    pipeline: object,
     result: any.isRequired, // FIXME: create a shape
     data: string,
     changeset: object.isRequired,
 };
 Runs.contextTypes = {
-    pipeline: object,
     router: object.isRequired, // From react-router
     location: object,
 };

--- a/blueocean-dashboard/src/test/js/branches-spec.js
+++ b/blueocean-dashboard/src/test/js/branches-spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {createRenderer} from 'react-addons-test-utils';
 import { assert} from 'chai';
 import sd from 'skin-deep';
-import Immutable from 'immutable';
 import { latestRuns as data } from './data/runs/latestRuns';
 import { RunsRecord } from '../../main/js/components/records.jsx';
 
@@ -15,9 +14,8 @@ describe("Branches should render", () => {
 
   beforeEach(() => {
     const branch = new RunsRecord(data[0]);
-    tree = sd.shallowRender(<Branches data={branch} />, {
+    tree = sd.shallowRender(<Branches data={branch} pipeline={{}} />, {
         router: {},
-        pipeline: {},
         location: {},
     });
   });

--- a/blueocean-dashboard/src/test/js/pipelines-spec.js
+++ b/blueocean-dashboard/src/test/js/pipelines-spec.js
@@ -24,13 +24,12 @@ describe('Pipelines', () => {
 
         beforeEach(() => {
             context = {
-                pipelines,
                 params,
                 config,
             };
 
             wrapper = shallow(
-                <Pipelines setTitle={()=>{}}/>,
+                <Pipelines pipelines={pipelines} setTitle={()=>{}}/>,
                 {
                     context,
                 }
@@ -51,11 +50,10 @@ describe('Pipelines', () => {
             const context = {
                 config,
                 params,
-                pipelines: pipelinesDupName,
             };
 
             const wrapper = mount(
-                <Pipelines setTitle={()=>{}}/>,
+                <Pipelines pipelines={pipelinesDupName} setTitle={()=>{}}/>,
                 { context },
             );
 

--- a/blueocean-dashboard/src/test/js/pullRequest-spec.js
+++ b/blueocean-dashboard/src/test/js/pullRequest-spec.js
@@ -13,9 +13,8 @@ describe('PullRequest should render', () => {
     let tree = null;
     beforeEach(() => {
         const immData = new RunsRecord(pr[0]);
-        tree = sd.shallowRender(<PullRequest pr={immData} />,{
+        tree = sd.shallowRender(<PullRequest pr={immData} pipeline={{}} />,{
             router: {},
-            pipeline: {},
             location: {},
         });
     });
@@ -44,15 +43,14 @@ describe('PullRequest should not render', () => {
 describe('PullRequest', () => {
     it('opens correctly', (done) => {
         const immData = new RunsRecord(pr[0]);
-        const tree = sd.shallowRender(<PullRequest pr={immData} />, {
+        const tree = sd.shallowRender(<PullRequest pr={immData} pipeline={{
+            fullName: 'asdf/blah',
+            organization: 'jenkins',
+            }} />, {
                 router: {push: function(url) {
                     assert(url.pathname == '/organizations/jenkins/asdf%2Fblah/detail/PR-6/1/pipeline', "Incorrect URL for pull request");
                     done();
                 }
-            },
-            pipeline: {
-                fullName: 'asdf/blah',
-                organization: 'jenkins',
             },
             location: {},
         });


### PR DESCRIPTION
# Description

In some circumstances, that are not reproducible, the listing of pipelines has shown a blank list.
I do not why I had this circumstances, but the usage of context had been wrong anyhow in this place.

https://issues.jenkins-ci.org/browse/JENKINS-39587

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

