### PR TITLE
[FIX JENKINS-40116] Fix for null return on request.getPageInfo() in ResourceCacheControl

### DIFF
--- a/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/ResourceCacheControl.java
@@ -134,8 +134,11 @@ public final class ResourceCacheControl implements Filter {
         chain.doFilter(request, response);
     }
 
-    private boolean isCacheableResourceRequest(HttpServletRequest request) {
+    boolean isCacheableResourceRequest(HttpServletRequest request) {
         String requestPath = request.getPathInfo();
+        if (requestPath == null) {
+            return false;
+        }
         for (String resourcePrefix : resourcePrefixes) {
             if (requestPath.startsWith(resourcePrefix)) {
                 return true;

--- a/blueocean-web/src/test/java/io/jenkins/blueocean/ResourceCacheControlTest.java
+++ b/blueocean-web/src/test/java/io/jenkins/blueocean/ResourceCacheControlTest.java
@@ -78,4 +78,17 @@ public class ResourceCacheControlTest {
         Mockito.when(servletRequest.getPathInfo()).thenReturn("/a/bc.js");
         resourceCacheControl.doFilter(servletRequest, servletResponse, filterChain);
         Mockito.verify(servletResponse, Mockito.never()).setHeader("Cache-Control", "public, max-age=31536000");
-    }}
+    }
+
+    @Test
+    public void test_getPathInfo_null_JENKINS_40116() throws IOException, ServletException {
+        Mockito.when(servletRequest.getPathInfo()).thenReturn(null);
+        Assert.assertFalse(resourceCacheControl.isCacheableResourceRequest(servletRequest));
+    }
+
+    @Test
+    public void test_getPathInfo_not_null_JENKINS_40116() throws IOException, ServletException {
+        Mockito.when(servletRequest.getPathInfo()).thenReturn("/a/b/c.js");
+        Assert.assertTrue(resourceCacheControl.isCacheableResourceRequest(servletRequest));
+    }
+}


### PR DESCRIPTION
# Description

See [JENKINS-40116](https://issues.jenkins-ci.org/browse/JENKINS-40116).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

