### PR TITLE
Use SCM API to determine "default" branch for favorite, weather, etc

### DIFF
--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -21,12 +21,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>github-api</artifactId>
-      <version>1.82</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-organization-folder</artifactId>
       <version>1.5</version>
@@ -35,7 +29,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <version>1.8.1</version>
+      <version>2.0.0-beta-2</version>
     </dependency>
 
 

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.1</version>
+            <version>2.0.2-beta-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
-            <version>1.8.1</version>
+            <version>2.0.0-beta-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -13,12 +13,13 @@ import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import jenkins.branch.MultiBranchProject;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.actions.ChangeRequestAction;
+import jenkins.scm.api.metadata.ObjectMetadataAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.export.Exported;
 
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 
 /**
  * @author Vivek Pandey
@@ -27,6 +28,7 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW
 public class BranchImpl extends PipelineImpl {
 
     private static final String PULL_REQUEST = "pullRequest";
+    private static final String BRANCH = "branch";
 
     private final Link parent;
     protected final Job job;
@@ -47,6 +49,15 @@ public class BranchImpl extends PipelineImpl {
             }
         }
         return null;
+    }
+
+    @Exported(name = BRANCH)
+    public Branch getBranch() {
+        ObjectMetadataAction om = job.getAction(ObjectMetadataAction.class);
+        if (om == null) {
+            return null;
+        }
+        return new Branch(om.getObjectUrl() != null ? om.getObjectUrl() : null);
     }
 
     @Override
@@ -74,7 +85,22 @@ public class BranchImpl extends PipelineImpl {
         }
     }
 
-    public static class PullRequest extends Resource {
+    public static class Branch {
+        private static final String BRANCH_URL = "url";
+
+        private final String url;
+
+        public Branch(String url) {
+            this.url = url;
+        }
+
+        @Exported(name = BRANCH_URL)
+        public String getUrl() {
+            return url;
+        }
+    }
+
+    public static class PullRequest {
         private static final String PULL_REQUEST_NUMBER = "id";
         private static final String PULL_REQUEST_AUTHOR = "author";
         private static final String PULL_REQUEST_TITLE = "title";
@@ -116,11 +142,6 @@ public class BranchImpl extends PipelineImpl {
         @Exported(name = PULL_REQUEST_AUTHOR)
         public String getAuthor() {
             return author;
-        }
-
-        @Override
-        public Link getLink() {
-            return null;
         }
     }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PrimaryBranch.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PrimaryBranch.java
@@ -1,0 +1,38 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import hudson.model.Job;
+import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public final class PrimaryBranch {
+    /**
+     * Resolves the primary branch for a folder
+     * @param folder to check within
+     * @return default branch
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    public static Job resolve(@Nonnull AbstractFolder folder) {
+        Job job = Iterables.find((Collection<Job>)folder.getAllJobs(), new Predicate<Job>() {
+            @Override
+            public boolean apply(@Nullable Job input) {
+                return input != null && input.getAction(PrimaryInstanceMetadataAction.class) != null;
+            }
+        }, null);
+        // Kept for backward compatibility for Git SCMs that do not yet implement PrimaryInstanceMetadataAction
+        if (job == null) {
+            job = (Job) folder.getJob(DEFAULT_BRANCH);
+        }
+        return job;
+    }
+
+    private static final String DEFAULT_BRANCH = "master";
+
+    private PrimaryBranch() {}
+}

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -20,6 +20,7 @@ import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
+import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.collection.IsArrayContainingInAnyOrder;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
@@ -51,6 +52,7 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_JOB;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -95,13 +97,16 @@ public class MultiBranchTest extends PipelineBaseTest {
 
 
     @Test
-    public void testGetURL() {
+    public void testBranchInfo() {
         Job job = mock(Job.class);
         BranchImpl branch = new BranchImpl(job, new Link("foo"));
         assertNull(branch.getBranch());
         ObjectMetadataAction oma = new ObjectMetadataAction("My Branch", "A feature branch", "https://path/to/branch");
         when(job.getAction(ObjectMetadataAction.class)).thenReturn(oma);
         assertEquals("https://path/to/branch", branch.getBranch().getUrl());
+        assertFalse(branch.getBranch().isPrimary());
+        when(job.getAction(PrimaryInstanceMetadataAction.class)).thenReturn(new PrimaryInstanceMetadataAction());
+        assertTrue(branch.getBranch().isPrimary());
     }
 
     @Test

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.2</version>
+            <version>2.0.2-beta-1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/FavoriteUtil.java
@@ -1,9 +1,6 @@
 package io.jenkins.blueocean.service.embedded.util;
 
-import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.model.Item;
-import hudson.model.Job;
-import hudson.model.TopLevelItem;
 import hudson.model.User;
 import hudson.plugins.favorite.Favorites;
 import hudson.plugins.favorite.Favorites.FavoriteException;
@@ -17,7 +14,6 @@ import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.service.embedded.rest.BlueFavoriteResolver;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
-import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
 import java.io.UnsupportedEncodingException;
@@ -27,8 +23,6 @@ import java.net.URLDecoder;
  * @author Ivan Meredith
  */
 public class FavoriteUtil {
-
-    private static final String DEFAULT_BRANCH = "master";
 
     public static void toggle(BlueFavoriteAction action, Item item) {
         if (action.isFavorite()) {
@@ -52,11 +46,6 @@ public class FavoriteUtil {
         } catch (UnsupportedEncodingException e) {
             throw new ServiceException.UnexpectedErrorException("Something went wrong URL decoding fullName: "+name, e);
         }
-    }
-
-    public static BlueFavorite getFavorite(String fullName, Reachable parent){
-        Item item = Jenkins.getInstance().getItem(fullName);
-        return getFavorite(item,parent);
     }
 
     public static BlueFavorite getFavorite(Item item){
@@ -101,23 +90,6 @@ public class FavoriteUtil {
         }
 
         return null;
-    }
-
-    /**
-     * Resolves the default branch for a folder
-     * @param folder to check within
-     * @return default branch
-     */
-    public static Job resolveDefaultBranch(AbstractFolder folder) {
-        // TODO: lookup the multibranch project and look for a default branch property
-        TopLevelItem job = folder.getJob(DEFAULT_BRANCH);
-        if(job == null) {
-            throw new ServiceException.BadRequestExpception("no master branch to favorite");
-        }
-        if (!(job instanceof Job)) {
-            throw new ServiceException.MethodNotAllowedException(DEFAULT_BRANCH + " is not a job");
-        }
-        return (Job) job;
     }
 
     private static User getUser() {

--- a/pom.xml
+++ b/pom.xml
@@ -228,12 +228,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.kohsuke</groupId>
-            <artifactId>github-api</artifactId>
-            <version>1.72</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.oltu.oauth2</groupId>
             <artifactId>org.apache.oltu.oauth2.client</artifactId>
             <version>1.0.1</version>


### PR DESCRIPTION
# Description

Use SCM API to determine default branch instead of looking for a branch named `master`

See [JENKINS-38718](https://issues.jenkins-ci.org/browse/JENKINS-38718).

Depends on https://github.com/jenkinsci/blueocean-plugin/pull/686

PTAL @vivek 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
