### PR TITLE
[JENKINS-39981] Show activities properly when no activities exist

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -62,7 +62,7 @@ export class Activity extends Component {
         // the Branches/PRs tab.
         const showRunButton = !isMultiBranchPipeline;
 
-        if (!this.pager.pending && ( !runs || !runs.length)) {
+        if (!this.pager.pending && (!runs || !runs.length)) {
             return (<EmptyState repoName={this.context.params.pipeline} showRunButton={showRunButton} pipeline={pipeline} t={t} />);
         }
         

--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -50,7 +50,7 @@ export class Activity extends Component {
     render() {
         const { pipeline, t, locale } = this.props;
         const runs = this.pager.data;
-        if (!pipeline && this.pager.pending) {
+        if (!pipeline || this.pager.pending) {
             return null;
         }
 

--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -50,10 +50,11 @@ export class Activity extends Component {
     render() {
         const { pipeline, t, locale } = this.props;
         const runs = this.pager.data;
-        if (!runs || !pipeline) {
+        if (!pipeline && this.pager.pending) {
             return null;
         }
-        
+
+       
         const isMultiBranchPipeline = capable(pipeline, MULTIBRANCH_PIPELINE);
 
         // Only show the Run button for non multi-branch pipelines.
@@ -61,14 +62,14 @@ export class Activity extends Component {
         // the Branches/PRs tab.
         const showRunButton = !isMultiBranchPipeline;
 
+        if (!this.pager.pending && ( !runs || !runs.length)) {
+            return (<EmptyState repoName={this.context.params.pipeline} showRunButton={showRunButton} pipeline={pipeline} t={t} />);
+        }
+        
         const onNavigation = (url) => {
             this.context.location.pathname = url;
             this.context.router.push(this.context.location);
         };
-
-        if (!this.pager.pending && !runs.length) {
-            return (<EmptyState repoName={this.context.params.pipeline} showRunButton={showRunButton} pipeline={pipeline} t={t} />);
-        }
 
         const latestRun = runs[0];
         const head = 'pipelinedetail.activity.header';

--- a/blueocean-dashboard/src/test/js/activity-spec.js
+++ b/blueocean-dashboard/src/test/js/activity-spec.js
@@ -149,7 +149,8 @@ const contextNoData = {
       activityService: {
         activityPager() {
           return {
-            data: undefined
+            data: undefined,
+            pending: true,
           }
         }
       }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
@@ -69,7 +69,7 @@ public class MultiBranchPipelineQueueContainer extends BlueQueueContainer {
         List<BluePipeline> branches = Lists.newArrayList(multiBranchPipeline.getBranches().list());
         sortBranchesByLatestRun(branches);
 
-        int l = limit/branches.size() > 0 ? limit/branches.size() : 1;
+        int l = branches.size() > 0 && limit/branches.size() > 0 ? limit/branches.size() : 1;
 
         int s=0;
         if(start > 0) {

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -909,4 +909,18 @@ public class MultiBranchTest extends PipelineBaseTest {
         Assert.assertEquals("io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl", ((Map) l.get(2)).get("_class"));
     }
 
+    @Test
+    public void getPipelineJobActivitiesNoBranches() throws Exception {
+        WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo1.toString(), "", "*", "", false),
+            new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+
+        List l = request().get("/organizations/jenkins/pipelines/p/activities").build(List.class);
+
+        Assert.assertEquals(0, l.size());
+
+        List branches = request().get("/organizations/jenkins/pipelines/p/branches").build(List.class);
+        Assert.assertEquals(0, branches.size());
+
+    }
 }


### PR DESCRIPTION
# Description

Root cause with a divide by zero error in backend. 

See [JENKINS-39981](https://issues.jenkins-ci.org/browse/JENKINS-39981

ATH PR: https://github.com/jenkinsci/blueocean-acceptance-test/pull/68

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@jenkinsci/code-reviewers @reviewbybees 

