### PR TITLE
JENKINS-40466# Reflect cause of blockage in synthetic step

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -286,7 +286,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         String cause=null;
         try {
             cause = PipelineNodeUtil.getCauseOfBlockage(chunk.getFirstNode(), agentNode, run);
-            status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.QUEUED);
+            if(cause!=null) {
+                status = new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.QUEUED);
+            }
         } catch (IOException | InterruptedException e) {
             //log the error but don't fail. This is better as in worst case all we will lose is blockage cause of a node.
             logger.error(String.format("Error trying to get blockage status of pipeline: %s, runId: %s node block: %s. %s"

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
@@ -1,8 +1,11 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import com.google.common.collect.ImmutableList;
 import io.jenkins.blueocean.rest.model.BlueRun;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner;
@@ -28,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Gives steps inside
@@ -56,6 +60,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
     private ArrayDeque<String> stages = new ArrayDeque<>();
     private InputAction inputAction;
     private StepEndNode closestEndNode;
+    private StepStartNode agentNode = null;
 
     private static final Logger logger = LoggerFactory.getLogger(PipelineStepVisitor.class);
 
@@ -104,6 +109,12 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
             this.stageStepsCollectionCompleted = false;
             this.inStageScope = true;
         }
+
+        if(endNode instanceof StepStartNode){
+            if(endNode.getDisplayFunctionName().equals("node")){
+                agentNode = (StepStartNode) endNode;
+            }
+        }
         // if we're using marker-based (and not block-scoped) stages, add the last node as part of its contents
         if (!(endNode instanceof BlockEndNode)) {
             atomNode(null, endNode, afterChunk, scanner);
@@ -119,6 +130,27 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
         if(node != null && chunk.getFirstNode().equals(node)){
             stageStepsCollectionCompleted = true;
             inStageScope = false;
+            try {
+                final String cause = PipelineNodeUtil.getCauseOfBlockage(chunk.getFirstNode(), agentNode, run);
+                if(cause != null) {
+                    //Now add a step that indicates bloackage cause
+                    FlowNode step = new AtomNode(chunk.getFirstNode().getExecution(), UUID.randomUUID().toString(), chunk.getFirstNode()) {
+
+                        @Override
+                        protected String getTypeDisplayName() {
+                            return cause;
+                        }
+                    };
+
+                    FlowNodeWrapper stepNode = new FlowNodeWrapper(step, new NodeRunStatus(BlueRun.BlueRunResult.UNKNOWN, BlueRun.BlueRunState.QUEUED),new TimingInfo(), run);
+                    steps.push(stepNode);
+                    stepMap.put(step.getId(), stepNode);
+                }
+            } catch (IOException | InterruptedException e) {
+                //log the error but don't fail. This is better as in worst case all we will lose is blockage cause of a node.
+                logger.error(String.format("Error trying to get blockage status of pipeline: %s, runId: %s node block: %s. %s"
+                        ,run.getParent().getFullName(), run.getId(), agentNode, e.getMessage()), e);
+            }
         }if(node != null && PipelineNodeUtil.isStage(node) && !inStageScope && !chunk.getFirstNode().equals(node)){
             resetSteps();
         }


### PR DESCRIPTION
# Description

See [JENKINS-40466](https://issues.jenkins-ci.org/browse/JENKINS-40466).

I tried this script:

```
pipeline {
  agent none
  stages {
    stage ('first') {
     agent { 
      label 'first' 
     }
     steps{
          sh 'echo "from first"'
      }
    }
  }
}
```

GET http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/:pipelineId/runs/:runId/nodes/

```
[
   {
      "state" : "QUEUED",
      "result" : "UNKNOWN",
      "startTime" : "2017-01-10T13:35:30.688-0800",
      "id" : "4",
      "actions" : [],
      "_links" : {},
      "durationInMillis" : 8690535,
      "causeOfBlockage" : "Waiting for next available executor",
      "_class" : "io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeImpl",
      "displayName" : "first",
      "edges" : [],
      "input" : null
   }
]
```

![image](https://cloud.githubusercontent.com/assets/38139/22081161/51d4d2ba-dd77-11e6-95a2-807d9bbaf6cd.png)


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 