### PR TITLE
Rename the modules so they follow the Update Center naming convention…

### DIFF
--- a/blueocean-commons/pom.xml
+++ b/blueocean-commons/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-commons</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Blue Ocean: Commons</name>
+  <name>Common API for Blue Ocean</name>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
   <dependencies>

--- a/blueocean-commons/pom.xml
+++ b/blueocean-commons/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-commons</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Module :: BlueOcean :: Commons API</name>
+  <name>Blue Ocean: Commons</name>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
   <dependencies>

--- a/blueocean-config/pom.xml
+++ b/blueocean-config/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-config</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Module :: BlueOcean :: Config</name>
+  <name>Blue Ocean: config</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-config/pom.xml
+++ b/blueocean-config/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-config</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Blue Ocean: config</name>
+  <name>Config API for Blue Ocean</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-dashboard/pom.xml
+++ b/blueocean-dashboard/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Module :: BlueOcean :: Dashboard</name>
+    <name>Blue Ocean: Dashboard</name>
     <artifactId>blueocean-dashboard</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-dashboard/pom.xml
+++ b/blueocean-dashboard/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Blue Ocean: Dashboard</name>
+    <name>Dashboard for Blue Ocean</name>
     <artifactId>blueocean-dashboard</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Module :: BlueOcean :: Events</name>
+    <name>Blue Ocean: Events</name>
     <artifactId>blueocean-events</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Blue Ocean: Events</name>
+    <name>Events API for Blue Ocean</name>
     <artifactId>blueocean-events</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-i18n/pom.xml
+++ b/blueocean-i18n/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-i18n</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Module :: BlueOcean :: i18n API</name>
+  <name>Blue Ocean: Internationalization</name>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 

--- a/blueocean-i18n/pom.xml
+++ b/blueocean-i18n/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-i18n</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Blue Ocean: Internationalization</name>
+  <name>i18n for Blue Ocean</name>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 

--- a/blueocean-jwt/pom.xml
+++ b/blueocean-jwt/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-jwt</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Blue Ocean: JWT</name>
+  <name>JWT for Blue Ocean</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-jwt/pom.xml
+++ b/blueocean-jwt/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-jwt</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Module :: BlueOcean :: JWT module</name>
+  <name>Blue Ocean: JWT</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-personalization/pom.xml
+++ b/blueocean-personalization/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Blue Ocean: Personalization</name>
+    <name>Personalization for Blue Ocean</name>
     <artifactId>blueocean-personalization</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-personalization/pom.xml
+++ b/blueocean-personalization/pom.xml
@@ -7,7 +7,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Module :: BlueOcean :: Personalization</name>
+    <name>Blue Ocean: Personalization</name>
     <artifactId>blueocean-personalization</artifactId>
     <packaging>hpi</packaging>
 

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-pipeline-api-impl</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Module :: BlueOcean :: Pipeline REST API implementation</name>
+    <name>Blue Ocean: Pipeline REST API implementation</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <dependencies>

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-pipeline-api-impl</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Blue Ocean: Pipeline REST API implementation</name>
+    <name>Pipeline REST API for Blue Ocean</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <dependencies>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-rest-impl</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Module :: BlueOcean :: REST API implementation</name>
+    <name>Blue Ocean: REST implementation</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <dependencies>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-rest-impl</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Blue Ocean: REST implementation</name>
+    <name>REST Implementation for Blue Ocean</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <dependencies>

--- a/blueocean-rest/pom.xml
+++ b/blueocean-rest/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-rest</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Module :: BlueOcean :: Rest module</name>
+  <name>Blue Ocean: REST</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-rest/pom.xml
+++ b/blueocean-rest/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>blueocean-rest</artifactId>
   <packaging>hpi</packaging>
 
-  <name>Blue Ocean: REST</name>
+  <name>REST API for Blue Ocean</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
   <dependencies>

--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-web</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Module :: BlueOcean :: Web module</name>
+    <name>Blue Ocean: Web</name>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 

--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-web</artifactId>
     <packaging>hpi</packaging>
 
-    <name>Blue Ocean: Web</name>
+    <name>Web for Blue Ocean</name>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean</artifactId>
     <packaging>hpi</packaging>
 
-    <name>BlueOcean beta</name>
+    <name>Blue Ocean beta</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>1.0.0-b13-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Blue Ocean UI Parent</name>
+  <name>Blue Ocean: Parent</name>
 
   <properties>
     <java.level>7</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>1.0.0-b13-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Blue Ocean: Parent</name>
+  <name>Blue Ocean Parent</name>
 
   <properties>
     <java.level>7</java.level>


### PR DESCRIPTION
# Description

```
<danielbeck> Daniel Beck yo i386 around?
10:08 AM Could we maybe get some consistency between Blue Ocean and Pipeline, the two big polluters of the plugin manager, re the naming of things?
10:08 AM Pipeline: Thing
10:08 AM Blue Ocean :: Module :: Thing
10:09 AM FWIW I'd prefer the former, because BO's looks like a 15 year old's online gaming tag ;-)
```

Gives me an opportunity to stamp out `BlueOcean` in favour of the proper `Blue Ocean` name.

This is a maven metadata name so does not require ATH. This does not break the plugins in the UC either - just a labelling change.

cc @daniel-beck 

See [JENKINS-40271](https://issues.jenkins-ci.org/browse/JENKINS-40271).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

… for multi-module plugins