### PR TITLE
Hotfix/close modal goes to activity

### DIFF
--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.44-unpublished",
+  "version": "0.0.44-location1",
   "dependencies": {
     "@jenkins-cd/diag": {
       "version": "0.0.2",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.44-location1",
+  "version": "0.0.45-unpublished",
   "dependencies": {
     "@jenkins-cd/diag": {
       "version": "0.0.2",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.44-unpublished",
+  "version": "0.0.44-location1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.44-location1",
+  "version": "0.0.45-unpublished",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/services/LocationService.js
+++ b/blueocean-core-js/src/js/services/LocationService.js
@@ -1,7 +1,7 @@
 import { observable, action } from 'mobx';
 
 /**
- * Stores the previous and current pathnames.
+ * Stores the previous and current location pathnames.
  */
 export default class LocationService {
     @observable current;
@@ -9,7 +9,7 @@ export default class LocationService {
 
     @action setCurrent(newLocation) {
         if (newLocation.action !== 'REPLACE') {
-            this.current = this.previous;
+            this.previous = this.current;
         }
 
         this.current = newLocation.pathname;

--- a/blueocean-core-js/test/js/services/LocationService-spec.js
+++ b/blueocean-core-js/test/js/services/LocationService-spec.js
@@ -1,0 +1,79 @@
+import { assert } from 'chai';
+
+import LocationService from '../../../src/js/services/LocationService';
+
+/**
+ * Utility for creating location object passed to history.listen
+ * @param {string} action
+ * @param {string} pathname
+ * @returns {Object}
+ */
+function createLocation(pathname, action = 'PUSH') {
+    return {
+        action,
+        pathname,
+        search: '',
+        hash: '',
+        state: null,
+        key: 'mdrv0s',
+        basename: '/jenkins/blue',
+        query: {},
+        $searchBase: {
+            search: '',
+            searchBase: '',
+        },
+    };
+}
+
+describe('LocationService', () => {
+    let locationService;
+
+    beforeEach(() => {
+        locationService = new LocationService();
+    });
+
+    it('sets current after a route added', () => {
+        const loc = '/pipelines';
+        locationService.setCurrent(
+            createLocation(loc)
+        );
+
+        assert.isNotOk(locationService.previous);
+        assert.equal(locationService.current, loc);
+    });
+
+    it('sets previous after two routes added', () => {
+        const loc = '/pipelines';
+        locationService.setCurrent(
+            createLocation(loc)
+        );
+
+        const loc2 = '/organizations/jenkins/pipelines';
+        locationService.setCurrent(
+            createLocation(loc2)
+        );
+
+        assert.equal(locationService.previous, loc);
+        assert.equal(locationService.current, loc2);
+    });
+
+    it('handles the REPLACE scenario', () => {
+        const loc = '/pipelines';
+        locationService.setCurrent(
+            createLocation(loc)
+        );
+
+        const loc2 = '/organizations/jankins/pipeline-1/activity';
+        locationService.setCurrent(
+            createLocation(loc2)
+        );
+
+        const loc3 = '/organizations/jenkins/pipelines';
+        locationService.setCurrent(
+            createLocation(loc3, 'REPLACE')
+        );
+
+        assert.equal(locationService.previous, loc);
+        assert.equal(locationService.current, loc3);
+    });
+});

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.44-location1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
+      "version": "0.0.44",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44.tgz",
       "dependencies": {
         "@jenkins-cd/sse-gateway": {
           "version": "0.0.10",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.43",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.43",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.43.tgz",
+      "version": "0.0.44-location1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
       "dependencies": {
         "@jenkins-cd/sse-gateway": {
           "version": "0.0.10",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
+    "@jenkins-cd/blueocean-core-js": "0.0.44",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.43",
+    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.44-location1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
+      "version": "0.0.44",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44.tgz",
       "dependencies": {
         "react-router": {
           "version": "3.0.0",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.43",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.43",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.43.tgz",
+      "version": "0.0.44-location1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
       "dependencies": {
         "react-router": {
           "version": "3.0.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.43",
+    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
+    "@jenkins-cd/blueocean-core-js": "0.0.44",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.43",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.43",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.43.tgz",
+      "version": "0.0.44-location1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
       "dependencies": {
         "history": {
           "version": "3.2.1",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.44-location1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.44-location1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44-location1.tgz",
+      "version": "0.0.44",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.44",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.44.tgz",
       "dependencies": {
         "history": {
           "version": "3.2.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
+    "@jenkins-cd/blueocean-core-js": "0.0.44",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.43",
+    "@jenkins-cd/blueocean-core-js": "0.0.44-location1",
     "@jenkins-cd/design-language": "0.0.99",
     "@jenkins-cd/js-extensions": "0.0.32",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
# Description
Closing of the Run Modal was not navigating back to the previous route in many instances:
- Coming from the dashboard, after close it was navigating to /activity instead of dashboard
- Coming from /branches, closing was navigating to /activity
- Deep-linking directly to Run Details /pipeline then closing was navigating back to /activity correctly
- Deep-linking to Run Details with no tab specified then closing was navigating back to /activity correctly
- Verified the above scenarios. Wrote a few unit tests for the buggy code in question

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
