### PR TITLE
Generate URL to user avatar on User resource

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -3,6 +3,7 @@ package io.jenkins.blueocean.service.embedded.rest;
 import hudson.model.User;
 import hudson.plugins.favorite.user.FavoriteUserProperty;
 import hudson.tasks.Mailer;
+import hudson.tasks.UserAvatarResolver;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.ApiHead;
 import io.jenkins.blueocean.rest.Reachable;
@@ -10,6 +11,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueFavoriteContainer;
 import io.jenkins.blueocean.rest.model.BlueUser;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.Stapler;
 
 import java.util.Collections;
 
@@ -58,6 +60,11 @@ public class UserImpl extends BlueUser {
 
         Mailer.UserProperty p = user.getProperty(Mailer.UserProperty.class);
         return p != null ? p.getAddress() : null;
+    }
+
+    @Override
+    public String getAvatar() {
+        return UserAvatarResolver.resolveOrNull(user, "48x48");
     }
 
     @Override

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
@@ -6,11 +6,13 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Project;
 import hudson.model.User;
 import hudson.tasks.Mailer;
+import hudson.tasks.UserAvatarResolver;
 import jenkins.model.Jenkins;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +29,7 @@ public class ProfileApiTest extends BaseTest{
         Map response = get("/users/"+system.getId());
         Assert.assertEquals(system.getId(), response.get("id"));
         Assert.assertEquals(system.getFullName(), response.get("fullName"));
+        Assert.assertEquals("http://avatar.example/i/img.png", response.get("avatar"));
     }
 
     //XXX: There is no method on User API to respond to POST or PUT or PATH. Since there are other tests that
@@ -347,4 +350,11 @@ public class ProfileApiTest extends BaseTest{
     }
 
 
+    @TestExtension
+    public static class TestUserAvatarResolver extends UserAvatarResolver {
+        @Override
+        public String findAvatarFor(User u, int width, int height) {
+            return "http://avatar.example/i/img.png";
+        }
+    }
 }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.rest.model;
 
+import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 
@@ -36,6 +37,9 @@ public abstract class BlueUser extends Resource {
     @Exported(name = EMAIL)
     // restricted to authorized users only
     public abstract String getEmail();
+
+    @Exported
+    public abstract String getAvatar();
 
     public abstract BlueFavoriteContainer getFavorites();
 }


### PR DESCRIPTION
# Description

See [JENKINS-39764](https://issues.jenkins-ci.org/browse/JENKINS-39764).

To test install the gravatar plugin and have a gravatar registered for your Jenkins email address. Hit the rest resource for your user and you should see an avatar field in the response.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 
