### PR TITLE
[FIX JENKINS-40137] Fix encoding of job name in "Open Blue Ocean" URLs

### DIFF
--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -44,6 +44,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.List;
 
@@ -108,7 +109,11 @@ public class BlueOceanWebURLBuilder {
             Run run = (Run) classicModelObject;
             Job job = run.getParent();
             BlueOceanModelMapping pipelineModelMapping = getPipelineModelMapping(job);
-            return pipelineModelMapping.blueUiUrl + "/detail/" + encodeURIComponent(job.getName()) + "/" + encodeURIComponent(run.getId());
+            // The job can be created with a name that has special encoding chars in it (if created outside the UI e.g. MBP indexing),
+            // specifically %. Encoding it again breaks things ala JENKINS-40137. The creation name can also
+            // have spaces, even from the UI (it should prevent that). So, decode to revert anything that's already
+            // encoded and re-encode to do the full monty. Nasty :)
+            return pipelineModelMapping.blueUiUrl + "/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId());
         } else if (classicModelObject instanceof Item) {
             Resource blueResource = BluePipelineFactory.resolve((Item) classicModelObject);
             if (blueResource != null) {
@@ -159,6 +164,14 @@ public class BlueOceanWebURLBuilder {
                 blueResource,
                 getOrgPrefix() + "/" + encodeURIComponent(blueResource.getFullName())
             );
+        }
+    }
+
+    static String decodeURIComponent(String string) {
+        try {
+            return URLDecoder.decode(string, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Unexpected UTF-8 encoding error.", e);
         }
     }
 

--- a/blueocean-dashboard/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
+++ b/blueocean-dashboard/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
@@ -110,7 +110,7 @@ public class BlueOceanWebURLBuilderTest {
         blueOceanURL = BlueOceanWebURLBuilder.toBlueOceanURL(masterJob.getFirstBuild());
         assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/master/1", blueOceanURL);
         blueOceanURL = BlueOceanWebURLBuilder.toBlueOceanURL(featureUx1Job.getFirstBuild());
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/feature%252Fux-1/1", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/feature%2Fux-1/1", blueOceanURL);
     }
 
     private WorkflowJob findBranchProject(WorkflowMultiBranchProject mp, String name) throws Exception {


### PR DESCRIPTION
# Description

See [JENKINS-40137](https://issues.jenkins-ci.org/browse/JENKINS-40137): "Open in blue ocean button does not work for runs when the branch name contains a /".

See ATH PR: https://github.com/jenkinsci/blueocean-acceptance-test/pull/92

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
