### PR TITLE
JENKINS-41159# Karaoke bug fix - disappearing parallels

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -12,8 +12,8 @@ import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import io.jenkins.blueocean.rest.model.BlueInputStep;
 import io.jenkins.blueocean.rest.model.BluePipelineStep;
 import io.jenkins.blueocean.rest.model.BlueRun;
-import io.jenkins.blueocean.service.embedded.rest.LogAppender;
 import io.jenkins.blueocean.service.embedded.rest.ActionProxiesImpl;
+import io.jenkins.blueocean.service.embedded.rest.LogAppender;
 import io.jenkins.blueocean.service.embedded.rest.LogResource;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
@@ -93,7 +93,8 @@ public class PipelineStepImpl extends BluePipelineStep {
     public Object getLog() {
         if(PipelineNodeUtil.isLoggable.apply(node.getNode())){
             if(node.getBlockErrorAction() != null
-                    && node.getBlockErrorAction().getError() != null){
+                    && node.getBlockErrorAction().getError() != null &&
+                    node.getBlockErrorAction().getError().getMessage() != null){
                 return new LogResource(node.getNode().getAction(LogAction.class).getLogText(), new LogAppender() {
                     @Nonnull
                     @Override


### PR DESCRIPTION
Bug was in union of nodes, specifically if current dag is partial and
current node is a parallel then it's edges were not stiched properly
with projected future nodes.

There is also NPE and other minor fixes.

# Description

See [JENKINS-41159](https://issues.jenkins-ci.org/browse/JENKINS-41159).

Try this pipeline: https://github.com/i386/app-store-demo and see karaoke on new build and multiple builds. 

You might notice ""Declarative: Checkout SCM"" stage appear instead of 'Build' node, there is a bug in declarative plugin where this stage added by declarative plugin has missing SYNTHETIC_STAGE TagAction, this causes API to return the DAG.   An issue has been opened to take care of this issue: https://issues.jenkins-ci.org/browse/JENKINS-41243

@scherler, @michaelneale, @i386 PTAL. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
