### PR TITLE
Fix spelling of Administration

### DIFF
--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -42,7 +42,7 @@ const AdminLink = (props) => {
 
     if (showLink) {
         var adminCaption = t('administration', {
-            defaultValue: 'Administation',
+            defaultValue: 'Administration',
         });
         return <a href={`${UrlConfig.getJenkinsRootURL()}/manage`}>{adminCaption}</a>;          
     }


### PR DESCRIPTION
Correct the default spelling of Administration navigation menu.