### PR TITLE
[FIX JENKINS-39955] re-run broken due to queue/executing timing/disconnect

### DIFF
--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -774,6 +774,7 @@ export const actions = {
     fetchLog(cfg) {
         return (dispatch, getState) => {
             const data = getState().adminStore.logs;
+            
             let config = cfg;
             if (!config.nodesBaseUrl) {
                 config = { ...config, nodesBaseUrl: calculateNodeBaseUrl(config) };

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -774,7 +774,6 @@ export const actions = {
     fetchLog(cfg) {
         return (dispatch, getState) => {
             const data = getState().adminStore.logs;
-            
             let config = cfg;
             if (!config.nodesBaseUrl) {
                 config = { ...config, nodesBaseUrl: calculateNodeBaseUrl(config) };

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -771,11 +771,12 @@ export const actions = {
      Get a specific log for a node, fetch it only if needed.
      key for cache: logUrl = calculateLogUrl
      */
-    fetchLog(config) {
+    fetchLog(cfg) {
         return (dispatch, getState) => {
             const data = getState().adminStore.logs;
+            let config = cfg;
             if (!config.nodesBaseUrl) {
-                config.nodesBaseUrl = calculateNodeBaseUrl(config);
+                config = { ...config, nodesBaseUrl: calculateNodeBaseUrl(config) };
             }
             const logUrl = calculateLogUrl(config);
             if (

--- a/blueocean-dashboard/src/main/js/redux/actions.js
+++ b/blueocean-dashboard/src/main/js/redux/actions.js
@@ -774,6 +774,9 @@ export const actions = {
     fetchLog(config) {
         return (dispatch, getState) => {
             const data = getState().adminStore.logs;
+            if (!config.nodesBaseUrl) {
+                config.nodesBaseUrl = calculateNodeBaseUrl(config);
+            }
             const logUrl = calculateLogUrl(config);
             if (
                 config.fetchAll ||


### PR DESCRIPTION
# Description

Re-run button was broken in a number of cases. Added code to retry in the case of a queued item and failed node/step fetches.

Can test this with the pipeline provided in the ticket, it runs or 15 seconds with a number of stages and logs.

See [JENKINS-39955](https://issues.jenkins-ci.org/browse/JENKINS-39955).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

