### PR TITLE
Adds all the capabilities of a Action to a _capabilities collection o…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/records.jsx
+++ b/blueocean-dashboard/src/main/js/components/records.jsx
@@ -65,6 +65,7 @@ export class RunRecord extends Record({
     state: null,
     type: null,
     commitId: null,
+    actions: null,
 }) {
     isQueued() {
         return this.state === 'QUEUED';
@@ -81,6 +82,17 @@ export class RunRecord extends Record({
 
     getComputedResult() {
         return this.isCompleted() ? this.result : this.state;
+    }
+
+    /** Get action by class or capability */
+    getActions(class) {
+        return run.actions.filter(action => {
+            if (action._class == class) {
+                return true;
+            }
+            var testCapability = action._capabilities.filter(capability => capability == class);
+            return testCapability.length > 0;
+        });
     }
 }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
@@ -1,12 +1,16 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.model.Action;
+import io.jenkins.blueocean.rest.Capabilities;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author Vivek Pandey
@@ -45,6 +49,12 @@ public class ActionProxiesImpl extends BlueActionProxy {
     @Override
     public String get_Class() {
         return action.getClass().getName();
+    }
+
+    @Override
+    public Collection<String> getCapabilities() {
+        Set<String> capabilities = Capabilities.allCapabilities(action.getClass());
+        return capabilities.isEmpty() ? null : capabilities;
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ExtensionClassImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ExtensionClassImpl.java
@@ -1,14 +1,11 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import io.jenkins.blueocean.rest.Capabilities;
 import io.jenkins.blueocean.rest.Reachable;
-import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueExtensionClass;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.Set;
 
 /**
  * @author Vivek Pandey
@@ -23,45 +20,9 @@ public class ExtensionClassImpl extends BlueExtensionClass {
     }
 
     @Override
-    public Collection<String> getClasses() {
-        List<String> classes = new ArrayList<>();
-        collectSuperClasses(classes, baseClass);
-        return classes;
+    public Set<String> getClasses() {
+        return Capabilities.allSuperClassesAndCapabilities(baseClass);
     }
-
-    private void collectSuperClasses(List<String> classes, Class base){
-        captureCapabilityAnnotation(classes,base);
-        Class clz = base.getSuperclass();
-        if(clz != null && !isBlackListed(clz.getName()) && !classes.contains(clz.getName())){
-            classes.add(clz.getName());
-            captureCapabilityAnnotation(classes,clz);
-            collectSuperClasses(classes,clz);
-        }
-    }
-
-    private void captureCapabilityAnnotation(List<String> classes, Class clz){
-        Annotation annotation = clz.getAnnotation(Capability.class);
-        if(annotation != null){
-            Capability capability = (Capability) annotation;
-            for(String c:capability.value()) {
-                if(!classes.contains(c)) {
-                    classes.add(c);
-                }
-            }
-        }
-    }
-
-    private boolean isBlackListed(String clz){
-        for(String s:BLACK_LISTED_CLASSES){
-            if(clz.startsWith(s)){
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static final String[] BLACK_LISTED_CLASSES={"java.", "javax.", "com.sun."};
-
 
     public Link getLink() {
         return parent.getLink().rel(baseClass.getName());

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Capabilities.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Capabilities.java
@@ -1,0 +1,58 @@
+package io.jenkins.blueocean.rest;
+
+import io.jenkins.blueocean.rest.annotation.Capability;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Capabilities {
+
+    public static Set<String> allCapabilities(Class base) {
+        Set<String> classes = new LinkedHashSet<>();
+        collectSuperClasses(classes, base, true);
+        return classes;
+    }
+
+    public static Set<String> allSuperClassesAndCapabilities(Class base) {
+        Set<String> classes = new LinkedHashSet<>();
+        collectSuperClasses(classes, base, false);
+        return classes;
+    }
+
+    private static void collectSuperClasses(Set<String> classes, Class base, boolean capabilitiesOnly){
+        captureCapabilityAnnotation(classes,base);
+        Class clz = base.getSuperclass();
+        if(clz != null && !isBlackListed(clz.getName()) && !classes.contains(clz.getName())){
+            if (!capabilitiesOnly) {
+                classes.add(clz.getName());
+            }
+            captureCapabilityAnnotation(classes,clz);
+            collectSuperClasses(classes,clz, capabilitiesOnly);
+        }
+    }
+
+    private static void captureCapabilityAnnotation(Set<String> classes, Class clz){
+        Annotation annotation = clz.getAnnotation(Capability.class);
+        if(annotation != null){
+            Capability capability = (Capability) annotation;
+            Collections.addAll(classes, capability.value());
+        }
+    }
+
+    private static boolean isBlackListed(String clz){
+        for(String s:BLACK_LISTED_CLASSES){
+            if(clz.startsWith(s)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final String[] BLACK_LISTED_CLASSES={"java.", "javax.", "com.sun."};
+
+
+    private Capabilities() {
+    }
+}

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueActionProxy.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueActionProxy.java
@@ -2,6 +2,8 @@ package io.jenkins.blueocean.rest.model;
 
 import org.kohsuke.stapler.export.Exported;
 
+import java.util.Collection;
+
 /**
  * Proxy of Jenkins action
  *
@@ -34,4 +36,10 @@ public abstract class BlueActionProxy extends Resource {
      */
     @Exported(name = "_class")
     public abstract String get_Class();
+
+    /**
+     * @return capabilities supported by this action
+     */
+    @Exported(name = "_capabilities", skipNull = true)
+    public abstract Collection<String> getCapabilities();
 }

--- a/blueocean-rest/src/test/java/io.jenkins.blueocean.rest/CapabilitiesTest.java
+++ b/blueocean-rest/src/test/java/io.jenkins.blueocean.rest/CapabilitiesTest.java
@@ -1,0 +1,38 @@
+package io.jenkins.blueocean.rest;
+
+import com.google.common.collect.ImmutableSet;
+import io.jenkins.blueocean.rest.annotation.Capability;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CapabilitiesTest {
+
+    @Test
+    public void testAllCapabilities() {
+        assertEquals(ImmutableSet.of(), Capabilities.allCapabilities(Object.class));
+        assertEquals(ImmutableSet.of(), Capabilities.allCapabilities(A.class));
+        assertEquals(ImmutableSet.of("b"), Capabilities.allCapabilities(B.class));
+        assertEquals(ImmutableSet.of("b"), Capabilities.allCapabilities(C.class));
+        assertEquals(ImmutableSet.of("d", "b"), Capabilities.allCapabilities(D.class));
+    }
+
+    @Test
+    public void testAllSuperclassesAndCapabilities() {
+        assertEquals(ImmutableSet.of(), Capabilities.allSuperClassesAndCapabilities(Object.class));
+        assertEquals(ImmutableSet.of(), Capabilities.allSuperClassesAndCapabilities(A.class));
+        assertEquals(ImmutableSet.of("b", "io.jenkins.blueocean.rest.CapabilitiesTest$A"), Capabilities.allSuperClassesAndCapabilities(B.class));
+        assertEquals(ImmutableSet.of("b", "io.jenkins.blueocean.rest.CapabilitiesTest$B", "io.jenkins.blueocean.rest.CapabilitiesTest$A"), Capabilities.allSuperClassesAndCapabilities(C.class));
+        assertEquals(ImmutableSet.of("d", "io.jenkins.blueocean.rest.CapabilitiesTest$C", "b", "io.jenkins.blueocean.rest.CapabilitiesTest$B", "io.jenkins.blueocean.rest.CapabilitiesTest$A"), Capabilities.allSuperClassesAndCapabilities(D.class));
+    }
+
+    class A {}
+
+    @Capability("b")
+    class B extends A {}
+
+    class C extends B {}
+
+    @Capability("d")
+    class D extends C {}
+}


### PR DESCRIPTION
Adds all the capabilities of a Action to a _capabilities collection on the response and adds RunRecord.getActions(classOrcapability).

I was playing over the weekend with supporting other testing plugins other than JUnit (e.g. [robotframework](https://github.com/i386/robot-plugin/tree/blueocean))

The capability on the RobotBuildAction tells me I can find a similar JUnit style structure at this action (robot framework seems to have copy/pasted half of the Junit code and depended on another half - I had to return a similar data structure to JUnit here).

Responses for `Action` now include a `_capabilities` array. This contains ONLY the capabilities of the type and its super classes.

```
{
  "_class": "hudson.plugins.robot.RobotBuildAction",
  "_links": {
    "self": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/robotframeworktest/runs/1/robot/"
    }
  },
  "_capabilities": [
    "io.jenkins.actions.testResult"
  ],
  "failCount": 8,
  "skipCount": 0,
  "totalCount": 16,
  "urlName": "robot"
}
```

**I strongly believe we should be removing the /classes endpoint and inlining the capabilities into the response**

The hypothesis that was used to support returning `Capabilities.allSuperClassesAndCapabilities`  on `/classes` was based on the idea that plugins would not have to be modified if the plugin developer could walk its classes and detect that an action was either an instance of or subclass of a type they were interested in. This is faulty thinking - many plugins will required modification for the `@ExportedBean` or `@Exported` annotations for them to even be exposed by Blue Ocean REST. Plugins have to be modified to work with Blue Ocean.

I propose a system where any `Resource` or `Container` has a map of the capabilities that its objects support (the `RobotBuildAction` being an example for the `Resource`)

For example, a response for a container would look like:
```
{
  "_capabilities": {
    "io.example.exampleResourceA": ["io.example.capability.A", "io.example.capability.SomethingElse"],
    "io.example.exampleResourceB": ["io.jenkins.stats.coverage"]
  },
  "collection": [
    {
      "_class": "io.example.exampleResourceA"
      ...
    },
    {
      "_class": "io.example.exampleResourceB"
      ...
    },
    {
      "_class": "io.example.exampleResourceB"
      ...
    }
  ]
}
```

A resource:
```
{
  "_class": "io.example.my.resource",
  "_capabilities": [
    "io.jenkins.blueocean.pipeline"
  ]
}
```

Which would remove the need entirely for `/classes`, the extra requests but keep the responses for containers small. When a `Container` is rendered, individual `Resource`s should not return their own `_capabilities` array.

@vivek @kzantow @michaelneale 