### PR TITLE
Use global style colors for try ocean button

### DIFF
--- a/blueocean-web/src/main/less/try.less
+++ b/blueocean-web/src/main/less/try.less
@@ -7,7 +7,6 @@
   margin-right: -5em;
   height: 30px !important;
   top: 5px;
-  background-color: @blueocean_blue;
   color: white;
   border: 1px solid;
   border-color: #4a90e2;
@@ -17,5 +16,4 @@
 
 .try-blueocean.header-callout:hover {
   cursor: pointer;
-  background-color: darken(@blueocean_blue, 10%);
 }


### PR DESCRIPTION
When custom Jenkins styling is used, like [jenkins-contrib-themes][1], 
the "Try" button breaks the style and looks [alien][2]. This patch fixes 
[this][3] by removing blue background, allowing to reuse global one.

[1]: https://jenkins-contrib-themes.github.io/jenkins-material-theme
[2]: http://i.imgur.com/R8B6sKS.png
[3]: http://i.imgur.com/hwxJwBj.png