### PR TITLE
[JENKINS-40296] Display latest commit messages

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -116,12 +116,11 @@ export class Activity extends Component {
                         runs.map((run, index) => {
                             const changeset = run.changeSet;
                             let latestRecord = {};
+                  
                             if (changeset && changeset.length > 0) {
-                                latestRecord = new ChangeSetRecord(changeset[
-                                    Object.keys(changeset)[changeset.length - 1]
-                                ]);
+                                latestRecord = new ChangeSetRecord(changeset[changeset.length - 1]);
                             }
-
+                            
                             return (
                                 <Runs {...{
                                     t,

--- a/blueocean-dashboard/src/main/js/components/Branches.jsx
+++ b/blueocean-dashboard/src/main/js/components/Branches.jsx
@@ -32,7 +32,8 @@ export default class Branches extends Component {
             router.push(location);
         };
 
-        const { msg } = (branch.changeSet && branch.changeSet.length > 0) ? (branch.changeSet[0] || {}) : {};
+        const { msg } = (latestRun.changeSet && latestRun.changeSet.length > 0) ? (latestRun.changeSet[latestRun.changeSet.length - 1] || {}) : {};
+        
         return (
             <CellRow linkUrl={runDetailsUrl} id={`${cleanBranchName}-${latestRun.id}`}>
                 <CellLink disableDefaultPadding>


### PR DESCRIPTION
# Description

Makes latest commit message show on activity and branches tabs. To test, make a change and rerun a branch and the latest commit should how on both.

See [JENKINS-40296](https://issues.jenkins-ci.org/browse/JENKINS-40296).

ATH PR: https://github.com/jenkinsci/blueocean-acceptance-test/pull/85
# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

