### PR TITLE
[JENKINS-39907] Hardcode default org to always be jenkins

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/OrganizationImpl.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 public class OrganizationImpl extends BlueOrganization {
+    public final static String DEFAULT_ORG_NAME = "jenkins";
+
     private final UserContainerImpl users = new UserContainerImpl(this);
 
     /**
@@ -40,12 +42,12 @@ public class OrganizationImpl extends BlueOrganization {
      * In embedded mode, there's only one organization
      */
     public String getName() {
-        return Util.rawEncode(Jenkins.getInstance().getDisplayName().toLowerCase());
+        return DEFAULT_ORG_NAME;
     }
 
     @Override
     public String getDisplayName() {
-        return Jenkins.getInstance().getDisplayName();
+        return "Jenkins";
     }
 
     @Override


### PR DESCRIPTION
# Description

No additional tests should be needed. This will only affect spanish versions of Jenkins by removing the space from the end of the jenkins org.

See [JENKINS-39907](https://issues.jenkins-ci.org/browse/JENKINS-39907).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

