### PR TITLE
release prod version of latest js-extensions; update blueocean to use it

### DIFF
--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -50,9 +50,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.31-sandbox1",
-      "from": "@jenkins-cd/js-extensions@0.0.31-sandbox1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31-sandbox1.tgz"
+      "version": "0.0.31",
+      "from": "@jenkins-cd/js-extensions@0.0.31",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -6736,9 +6736,9 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.17.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.31-unpublished3",
     "@jenkins-cd/design-language": "0.0.88",
-    "@jenkins-cd/js-extensions": "0.0.31-sandbox1",
+    "@jenkins-cd/js-extensions": "0.0.31",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/sse-gateway": "0.0.9",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.31-sandbox1",
-      "from": "@jenkins-cd/js-extensions@0.0.31-sandbox1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31-sandbox1.tgz"
+      "version": "0.0.31",
+      "from": "@jenkins-cd/js-extensions@0.0.31",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -6707,9 +6707,9 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.17.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.31-unpublished3",
     "@jenkins-cd/design-language": "0.0.88",
-    "@jenkins-cd/js-extensions": "0.0.31-sandbox1",
+    "@jenkins-cd/js-extensions": "0.0.31",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -42,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.31-sandbox1",
-      "from": "@jenkins-cd/js-extensions@0.0.31-sandbox1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31-sandbox1.tgz"
+      "version": "0.0.31",
+      "from": "@jenkins-cd/js-extensions@0.0.31",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.31.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -4311,9 +4311,9 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.17.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.31-unpublished3",
     "@jenkins-cd/design-language": "0.0.88",
-    "@jenkins-cd/js-extensions": "0.0.31-sandbox1",
+    "@jenkins-cd/js-extensions": "0.0.31",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.31-sandbox1",
+  "version": "0.0.31",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
# Description
- In #572 I accidentally forgot to release a prod version of `js-extensions` so version "0.0.31-sandbox1" was accidentally merged to master. This PR fixes this. Tested locally and looks good; will self-merge once CI passes.
