### PR TITLE
[FIX JENKINS-39842] Open Blue Ocean button should not try to load /activity for a folder

### DIFF
--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -116,12 +116,8 @@ public class BlueOceanWebURLBuilder {
             return pipelineModelMapping.blueUiUrl + "/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId());
         } else if (classicModelObject instanceof Item) {
             Resource blueResource = BluePipelineFactory.resolve((Item) classicModelObject);
-            if (blueResource != null) {
-                if (blueResource instanceof BlueMultiBranchPipeline) {
-                    return getOrgPrefix() + "/" + encodeURIComponent(((BluePipeline) blueResource).getFullName()) + "/branches";
-                } else if (blueResource instanceof BluePipeline) {
-                    return getOrgPrefix() + "/" + encodeURIComponent(((BluePipeline) blueResource).getFullName());
-                }
+            if (blueResource instanceof BlueMultiBranchPipeline) {
+                return getOrgPrefix() + "/" + encodeURIComponent(((BluePipeline) blueResource).getFullName()) + "/branches";
             }
         }
 


### PR DESCRIPTION
# Description

See [JENKINS-39842](https://issues.jenkins-ci.org/browse/JENKINS-39842).

1. Create an MBP down inside a folder tree e.g. a/b/c.
1. Click on one of the folders on that tree (e.g. "b"), but not the MBP folder itself (the leaf folder).
1. Click on the "Open Blue Ocean" button.

Should bring the user to the main top-level pipelines page in BO Vs a blank page in BO, as is the case without the fix.

ATH Test PR: https://github.com/jenkinsci/blueocean-acceptance-test/pull/96

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
