### PR TITLE
don't try to run npm, it's not available in official jenkins image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,4 @@ RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.jpi; do mv "$f" "$f.over
 # let scripts customize the reference Jenkins folder. Used in bin/build-in-docker to inject the git build data
 COPY docker/ref /usr/share/jenkins/ref
 
-RUN npm install -g npm@3.10.9
-
 USER jenkins


### PR DESCRIPTION
This should fix the PR deployer which is failing to build Docker images because `npm` is not available in standard Jenkins image.

Regression introduced in #665

@reviewbybees @michaelneale @cliffmeyers 
