### PR TITLE
JENKINS-39158 - upgrade workflow-api to 2.8 to correct an issue where…

### DIFF
--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.4</version>
+            <version>2.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Description

upgrade workflow-api to 2.8 to correct an issue where parallel branch isn't showing up as completed in karaoke mode

See [JENKINS-39158](https://issues.jenkins-ci.org/browse/JENKINS-39158).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

… parallel branch isn't showing up as completed in karaoke mode