### PR TITLE
bug / smart fetch fault handler

### DIFF
--- a/blueocean-dashboard/src/main/js/util/smart-fetch.js
+++ b/blueocean-dashboard/src/main/js/util/smart-fetch.js
@@ -140,25 +140,27 @@ class Pager {
             Fetch.fetchJSON(url) // Fetch data
             .then(data => augmenter.augmentCapabilities(data))
             .then(successAndFreeze)) // add success field & freeze graph
-            .then((data) => {
-                debugLog(' -- success: ', url, data);
-                // fetched an extra to test if more
-                const hasMore = data.length > limit;
-                const outData = assignObj(concatenator(this, existingData, data));
-                outData.$success = true;
-                outData.$pager = Object.assign(this, {
-                    current: first,
-                    hasMore,
-                    currentData: outData,
-                    startIndex: existingData.length > 0 ? this.startIndex : first,
-                });
-                Object.freeze(outData); // children are already frozen, only shallow freeze here
-                onData(outData);
-            })
-            .catch(err => {
-                debugLog(' -- error: ', url, err);
-                onData(assignObj(concatenator(this, existingData), { $failed: err }));
-            });
+            .then(
+                (data) => {
+                    debugLog(' -- success: ', url, data);
+                    // fetched an extra to test if more
+                    const hasMore = data.length > limit;
+                    const outData = assignObj(concatenator(this, existingData, data));
+                    outData.$success = true;
+                    outData.$pager = Object.assign(this, {
+                        current: first,
+                        hasMore,
+                        currentData: outData,
+                        startIndex: existingData.length > 0 ? this.startIndex : first,
+                    });
+                    Object.freeze(outData); // children are already frozen, only shallow freeze here
+                    onData(outData);
+                },
+                err => {
+                    debugLog(' -- error: ', url, err);
+                    onData(assignObj(concatenator(this, existingData), { $failed: err }));
+                }
+            );
     }
 }
 


### PR DESCRIPTION
# Description
- While working on an unrelated bug, I noticed that React errors were being silently swallowed on some screens. On the Activity tab, if an error occurred during render after data fetch, the screen would break with no error being printed in console. I tracked this down to the use of `catch()` in the `smart-fetch` library. I switched it to use a fault handler instead and now errors display as expected.
- Relevant discussion: https://github.com/facebook/react/issues/4199

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

…t React errors aren't swallowed