### PR TITLE
[JENKINS-39804] Script to build the official BlueOcean image

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,0 +1,11 @@
+# This image is based off the latest Jenkins LTS
+FROM jenkins:latest
+
+USER root
+
+COPY blueocean/target/plugins /usr/share/jenkins/ref/plugins/
+
+RUN for f in /usr/share/jenkins/ref/plugins/*.hpi; do mv "$f" "${f%%hpi}jpi"; done
+RUN install-plugins.sh antisamy-markup-formatter matrix-auth pipeline-model-definition
+
+USER jenkins

--- a/docker/official/build.sh
+++ b/docker/official/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+set -x
+
+HERE=$(dirname $0)
+cd $HERE
+
+# There's no way to get tags ordered by date from GitHub API (in a single query), fall back to using the Git repository
+BLUEOCEAN_VERSION=$(git tag --sort=-taggerdate | egrep '^blueocean-parent' | egrep -o '[0-9]+(\.[0-9]+)+.*' | head -1)
+
+# Check if the image already exists
+if docker pull jenkinsci/blueocean:$BLUEOCEAN_VERSION; then
+  echo "Image jenkinsci/blueocean:$BLUEOCEAN_VERSION already exists in Docker Hub"
+  exit 0
+fi
+
+# ensure that we have the latest Jenkins LTS image available
+docker pull jenkins:latest
+
+# Fetch BlueOcean plugins using Maven
+#
+# Note: we don't use "install-plugins.sh" script from the official Jenkins Docker image because we want to use Maven to resolve
+# plugin dependency. For BO we will all blueocean-* plugins to be the same version. The aforementioned script downloads latest version
+# of dependent plugins, so we would need to list all BO plugins and do it in the right order (if there's any)
+docker run -it --rm -v "$PWD":/usr/src/boplugins -w /usr/src/boplugins maven:3.3.9 -u "$(id -u)" mvn "-Dblueocean.version=$BLUEOCEAN_VERSION" package
+
+# Build the image
+docker build --no-cache --pull \
+             --tag "jenkinsci/blueocean:$BLUEOCEAN_VERSION" .
+
+# Consider this build is the latest
+docker tag -f "jenkinsci/blueocean:$BLUEOCEAN_VERSION" jenkinsci/blueocean:latest
+
+docker push "jenkinsci/blueocean:$BLUEOCEAN_VERSION"
+docker push jenkinsci/blueocean:latest

--- a/docker/official/pom.xml
+++ b/docker/official/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.jenkins.blueocean</groupId>
+    <artifactId>blueocean-plugin-fetch</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>BlueOcean plugin fetcher</name>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blueocean</artifactId>
+            <version>${blueocean.version}</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+      <repository>
+        <id>repo.jenkins-ci.org</id>
+        <url>https://repo.jenkins-ci.org/public/</url>
+      </repository>
+    </repositories>
+
+    <pluginRepositories>
+      <pluginRepository>
+        <id>repo.jenkins-ci.org</id>
+        <url>https://repo.jenkins-ci.org/public/</url>
+      </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <version>1.119</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>assemble-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
# Description

See [JENKINS-39804](https://issues.jenkins-ci.org/browse/JENKINS-39804).

This is my first take at providing a set of scripts to build an official BlueOcean image. Code is based off the script used to build Jenkins weekly images (see https://github.com/jenkinsci/docker/blob/master/weekly.sh). Like for Jenkins weekly images, the idea would be to trigger `build.sh` after every release.

The image is based on top of the latest Jenkins LTS. It bundles all BO plugins and their dependencies.

@jenkinsci/code-reviewers @reviewbybees 

