### PR TITLE
[JENKINS-37604] API to get a link to the branch on Github

### DIFF
--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -21,12 +21,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>github-api</artifactId>
-      <version>1.82</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-organization-folder</artifactId>
       <version>1.5</version>
@@ -35,7 +29,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <version>1.8.1</version>
+      <version>2.0.0-beta-2</version>
     </dependency>
 
 

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.1</version>
+            <version>2.0.2-beta-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
-            <version>1.8.1</version>
+            <version>2.0.0-beta-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -13,12 +13,13 @@ import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import jenkins.branch.MultiBranchProject;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.actions.ChangeRequestAction;
+import jenkins.scm.api.metadata.ObjectMetadataAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.export.Exported;
 
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 
 /**
  * @author Vivek Pandey
@@ -27,6 +28,7 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW
 public class BranchImpl extends PipelineImpl {
 
     private static final String PULL_REQUEST = "pullRequest";
+    private static final String BRANCH = "branch";
 
     private final Link parent;
     protected final Job job;
@@ -47,6 +49,15 @@ public class BranchImpl extends PipelineImpl {
             }
         }
         return null;
+    }
+
+    @Exported(name = BRANCH)
+    public Branch getBranch() {
+        ObjectMetadataAction om = job.getAction(ObjectMetadataAction.class);
+        if (om == null) {
+            return null;
+        }
+        return new Branch(om.getObjectUrl() != null ? om.getObjectUrl() : null);
     }
 
     @Override
@@ -74,7 +85,22 @@ public class BranchImpl extends PipelineImpl {
         }
     }
 
-    public static class PullRequest extends Resource {
+    public static class Branch {
+        private static final String BRANCH_URL = "url";
+
+        private final String url;
+
+        public Branch(String url) {
+            this.url = url;
+        }
+
+        @Exported(name = BRANCH_URL)
+        public String getUrl() {
+            return url;
+        }
+    }
+
+    public static class PullRequest {
         private static final String PULL_REQUEST_NUMBER = "id";
         private static final String PULL_REQUEST_AUTHOR = "author";
         private static final String PULL_REQUEST_TITLE = "title";
@@ -116,11 +142,6 @@ public class BranchImpl extends PipelineImpl {
         @Exported(name = PULL_REQUEST_AUTHOR)
         public String getAuthor() {
             return author;
-        }
-
-        @Override
-        public Link getLink() {
-            return null;
         }
     }
 

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.2</version>
+            <version>2.0.2-beta-1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -228,12 +228,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>github-api</artifactId>
-            <version>1.72</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.oltu.oauth2</groupId>
             <artifactId>org.apache.oltu.oauth2.client</artifactId>
             <version>1.0.1</version>


### PR DESCRIPTION
# Description

API to get a link to the branch on Github. Not possible to write ATH as we do not have any live tests that work against Github and have provided a unit test instead.

See [JENKINS-37604](https://issues.jenkins-ci.org/browse/JENKINS-37604).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
