### PR TITLE
GH avatar sizes

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
@@ -21,7 +21,7 @@ public abstract class AbstractGithubOrganization extends ScmOrganization {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractGithubOrganization.class.getName());
 
-    static final int AVATAR_SIZE = 50;
+    private static final int AVATAR_SIZE = 50;
 
     @Override
     public boolean isJenkinsOrganizationPipeline() {
@@ -43,7 +43,7 @@ public abstract class AbstractGithubOrganization extends ScmOrganization {
     }
 
     @Nullable
-    static String getAvatarWithSize(@Nonnull String avatarUrl) {
+    private static String getAvatarWithSize(@Nonnull String avatarUrl) {
         try {
             return new URIBuilder(avatarUrl).addParameter("s", Integer.toString(AVATAR_SIZE)).build().toString();
         } catch (URISyntaxException e) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
@@ -43,7 +43,7 @@ public abstract class AbstractGithubOrganization extends ScmOrganization {
     }
 
     @Nullable
-    private static String getAvatarWithSize(@Nonnull String avatarUrl) {
+    protected static String getAvatarWithSize(@Nonnull String avatarUrl) {
         try {
             return new URIBuilder(avatarUrl).addParameter("s", Integer.toString(AVATAR_SIZE)).build().toString();
         } catch (URISyntaxException e) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/AbstractGithubOrganization.java
@@ -5,12 +5,23 @@ import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmOrganization;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMNavigator;
+import org.apache.http.client.utils.URIBuilder;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Vivek Pandey
  */
 public abstract class AbstractGithubOrganization extends ScmOrganization {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractGithubOrganization.class.getName());
+
+    static final int AVATAR_SIZE = 50;
 
     @Override
     public boolean isJenkinsOrganizationPipeline() {
@@ -29,5 +40,15 @@ public abstract class AbstractGithubOrganization extends ScmOrganization {
         }
         return false;
 
+    }
+
+    @Nullable
+    static String getAvatarWithSize(@Nonnull String avatarUrl) {
+        try {
+            return new URIBuilder(avatarUrl).addParameter("s", Integer.toString(AVATAR_SIZE)).build().toString();
+        } catch (URISyntaxException e) {
+            LOGGER.log(Level.WARNING, "Could not parse avatar URL <" + avatarUrl + ">", e);
+            return null;
+        }
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganization.java
@@ -30,7 +30,7 @@ public class GithubOrganization extends AbstractGithubOrganization {
 
     @Override
     public String getAvatar() {
-        return ghOrganization.getAvatarUrl();
+        return getAvatarWithSize(ghOrganization.getAvatarUrl());
     }
 
     @Override

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubUserOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubUserOrganization.java
@@ -29,7 +29,7 @@ public class GithubUserOrganization  extends AbstractGithubOrganization{
 
     @Override
     public String getAvatar() {
-        return user.getAvatarUrl();
+        return getAvatarWithSize(user.getAvatarUrl());
     }
 
     @Override


### PR DESCRIPTION
# Description

Only serve up github avatars at 50x50px to reduce size. As @cliffmeyers discovered some avatars can be unreasonably big.

PTAL @vivek @cliffmeyers 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
