### PR TITLE
Fix border color for try blue ocean button

### DIFF
--- a/blueocean-web/src/main/less/try.less
+++ b/blueocean-web/src/main/less/try.less
@@ -9,7 +9,6 @@
   top: 5px;
   color: white;
   border: 1px solid;
-  border-color: #4a90e2;
   border-radius: 3px;
   text-decoration: none;
 }


### PR DESCRIPTION
In the #598 PR I did a big mistake and forgot to fix border color of the button as well while I did everything right locally as screenshot shows. I just notices that issue after plugin update, when it overrided mine patched one. Sorry for that! ):