### PR TITLE
[INFRA-987] Jenkinsfile to build the official docker image

### DIFF
--- a/docker/official/Jenkinsfile
+++ b/docker/official/Jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+/* Only keep the 10 most recent builds. */
+properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
+
+node('docker') {
+  stage('Checkout') {
+    deleteDir()
+    checkout scm
+  }
+
+  stage('Build and publish container') {
+      sh 'docker/official/build.sh'
+  }
+}


### PR DESCRIPTION
# Description

See [INFRA-987](https://issues.jenkins-ci.org/browse/INFRA-987).

Provides a Jenkinsfile to build on Jenkins infra.

@rtyler 