### PR TITLE
Task/jenkins 40809 Publish event for input step submission

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BlueOceanGraphListener.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BlueOceanGraphListener.java
@@ -1,0 +1,21 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import hudson.ExtensionPoint;
+import org.jenkinsci.plugins.workflow.flow.GraphListener;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
+
+/**
+ *
+ * {@link GraphListener} with BlueOcean enhancements
+ *
+ * @author Vivek Pandey
+ */
+public interface BlueOceanGraphListener extends ExtensionPoint{
+    /**
+     * This event is sent when an input step moves from paused to continue state. That is when an input form is submitted.
+     *
+      * @param inputStep {@link InputStep} which got executed by sumitting parameters
+     */
+    void onStepContinue(InputStep inputStep, WorkflowRun run);
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BlueOceanGraphListener.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BlueOceanGraphListener.java
@@ -1,13 +1,12 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
 import hudson.ExtensionPoint;
-import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStep;
 
 /**
  *
- * {@link GraphListener} with BlueOcean enhancements
+ * Listener for input step submission event
  *
  * @author Vivek Pandey
  */
@@ -16,6 +15,7 @@ public interface BlueOceanGraphListener extends ExtensionPoint{
      * This event is sent when an input step moves from paused to continue state. That is when an input form is submitted.
      *
       * @param inputStep {@link InputStep} which got executed by sumitting parameters
+     *  @param run {@link WorkflowRun} associated with this input step
      */
     void onStepContinue(InputStep inputStep, WorkflowRun run);
 }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.model.FileParameterValue;
 import hudson.model.ParameterDefinition;
@@ -144,7 +145,11 @@ public class PipelineStepImpl extends BluePipelineStep {
 
             Object o = parseValue(execution, JSONArray.fromObject(body.get(PARAMETERS_ELEMENT)), request);
 
-            return execution.proceed(o);
+            HttpResponse response =  execution.proceed(o);
+            for(BlueOceanGraphListener listener: ExtensionList.lookup(BlueOceanGraphListener.class)){
+                listener.onStepContinue(execution.getInput(), run);
+            }
+            return response;
         } catch (IOException | InterruptedException | ServletException e) {
             throw new ServiceException.UnexpectedErrorException("Error processing Input Submit request."+e.getMessage());
         }


### PR DESCRIPTION
# Description

See [JENKINS-40809](https://issues.jenkins-ci.org/browse/JENKINS-40809).

To test

- Create a pipeline job with input step
- In browser console set `window.localStorage.env = 'debug=sse'`
- Run the pipeline and submit input step, you should receive 'job_run_unpaused' event

@scherler Please take a look and test with your changes in PR 678. If you need more data with this event  - only possible data is InputStep id, a UUID, its not step id in DAG, I can add it to message.

![image](https://cloud.githubusercontent.com/assets/38139/21658697/7172a4ae-d27c-11e6-81da-04b580874e16.png)


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 