### PR TITLE
JENKINS-40209 Introduce specialised types for organization folders so…

### DIFF
--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -82,6 +82,12 @@
             <version>1.8.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-bitbucket-branch-source</artifactId>
+            <version>1.8</version>
+        </dependency>
+
         <!-- Test plugins -->
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BitbucketOrganizationFolder.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BitbucketOrganizationFolder.java
@@ -1,0 +1,24 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMNavigator;
+import com.google.common.collect.Iterables;
+import hudson.Extension;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.hal.Link;
+import jenkins.scm.api.SCMNavigator;
+
+public class BitbucketOrganizationFolder extends OrganizationFolder {
+
+    public BitbucketOrganizationFolder(jenkins.branch.OrganizationFolder folder, Link parent) {
+        super(folder, parent);
+    }
+
+    @Extension
+    public static class OrganizationFolderFactoryImpl extends OrganizationFolderFactory {
+        @Override
+        protected OrganizationFolder getFolder(jenkins.branch.OrganizationFolder folder, Reachable parent) {
+            SCMNavigator navigator = Iterables.getFirst(folder.getNavigators(), null);
+            return BitbucketSCMNavigator.class.isInstance(navigator) ? new BitbucketOrganizationFolder(folder, parent.getLink()) : null;
+        }
+    }
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/GithubOrganizationFolder.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/GithubOrganizationFolder.java
@@ -1,0 +1,24 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.google.common.collect.Iterables;
+import hudson.Extension;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.hal.Link;
+import jenkins.scm.api.SCMNavigator;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+
+public class GithubOrganizationFolder extends OrganizationFolder {
+
+    public GithubOrganizationFolder(jenkins.branch.OrganizationFolder folder, Link parent) {
+        super(folder, parent);
+    }
+
+    @Extension
+    public static class OrganizationFolderFactoryImpl extends OrganizationFolderFactory {
+        @Override
+        protected OrganizationFolder getFolder(jenkins.branch.OrganizationFolder folder, Reachable parent) {
+            SCMNavigator navigator = Iterables.getFirst(folder.getNavigators(), null);
+            return GitHubSCMNavigator.class.isInstance(navigator) ? new GithubOrganizationFolder(folder, parent.getLink()) : null;
+        }
+    }
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolder.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolder.java
@@ -1,0 +1,35 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import hudson.model.Item;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.service.embedded.rest.PipelineFolderImpl;
+import org.kohsuke.stapler.export.Exported;
+
+public abstract class OrganizationFolder extends PipelineFolderImpl {
+
+    protected final jenkins.branch.OrganizationFolder folder;
+
+    public OrganizationFolder(jenkins.branch.OrganizationFolder folder, Link parent) {
+        super(folder, parent);
+        this.folder = folder;
+    }
+
+    @Exported
+    public String getIcon() {
+        return folder.getIcon().getImageOf("32x32");
+    }
+
+    public abstract static class OrganizationFolderFactory extends PipelineFactoryImpl {
+
+        protected abstract OrganizationFolder getFolder(jenkins.branch.OrganizationFolder folder, Reachable parent);
+
+        @Override
+        public OrganizationFolder getPipeline(Item item, Reachable parent) {
+            if (item instanceof jenkins.branch.OrganizationFolder) {
+                return getFolder((jenkins.branch.OrganizationFolder)item, parent);
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# Description

You can now determine the type of Folder by its `_class`. Also includes a link to its icon.

*Github Org folder*
```
{
  "_class": "io.jenkins.blueocean.rest.impl.pipeline.GithubOrganizationFolder",
  "_links": {
    "activities": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/cloudbeers/activities/"
    },
    "self": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/cloudbeers/"
    },
    "actions": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/cloudbeers/actions/"
    },
    "runs": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/cloudbeers/runs/"
    },
    "queue": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/cloudbeers/queue/"
    }
  },
  "actions": [],
  "displayName": "cloudbeers",
  "fullDisplayName": "cloudbeers",
  "fullName": "cloudbeers",
  "name": "cloudbeers",
  "organization": "jenkins",
  "permissions": {
    "create": true,
    "read": true,
    "start": true,
    "stop": true
  },
  "numberOfFolders": 0,
  "numberOfPipelines": 0,
  "icon": "/jenkins/static/c653c0ab/plugin/cloudbees-folder/images/32x32/folder.png"
}
```

*Bitbucket org folder*
```
{
  "_class": "io.jenkins.blueocean.rest.impl.pipeline.BitbucketOrganizationFolder",
  "_links": {
    "activities": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/bitbuckety/activities/"
    },
    "self": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/bitbuckety/"
    },
    "actions": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/bitbuckety/actions/"
    },
    "runs": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/bitbuckety/runs/"
    },
    "queue": {
      "_class": "io.jenkins.blueocean.rest.hal.Link",
      "href": "/blue/rest/organizations/jenkins/pipelines/bitbuckety/queue/"
    }
  },
  "actions": [],
  "displayName": "bitbuckety",
  "fullDisplayName": "bitbuckety",
  "fullName": "bitbuckety",
  "name": "bitbuckety",
  "organization": "jenkins",
  "permissions": {
    "create": true,
    "read": true,
    "start": true,
    "stop": true
  },
  "numberOfFolders": 0,
  "numberOfPipelines": 0,
  "icon": "/jenkins/static/c653c0ab/plugin/cloudbees-folder/images/32x32/folder.png"
}
```

See [JENKINS-40209](https://issues.jenkins-ci.org/browse/JENKINS-40209).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 

… that they can be detected in the client