### PR TITLE
Do not return action proxies that are not exported beans

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -1,8 +1,10 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import com.google.common.base.Predicate;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.console.AnnotatedLargeText;
+import hudson.model.Action;
 import hudson.model.FileParameterValue;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
@@ -31,6 +33,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.framework.io.ByteBuffer;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.Reader;
@@ -134,7 +137,13 @@ public class PipelineStepImpl extends BluePipelineStep {
 
     @Override
     public Collection<BlueActionProxy> getActions() {
-        return ActionProxiesImpl.getActionProxies(node.getNode().getActions(), this);
+        // The LogAction is not @ExportedBean but we want to expose its subgraph
+        return ActionProxiesImpl.getActionProxies(node.getNode().getActions(), new Predicate<Action>() {
+            @Override
+            public boolean apply(@Nullable Action input) {
+                return input instanceof LogAction;
+            }
+        }, this);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -32,6 +32,7 @@ import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.json.JsonBody;
 import org.kohsuke.stapler.verb.DELETE;
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
@@ -1,6 +1,7 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import hudson.model.Action;
@@ -62,12 +63,31 @@ public class ActionProxiesImpl extends BlueActionProxy {
         return null;
     }
 
+    /**
+     * Finds all the actions and proxys them so long as they are annotated with ExportedBean
+     * @param actions to proxy
+     * @param parent reachable
+     * @return actionProxies
+     */
     public static Collection<BlueActionProxy> getActionProxies(List<? extends Action> actions, Reachable parent){
+        return getActionProxies(actions, Predicates.<Action>alwaysFalse(), parent);
+    }
+
+    /**
+     * Finds all the actions and proxys them so long as they are annotated with ExportedBean or match the provided predicate
+     * @param actions to proxy
+     * @param alwaysAllowAction predicate to positively filter
+     * @param parent reachable
+     * @return actionProxies
+     */
+    public static Collection<BlueActionProxy> getActionProxies(List<? extends Action> actions, final Predicate<Action> alwaysAllowAction, Reachable parent){
         List<BlueActionProxy> actionProxies = new ArrayList<>();
         for(Action action : Iterables.filter(actions, new Predicate<Action>() {
             @Override
             public boolean apply(Action action) {
-                return action != null && !BANNED_ACTIONS.contains(action.getClass().getName());
+                return action != null
+                    && (action.getClass().getAnnotation(ExportedBean.class) != null || alwaysAllowAction.apply(action))
+                    && !BANNED_ACTIONS.contains(action.getClass().getName());
             }
         })){
             actionProxies.add(new ActionProxiesImpl(action, parent));


### PR DESCRIPTION
On my test data it took a total of 245 ms (15.75KB) to load 48 runs. After this change it took 174ms (13.5KB) to load the same data **resulting in a 71% improvement**.

OOTB it reduces the amount of actions returned for a WorkflowRun BlueRun from 12 to 5.

# Description

See [JENKINS-40880](https://issues.jenkins-ci.org/browse/JENKINS-40880).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
