### PR TITLE
JENKINS-36907 Raw encode the organization name (the instance display …

### DIFF
--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -124,7 +124,7 @@ public class BlueOceanWebURLBuilder {
     }
 
     private static String getOrgPrefix() {
-        return getBlueHome() + "/organizations/" + encodeURIComponent(OrganizationImpl.INSTANCE.getName());
+        return getBlueHome() + "/organizations/" + OrganizationImpl.INSTANCE.getName();
     }
 
     private static String getBlueHome() {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationContainerImpl.java
@@ -32,7 +32,7 @@ public class OrganizationContainerImpl extends BlueOrganizationContainer {
     }
 
     protected void validateOrganization(String organization){
-        if (!organization.equals(Jenkins.getActiveInstance().getDisplayName().toLowerCase())) {
+        if (!organization.equals(OrganizationImpl.INSTANCE.getName())) {
             throw new ServiceException.UnprocessableEntityException(String.format("Organization %s not found",
                 organization));
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
@@ -44,6 +44,11 @@ public class OrganizationImpl extends BlueOrganization {
     }
 
     @Override
+    public String getDisplayName() {
+        return Jenkins.getInstance().getDisplayName();
+    }
+
+    @Override
     public BluePipelineContainer getPipelines() {
         return new PipelineContainerImpl(Jenkins.getInstance());
     }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
@@ -40,7 +40,7 @@ public class OrganizationImpl extends BlueOrganization {
      * In embedded mode, there's only one organization
      */
     public String getName() {
-        return Util.rawEncode(Jenkins.getInstance().getDisplayName());
+        return Util.rawEncode(Jenkins.getInstance().getDisplayName().toLowerCase());
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
@@ -1,5 +1,7 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import com.google.common.base.Objects;
+import hudson.Util;
 import hudson.model.User;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.commons.stapler.JsonBody;
@@ -10,6 +12,7 @@ import io.jenkins.blueocean.rest.model.BluePipelineContainer;
 import io.jenkins.blueocean.rest.model.BlueUser;
 import io.jenkins.blueocean.rest.model.BlueUserContainer;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.DELETE;
 import org.kohsuke.stapler.verb.PUT;
@@ -37,7 +40,7 @@ public class OrganizationImpl extends BlueOrganization {
      * In embedded mode, there's only one organization
      */
     public String getName() {
-        return Jenkins.getInstance().getDisplayName().toLowerCase();
+        return Util.rawEncode(Jenkins.getInstance().getDisplayName());
     }
 
     @Override

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueOrganization.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueOrganization.java
@@ -14,10 +14,14 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_ORGANIZATIO
 @Capability(BLUE_ORGANIZATION)
 public abstract class BlueOrganization extends Resource {
     public static final String NAME="name";
+    public static final String DISPLAY_NAME="name";
     public static final String PIPELINES="pipelines";
 
     @Exported(name = NAME)
     public abstract String getName();
+
+    @Exported(name = DISPLAY_NAME)
+    public abstract String getDisplayName();
 
     @Navigable
     //   /organizations/jenkins/piplelines/f1


### PR DESCRIPTION
# Description

This problem [came up on the mailing list again](https://groups.google.com/forum/#!topic/jenkinsci-dev/rwu5AzMilII).

The fix is to `Util.rawEncode` the display name of Jenkins so that it can be used as the organizations name safely in a URL. Should fix this problem regardless of the translation contents (e.g. illegal characters in the URL) and fixes it in all versions of Jenkins.

See [JENKINS-36907](https://issues.jenkins-ci.org/browse/JENKINS-36907).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

…name) as it gets used in the URL