### PR TITLE
JENKINS-39965 Add extension point for top of runs changes tab

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import Extensions from '@jenkins-cd/js-extensions';
 import { CommitHash, EmptyStateView, ReadableDate, Table } from '@jenkins-cd/design-language';
 import Markdown from 'react-remarkable';
 
@@ -40,24 +41,32 @@ export default class RunDetailsChanges extends Component {
         ];
 
         return (
-            <Table headers={headers} className="changeset-table fixed">
-                { changeSet.map(commit => (
-                    <tr key={commit.commitId}>
-                        <td><CommitLink {...commit} /></td>
-                        <td>{commit.author.fullName}</td>
-                        <td className="multipleLines">{commit.msg}</td>
-                        <td>
-                            <ReadableDate
-                              date={commit.timestamp}
-                              liveUpdate
-                              locale={locale}
-                              shortFormat={t('common.date.readable.short', { defaultValue: 'MMM DD h:mma Z' })}
-                              longFormat={t('common.date.readable.long', { defaultValue: 'MMM DD YYYY h:mma Z' })}
-                            />
-                        </td>
-                    </tr>
-                ))}
-            </Table>
+            <div>
+                <Extensions.Renderer
+                  extensionPoint="jenkins.pipeline.run.changes.top"
+                  result={result}
+                  store={this.context.store}
+                  {...t}
+                />
+                <Table headers={headers} className="changeset-table fixed">
+                    { changeSet.map(commit => (
+                        <tr key={commit.commitId}>
+                            <td><CommitLink {...commit} /></td>
+                            <td>{commit.author.fullName}</td>
+                            <td className="multipleLines">{commit.msg}</td>
+                            <td>
+                                <ReadableDate
+                                  date={commit.timestamp}
+                                  liveUpdate
+                                  locale={locale}
+                                  shortFormat={t('common.date.readable.short', { defaultValue: 'MMM DD h:mma Z' })}
+                                  longFormat={t('common.date.readable.long', { defaultValue: 'MMM DD YYYY h:mma Z' })}
+                                />
+                            </td>
+                        </tr>
+                    ))}
+                </Table>
+            </div>
         );
     }
 }

--- a/blueocean-dashboard/src/main/js/components/records.jsx
+++ b/blueocean-dashboard/src/main/js/components/records.jsx
@@ -65,6 +65,7 @@ export class RunRecord extends Record({
     state: null,
     type: null,
     commitId: null,
+    actions: null,
 }) {
     isQueued() {
         return this.state === 'QUEUED';


### PR DESCRIPTION
# Description

Add an extension point at the top of the runs changes tab called jenkins.pipeline.run.changes.top.

PM by day 🎩 , plugin developer by night 🌔 

https://github.com/i386/blueocean-jira-plugin

See [JENKINS-39965](https://issues.jenkins-ci.org/browse/JENKINS-39965).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 