### PR TITLE
[FIX JENKINS-40080] Cache class info in browser storage

### DIFF
--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -33,6 +33,11 @@
       "from": "@jenkins-cd/sse-gateway@0.0.10",
       "resolved": "https://registry.npmjs.org/@jenkins-cd/sse-gateway/-/sse-gateway-0.0.10.tgz"
     },
+    "@jenkins-cd/storage": {
+      "version": "0.0.2",
+      "from": "@jenkins-cd/storage@latest",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.2.tgz"
+    },
     "abab": {
       "version": "1.0.3",
       "from": "abab@>=1.0.0 <2.0.0",
@@ -4385,6 +4390,11 @@
       "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dev": true
+    },
+    "localstorage-memory": {
+      "version": "1.0.2",
+      "from": "localstorage-memory@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz"
     },
     "lodash": {
       "version": "4.17.2",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.41-unpublished",
+  "version": "0.0.42-unpublished",
   "dependencies": {
     "@jenkins-cd/diag": {
       "version": "0.0.2",
@@ -34,9 +34,9 @@
       "resolved": "https://registry.npmjs.org/@jenkins-cd/sse-gateway/-/sse-gateway-0.0.10.tgz"
     },
     "@jenkins-cd/storage": {
-      "version": "0.0.2",
-      "from": "@jenkins-cd/storage@latest",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.2.tgz"
+      "version": "0.0.3",
+      "from": "@jenkins-cd/storage@0.0.3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.3.tgz"
     },
     "abab": {
       "version": "1.0.3",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.42-unpublished",
+  "version": "0.0.42",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {
@@ -28,6 +28,7 @@
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "@jenkins-cd/sse-gateway": "0.0.10",
+    "@jenkins-cd/storage": "0.0.3",
     "es6-promise": "4.0.5",
     "i18next": "3.5.2",
     "i18next-browser-languagedetector": "1.0.0",

--- a/blueocean-core-js/src/js/capability/CapabilityStore.js
+++ b/blueocean-core-js/src/js/capability/CapabilityStore.js
@@ -2,6 +2,13 @@
  * Created by cmeyers on 8/31/16.
  */
 import es6Promise from 'es6-promise'; es6Promise.polyfill();
+import { installInfo } from '../storage';
+
+// Create a dedicated storage namespace that we use to store classes
+// info in the browser, eliminating client REST call overhead for classes
+// info. This storage namespace will be auto-cleared if the jesnkins version
+// changes, or if the active plugins change.
+const classesInfoNS = installInfo.subspace('classesInfo');
 
 /**
  * Retrieves capability metadata for class names.
@@ -10,7 +17,7 @@ import es6Promise from 'es6-promise'; es6Promise.polyfill();
 export class CapabilityStore {
 
     constructor(capabilityApi) {
-        this._store = {};
+        this._localStore = {};
         this._capabilityApi = capabilityApi;
     }
 
@@ -27,8 +34,9 @@ export class CapabilityStore {
 
         // determine which class names are already in the cache and which aren't
         for (const className of classNames) {
-            if (this._store[className]) {
-                result[className] = this._store[className];
+            const classInfo = this._getStoredClassInfo(className);
+            if (classInfo) {
+                result[className] = classInfo;
             } else {
                 classesToFetch.push(className);
             }
@@ -68,9 +76,25 @@ export class CapabilityStore {
 
         Object.keys(map).forEach(className => {
             const capabilities = map[className];
-            this._store[className] = storedCapabilities[className] = capabilities.classes.slice();
+            this._localStore[className] = storedCapabilities[className] = capabilities.classes.slice();
+            // Also store in the browser so we don't have to look
+            // up this info again (unless the storage namespace is
+            // cleared due to jenkins or plugin changes).
+            classesInfoNS.set(className, this._localStore[className]);
         });
 
         return storedCapabilities;
+    }
+
+    _getStoredClassInfo(className) {
+        if (!this._localStore[className]) {
+            // If we don't have a copy of the class info in the localStore,
+            // check the browser storage and copy it into the localStore.
+            // We still want to use the localStore because it holds deserialized
+            // copies of the class info, which means that a localStore lookup
+            // would be lower overhead and probably faster.
+            this._localStore[className] = classesInfoNS.get(className);
+        }
+        return this._localStore[className];
     }
 }

--- a/blueocean-core-js/src/js/i18n/i18n.js
+++ b/blueocean-core-js/src/js/i18n/i18n.js
@@ -15,6 +15,7 @@ export const defaultLngDetector = new LngDetector(null, {
     lookupQuerystring: 'language',
 });
 const prefix = urlConfig.getJenkinsRootURL() || '';
+const FALLBACK_LANG = '';
 
 function newPluginXHR(pluginName) {
     let pluginVersion = store.getPluginVersion(pluginName);
@@ -91,7 +92,7 @@ const pluginI18next = (pluginName, namespace = toDefaultNamespace(pluginName)) =
         defaultNS: namespace,
         keySeparator: false, // we do not have any nested keys in properties files
         debug: false,
-        fallbackLng: '',
+        fallbackLng: FALLBACK_LANG,
         load: 'currentOnly',
         interpolation: {
             prefix: '{',
@@ -136,7 +137,13 @@ export default function i18nTranslator(pluginName, namespace) {
     const I18n = pluginI18next(pluginName, namespace);
 
     // Create and cache the translator instance.
-    translator = I18n.getFixedT(defaultLngDetector.detect(), namespace);
+    let detectedLang;
+    try {
+        detectedLang = defaultLngDetector.detect();
+    } catch (e) {
+        detectedLang = FALLBACK_LANG;
+    }
+    translator = I18n.getFixedT(detectedLang, namespace);
     translatorCache[translatorCacheKey] = translator;
 
     return translator;

--- a/blueocean-core-js/src/js/storage.js
+++ b/blueocean-core-js/src/js/storage.js
@@ -1,0 +1,123 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Client-side local storage for Blue Ocean.
+ * See https://tfennelly.github.io/jenkins-js-storage/
+ */
+
+import * as storage from '@jenkins-cd/storage';
+import { blueocean } from './scopes';
+import config from './config';
+
+export const jenkinsNS = storage.jenkinsNamespace();
+export const installInfo = jenkinsNS.subspace('installInfo');
+
+/**
+ * Check do we need to clear the jenkinsNS.
+ * <p>
+ * Simple process of checking if the version OR list of plugins
+ * stored (from the last change) have changed based on what was
+ * delivered with this page.
+ * <p>
+ * Internal use only. Exported for testing purposes only.
+ * @param {string} installVersion The version of the Jenkins instance that's running now
+ * i.e. that loaded this page.
+ * @param {Array} installPluginList The list of active plugins installed in the Jenkins instance
+ * that's running now i.e. that loaded this page.
+ * @private
+ */
+export const _clearJenkinsNS = (installVersion, installPluginList) => {
+    // Info about the Jenkins that was running the last time we loaded this page.
+    const storedVersion = installInfo.get('version');
+    const storedPluginList = installInfo.get('plugins');
+
+    const doClear = (because) => {
+        jenkinsNS.clear();
+        installInfo.set('version', installVersion);
+        installInfo.set('plugins', installPluginList);
+        installInfo.set('lastcleared', {
+            at: Date.now(),
+            because,
+        });
+    };
+
+    try {
+        if (storedVersion && storedPluginList) {
+            // compare the Jenkins version
+            if (installVersion !== storedVersion) {
+                doClear(`Jenkins versions did not match. installVersion: ${installVersion}, storedVersion: ${storedVersion}`);
+            } else {
+                // compare the plugin lists
+                if (installPluginList.length !== storedPluginList.length) {
+                    // Different number of active plugins.
+                    // No need to check the names and versions.
+                    doClear('Different number of active plugins');
+                } else {
+                    // Same number of plugins. Lets check that they all
+                    // match up i.e. that we can find each plugin in each list and
+                    // that the versions match.
+                    try {
+                        installPluginList.forEach((installedPlugin) => {
+                            let found = false;
+                            storedPluginList.forEach((storedPlugin) => {
+                                if (storedPlugin.hpiPluginId === installedPlugin.hpiPluginId) {
+                                    // same plugin.
+                                    found = true;
+                                    // Check the versions.
+                                    if (storedPlugin.hpiPluginVer !== installedPlugin.hpiPluginVer) {
+                                        throw new Error(`Different plugin versions for plugin ${installedPlugin.hpiPluginId}`);
+                                    }
+                                }
+                            });
+                            if (!found) {
+                                throw new Error(`New plugin installed ${installedPlugin.hpiPluginId}`);
+                            }
+                        });
+                    } catch (e) {
+                        // One of the plugins has been updated or removed.
+                        // See Errors thrown inside above try/catch.
+                        doClear(e.message);
+                    }
+                }
+            }
+        } else {
+            // Theoretically no need to clear in this case,
+            // but lets do it anyway.
+            doClear('No Jenkins info stored. Clearing anyway, just in case.');
+        }
+    } catch (e) {
+        console.error('Unexpected error while checking/clearing Jenkins instance client-side storage. Clearing as a precaution.', e);
+        doClear(`Unexpected error while checking/clearing Jenkins instance client-side storage: ${e.message}`);
+    }
+};
+
+// Call the clear function automatically.
+const installVersion = config.getJenkinsConfig().version;
+const installPluginList = blueocean.jsExtensions;
+if (installVersion && installPluginList) {
+    _clearJenkinsNS(installVersion, installPluginList);
+} else {
+    console.warn('Unexpected state. Blue Ocean preload state not on page as expected. This is okay if running in a test.');
+}

--- a/blueocean-core-js/test/js/capability/CapabilityStore-spec.js
+++ b/blueocean-core-js/test/js/capability/CapabilityStore-spec.js
@@ -6,6 +6,7 @@ import es6Promise from 'es6-promise'; es6Promise.polyfill();
 import sinon from 'sinon';
 
 import { CapabilityStore } from '../../../src/js/capability/CapabilityStore';
+import { jenkinsNS } from '../../../src/js/storage';
 
 const mockCapabilityApi = {
     fetchCapabilities: (classNames) => {
@@ -33,6 +34,9 @@ describe('CapabilityStore', () => {
     beforeEach(() => {
         capabilityStore = new CapabilityStore(mockCapabilityApi);
         fetchCapabilitiesSpy.reset();
+        // Clear the localStorage namespace, making sure the test
+        // REST API calls are not interfered with.
+        jenkinsNS.clear();
     });
 
     it('resolves capabilities for a single class', (done) => {

--- a/blueocean-core-js/test/js/storage-clear-spec.js
+++ b/blueocean-core-js/test/js/storage-clear-spec.js
@@ -1,0 +1,210 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { assert } from 'chai';
+import { jenkinsNS, _clearJenkinsNS } from '../../src/js/storage';
+
+/**
+ * Tests to make sure that the Jenkins StorageNamespace gets cleared out
+ * (or not) appropriately i.e. when the Jenkins version changes, or when the
+ * active plugin state changes (installs, updates, removals etc).
+ */
+
+describe('Storage Clearing', () => {
+    const installInfo = jenkinsNS.subspace('installInfo');
+
+    // A subspace for store some random things that should get
+    // wiped when the state of the server changes.
+    const magicNamespace = jenkinsNS.subspace('magicNamespace');
+
+    function version() {
+        return installInfo.get('version');
+    }
+    function plugins() {
+        return installInfo.get('plugins');
+    }
+    function lastcleared() {
+        return (installInfo.get('lastcleared') || { because: '??? lastcleared has not been set !!!' });
+    }
+
+    // Clear the state in case
+    jenkinsNS.clear();
+
+    /**
+     * Check that the currently stored Jenkins state is the same as
+     * the supplied state object.
+     * @param {object} stateObject The state object e.g. see t1State.
+     */
+    function assertState(stateObject) {
+        assert.equal(version(), stateObject.version, `Jenkins versions do not match. Last cleared because: "${lastcleared().because}"`);
+        assert.deepEqual(plugins(), stateObject.plugins, `Jenkins active plugins do not match. Last cleared because: "${lastcleared().because}"`);
+    }
+
+    function doClearCall(stateObject) {
+        _clearJenkinsNS(stateObject.version, stateObject.plugins);
+        assertState(stateObject);
+    }
+
+    function setMagicVal() {
+        magicNamespace.set('a', 'aval');
+    }
+    function assertMagicValIsSet() {
+        if (magicNamespace.get('a') !== 'aval') {
+            assert.fail(magicNamespace.get('a'), 'aval', `magicNamespace subspace has been cleared unexpectedly. Last cleared because: ${lastcleared().because}`);
+        }
+    }
+    function assertMagicValIsNotSet() {
+        if (magicNamespace.get('a')) {
+            assert.fail(magicNamespace.get('a'), undefined, `magicNamespace subspace has not been cleared out as expected. Last cleared because: ${lastcleared().because}`);
+        }
+    }
+    function assertLastClearBecause(because) {
+        assert.equal(lastcleared().because, because, 'lastcleared string not as expected.');
+    }
+
+    const t1State = {
+        version: '2.32.1',
+        plugins: [
+            { hpiPluginId: 'pluginA', hpiPluginVer: '1.0' },
+            { hpiPluginId: 'pluginB', hpiPluginVer: '1.0' },
+        ],
+    };
+
+    it('T1: 1st run in browser', () => {
+        // First run of course nothing is stored in the client-side
+        // storage, so the version should NOT be set.
+        assert.isUndefined(version());
+
+        doClearCall(t1State);
+        assertLastClearBecause('No Jenkins info stored. Clearing anyway, just in case.');
+    });
+
+    it('T2: 2nd run in browser - nothing changed on the server side => stored values the same', () => {
+        // store something in the magicNamespace
+        setMagicVal();
+        assertMagicValIsSet();
+
+        // Call _clearJenkinsNS with the same state values as with T1
+        doClearCall(t1State);
+        assertLastClearBecause('No Jenkins info stored. Clearing anyway, just in case.');
+
+        // The earlier value stored in the magicNamespace subspace should
+        // still be there, indicating the StorageNamespace was not cleared (as expected).
+        // See above.
+        assertMagicValIsSet();
+    });
+
+    const t3State = {
+        version: '2.33.0', // New Jenkins version
+        plugins: t1State.plugins,
+    };
+
+    it('T3: 3rd run in browser - new Jenkins version => should trigger state clearout', () => {
+        // Call _clearJenkinsNS with new state ... a new Jenkins version
+        doClearCall(t3State);
+        assertLastClearBecause('Jenkins versions did not match. installVersion: 2.33.0, storedVersion: 2.32.1');
+
+        // The the StorageNamespace should have been cleared (as expected).
+        assertMagicValIsNotSet();
+    });
+
+    it('T4: 4rd run in browser - nothing changed from last time ... clear should not happen', () => {
+        // Set the magic value again, call clear again with the same state as last time
+        setMagicVal();
+        doClearCall(t3State);
+        // clear shouldn't have happened and the magic value should still be there.
+        assertMagicValIsSet();
+    });
+
+    const t5State = {
+        version: t3State.version,
+        plugins: [
+            { hpiPluginId: 'pluginA', hpiPluginVer: '1.0' },
+            { hpiPluginId: 'pluginB', hpiPluginVer: '2.0' },
+        ],
+    };
+
+    it('T5: 5th run in browser - plugin version change ... clear should happen', () => {
+        // new state with a plugin version change
+        doClearCall(t5State);
+        // clear should have happened.
+        assertLastClearBecause('Different plugin versions for plugin pluginB');
+        assertMagicValIsNotSet();
+    });
+
+    it('T6: 6th run in browser - nothing changed ... clear should not happen', () => {
+        setMagicVal();
+        doClearCall(t5State);
+        assertLastClearBecause('Different plugin versions for plugin pluginB');
+        assertMagicValIsSet();
+    });
+
+    const t7State = {
+        version: t3State.version,
+        plugins: [
+            { hpiPluginId: 'pluginA', hpiPluginVer: '1.0' },
+            { hpiPluginId: 'pluginB', hpiPluginVer: '2.0' },
+            { hpiPluginId: 'pluginC', hpiPluginVer: '1.0' },
+        ],
+    };
+
+    it('T7: 7th run in browser - new plugin installed ... clear should happen', () => {
+        // new state with a new plugin
+        doClearCall(t7State);
+        // clear should have happened.
+        assertLastClearBecause('Different number of active plugins');
+        assertMagicValIsNotSet();
+    });
+
+    it('T8: 8th run in browser - nothing changed ... clear should not happen', () => {
+        setMagicVal();
+        doClearCall(t7State);
+        assertLastClearBecause('Different number of active plugins');
+        assertMagicValIsSet();
+    });
+
+    const t9State = {
+        version: t3State.version,
+        plugins: [
+            { hpiPluginId: 'pluginA', hpiPluginVer: '1.0' },
+            { hpiPluginId: 'pluginB', hpiPluginVer: '2.0' },
+            { hpiPluginId: 'pluginD', hpiPluginVer: '1.0' },
+        ],
+    };
+
+    it('T9: 9th run in browser - new plugin installed and plugin removed... clear should happen', () => {
+        // new state with a new plugin
+        doClearCall(t9State);
+        // clear should have happened.
+        assertLastClearBecause('New plugin installed pluginD');
+        assertMagicValIsNotSet();
+    });
+
+    it('T10: 10th run in browser - nothing changed ... clear should not happen', () => {
+        setMagicVal();
+        doClearCall(t9State);
+        assertLastClearBecause('New plugin installed pluginD');
+        assertMagicValIsSet();
+    });
+});

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.41",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.41",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.41.tgz",
+      "version": "0.0.42",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.42",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.42.tgz",
       "dependencies": {
         "@jenkins-cd/sse-gateway": {
           "version": "0.0.10",
@@ -68,6 +68,11 @@
       "version": "0.0.9",
       "from": "@jenkins-cd/sse-gateway@0.0.9",
       "resolved": "https://registry.npmjs.org/@jenkins-cd/sse-gateway/-/sse-gateway-0.0.9.tgz"
+    },
+    "@jenkins-cd/storage": {
+      "version": "0.0.3",
+      "from": "@jenkins-cd/storage@0.0.3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.3.tgz"
     },
     "@kadira/react-split-pane": {
       "version": "1.4.7",
@@ -5089,6 +5094,11 @@
           "dev": true
         }
       }
+    },
+    "localstorage-memory": {
+      "version": "1.0.2",
+      "from": "localstorage-memory@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz"
     },
     "lodash": {
       "version": "4.17.2",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.41",
+    "@jenkins-cd/blueocean-core-js": "0.0.42",
     "@jenkins-cd/design-language": "0.0.97",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.41",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.41",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.41.tgz",
+      "version": "0.0.42",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.42",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.42.tgz",
       "dependencies": {
         "react-router": {
           "version": "3.0.0",
@@ -55,6 +55,11 @@
       "version": "0.0.10",
       "from": "@jenkins-cd/sse-gateway@0.0.10",
       "resolved": "https://registry.npmjs.org/@jenkins-cd/sse-gateway/-/sse-gateway-0.0.10.tgz"
+    },
+    "@jenkins-cd/storage": {
+      "version": "0.0.3",
+      "from": "@jenkins-cd/storage@0.0.3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.3.tgz"
     },
     "@kadira/react-split-pane": {
       "version": "1.4.7",
@@ -5083,6 +5088,11 @@
           "dev": true
         }
       }
+    },
+    "localstorage-memory": {
+      "version": "1.0.2",
+      "from": "localstorage-memory@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz"
     },
     "lodash": {
       "version": "4.17.2",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.41",
+    "@jenkins-cd/blueocean-core-js": "0.0.42",
     "@jenkins-cd/design-language": "0.0.97",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/src/test/js/CapabilityTestUtils.js
+++ b/blueocean-personalization/src/test/js/CapabilityTestUtils.js
@@ -19,7 +19,7 @@ export class CapabilityTestUtils {
      * @param capabilities
      */
     bindCapability(className, ...capabilities) {
-        store._store[className] = [className, ...capabilities];
+        store._localStore[className] = [className, ...capabilities];
     }
 
     /**
@@ -34,8 +34,8 @@ export class CapabilityTestUtils {
         const classMap = augmenter._findClassesInTree(data);
 
         for (const className of Object.keys(classMap)) {
-            if (!store._store[className]) {
-                store._store[className] = [className];
+            if (!store._localStore[className]) {
+                store._localStore[className] = [className];
             }
         }
 
@@ -46,6 +46,6 @@ export class CapabilityTestUtils {
      * Unbinds all capabilities previously registered.
      */
     unbindAll() {
-        store._store = {};
+        store._localStore = {};
     }
 }

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.41",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.41",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.41.tgz",
+      "version": "0.0.42",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.42",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.42.tgz",
       "dependencies": {
         "history": {
           "version": "3.2.1",
@@ -60,6 +60,11 @@
       "version": "0.0.10",
       "from": "@jenkins-cd/sse-gateway@0.0.10",
       "resolved": "https://registry.npmjs.org/@jenkins-cd/sse-gateway/-/sse-gateway-0.0.10.tgz"
+    },
+    "@jenkins-cd/storage": {
+      "version": "0.0.3",
+      "from": "@jenkins-cd/storage@0.0.3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/storage/-/storage-0.0.3.tgz"
     },
     "acorn": {
       "version": "4.0.3",
@@ -3344,6 +3349,11 @@
       "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dev": true
+    },
+    "localstorage-memory": {
+      "version": "1.0.2",
+      "from": "localstorage-memory@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz"
     },
     "lodash": {
       "version": "4.17.2",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.41",
+    "@jenkins-cd/blueocean-core-js": "0.0.42",
     "@jenkins-cd/design-language": "0.0.97",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
# Description

.. and the infra for caching other data we might want and eliminate more backend calls.

See [JENKINS-40080](https://issues.jenkins-ci.org/browse/JENKINS-40080). This JIRA was a higher priority a few weeks ago but, for some reason, has dropped out completely now.

These changes eliminate all but the min calls to get class info from the backend by storing the class info in the browser `localStorage` (via a new [@jenkins-cd/storage](https://www.npmjs.com/package/@jenkins-cd/storage) package).

The main part of the changes though (and most interesting from a wider perspective) are the parts around the `localStorage` (see 2392247), how it's invalidated etc. These are bits of infra that we can use for caching other such data on the client and so eliminate more backend calls (e.g. localization data). The actual changes for caching the classes info were minimal (see 90397e2).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes. [ATH: master/781](https://ci.blueocean.io/job/ATH-Jenkinsfile/job/master/781/).

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
