### PR TITLE
[JENKINS-36975] Show admin link at the correct times

### DIFF
--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -33,6 +33,27 @@ function loginOrLogout(t) {
         }
     }
 }
+
+// Show link when only when someone is logged in...unless security is not configured,
+// then show it anyway.
+const AdminLink = (props) => {
+    const { t } = props;
+    const showLink = !Security.isSecurityEnabled() || !Security.isAnonymousUser();
+
+    if (showLink) {
+        var adminCaption = t('administration', {
+            defaultValue: 'Administation',
+        });
+        return <a href={`${UrlConfig.getJenkinsRootURL()}/manage`}>{adminCaption}</a>;          
+    }
+
+    return null;
+};
+
+AdminLink.propTypes = {
+    t: PropTypes.func,
+};
+
 /**
  * Root Blue Ocean UI component
  */
@@ -45,9 +66,6 @@ class App extends Component {
     render() {
         const { location } = this.context;
 
-        var adminCaption = translate('administration', {
-            defaultValue: 'Administation',
-        });
         var pipeCaption = translate('pipelines', {
             defaultValue: 'Pipelines',
         });
@@ -58,7 +76,7 @@ class App extends Component {
                         <Extensions.Renderer extensionPoint="jenkins.logo.top"/>
                         <nav>
                             <Link query={location.query} to="/pipelines">{pipeCaption}</Link>
-                            <a href="#">{adminCaption}</a>
+                            <AdminLink t={translate} />
                         </nav>
                         <div className="button-bar layout-small inverse">
                             { loginOrLogout(translate) }


### PR DESCRIPTION
# Description

'Administration' Link now links to /manage. IT only shows if user is logged in OR if security is disabled (and therefore anyone can access it).

No ATH changes as we cant log in with ath at this time.

See [JENKINS-36975](https://issues.jenkins-ci.org/browse/JENKINS-36975).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
