### PR TITLE
JENKINS-40135# NPE fix with non-block stages without steps in between

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -1688,6 +1688,25 @@ public class PipelineNodeTest extends PipelineBaseTest {
         Assert.assertEquals("FINISHED", nodes.get(2).get("state"));
     }
 
+    @Test
+    public void stageTestJENKINS_40135() throws Exception {
+        String script = "node {\n" +
+                "    stage 'Stage 1'\n" +
+                "    stage 'Stage 2'\n" +
+                "       echo 'hello'\n"+
+                "}";
+        WorkflowJob job1 = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
+        job1.setDefinition(new CpsFlowDefinition(script));
+        WorkflowRun b1 = job1.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(b1);
+        List<Map> nodes = get("/organizations/jenkins/pipelines/pipeline1/runs/1/nodes/", List.class);
+        Assert.assertEquals(2, nodes.size());
+        Assert.assertEquals("SUCCESS", nodes.get(0).get("result"));
+        Assert.assertEquals("FINISHED", nodes.get(0).get("state"));
+        Assert.assertEquals("SUCCESS", nodes.get(1).get("result"));
+        Assert.assertEquals("FINISHED", nodes.get(1).get("state"));
+    }
+
     private String getActionLink(Map resp, String capability){
         List<Map> actions = (List<Map>) resp.get("actions");
         assertNotNull(actions);


### PR DESCRIPTION
# Description

See [JENKINS-40135](https://issues.jenkins-ci.org/browse/JENKINS-40135).

Following script cause NPE, this PR fixes that. Similar script in ATH (src/test/resources/multibranch_1 ) fails with same NPE. I think this used to pass on master, perhaps underlying workflow-api was upgraded. In any case MemoryFlowChunk.getLastNode() is returning null that its not supposed to and that resulted in NPE. A non-null check has been added and https://issues.jenkins-ci.org/browse/JENKINS-40200 is raised.

```
node {
    stage 'Stage 1'
    stage 'Stage 2'
       echo 'hello'
}
```

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

Root cause is MemoryFlowChunk.getLastNode() returns null, its supposed to be @Nonnull.
JENKINS-40200 raised, as work around null check is added.