### PR TITLE
fetchMore is no longer used.. also someone needs a test for this

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -138,7 +138,7 @@ export class Activity extends Component {
                 }
 
                 {runs && runs.length > 0 &&
-                <button disabled={this.pager.pending || !this.pager.hasMore} className="btn-show-more btn-secondary" onClick={() => this.pager.fetchMore()}>
+                <button disabled={this.pager.pending || !this.pager.hasMore} className="btn-show-more btn-secondary" onClick={() => this.pager.fetchNextPage()}>
                     {this.pager.pending ? t('common.pager.loading', { defaultValue: 'Loading...' }) : t('common.pager.more', { defaultValue: 'Show more' })}
                 </button>
                 }


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-40434

fetchNextPage should be used instead of fetchMore. 

After this change, should delete all trace of fetchMore as AFAICT it isn't used other than in test code. 

Also - need to have an ATH for this but I have done my tour of duty there for this week. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

