### PR TITLE
JENKINS-41285 API to retrieve organization folder avatar

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -16,6 +16,7 @@ import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteAction;
+import io.jenkins.blueocean.rest.model.BlueIcon;
 import io.jenkins.blueocean.rest.model.BlueMultiBranchPipeline;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineContainer;
@@ -479,6 +480,11 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
 
     @Override
     public List<Object> getParameters() {
+        return null;
+    }
+
+    @Override
+    public BlueIcon getIcon() {
         return null;
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -10,6 +10,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteAction;
+import io.jenkins.blueocean.rest.model.BlueIcon;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineContainer;
 import io.jenkins.blueocean.rest.model.BluePipelineFolder;
@@ -28,7 +29,7 @@ import java.util.Map;
 public class PipelineFolderImpl extends BluePipelineFolder {
 
     private final ItemGroup folder;
-    private final Link parent;
+    protected final Link parent;
 
     public PipelineFolderImpl(ItemGroup folder, Link parent) {
         this.folder = folder;
@@ -154,5 +155,10 @@ public class PipelineFolderImpl extends BluePipelineFolder {
             }
             return null;
         }
+    }
+
+    @Override
+    public BlueIcon getIcon() {
+        return null;
     }
 }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueIcon.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueIcon.java
@@ -1,0 +1,11 @@
+package io.jenkins.blueocean.rest.model;
+
+import io.jenkins.blueocean.rest.Navigable;
+
+public abstract class BlueIcon extends Resource {
+
+    public static final int DEFAULT_ICON_SIZE = 20;
+
+    @Navigable
+    public abstract void getUrl();
+}

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineFolder.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineFolder.java
@@ -3,8 +3,8 @@ package io.jenkins.blueocean.rest.model;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import org.kohsuke.stapler.export.Exported;
 
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_ABSTRACT_FOLDER;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE_FOLDER;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_ABSTRACT_FOLDER;
 
 /**
  * Folder  has pipelines, could also hold another BluePipelineFolders.
@@ -99,5 +99,6 @@ public abstract class BluePipelineFolder extends BluePipeline {
         return null;
     }
 
-
+    @Exported(skipNull = true)
+    public abstract BlueIcon getIcon();
 }


### PR DESCRIPTION
# Description

`curl http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/cloudbeers/icon/url/?s=50` will redirect to the Github organization avatar URL with an image 50x50px. Caches for 7 days.

Requires SCM 2.0 API

See [JENKINS-41285](https://issues.jenkins-ci.org/browse/JENKINS-41285).

PTAL @vivek @cliffmeyers 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
