### PR TITLE
[betterCleanInstall] Allow to pass the full version string as input p…

### DIFF
--- a/bin/cleanInstall.js
+++ b/bin/cleanInstall.js
@@ -7,20 +7,7 @@ const prompt = require('prompt');
 
 const start = new Date().getTime();
 const directories = ['../blueocean-dashboard', '../blueocean-personalization', '../blueocean-web'];
-
-prompt.start();
-prompt.get({
-    properties: {
-        package: {
-            message: `PACKAGE to install?`,
-            required: true,
-        },
-        version: {
-            message: `VERSION to install?`,
-            required: true,
-        }
-    }
-}, function (err, result) {
+function invokeInstall(err, result) {
     // Log the results.
     console.log('Command-line input received:');
     console.log('package: ' + result.package);
@@ -38,8 +25,33 @@ prompt.get({
         console.log(`Install look good! took ${ellapsed}ms`);
         process.exit(0);
     });
-});
-
+}
+if (process.argv[2]) {
+  const versionArray = process.argv[2].split('@');
+  const result = {};
+  if (versionArray.length > 2) {
+    result.package = "@" + versionArray[1];
+    result.version = versionArray[2];
+  } else {
+    result.package = versionArray[0];
+    result.version = versionArray[1];
+  }
+  invokeInstall(null, result);
+} else {
+  prompt.start();
+  prompt.get({
+      properties: {
+          package: {
+              message: `PACKAGE to install?`,
+              required: true,
+          },
+          version: {
+              message: `VERSION to install?`,
+              required: true,
+          }
+      }
+  }, invokeInstall);
+}
 function buildPath(path) {
     try {
         return fs.realpathSync(path);
@@ -76,7 +88,7 @@ function deleteFolderRecursive(path) {
 }
 function install(packages, callback) {
     console.log('installing ', packages);
-    const child = exec('npm install ' + packages + ' --save -E',
+    const child = exec('npm prune; npm install; npm install ' + packages + ' --save -E; mvn clean install -DskipTests',
         function (error, stdout, stderr) {
             if (error !== null) {
                 callback(error);

--- a/bin/cleanInstall.js
+++ b/bin/cleanInstall.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
-
+/**
+ * This script will install the package and version you want in the directories
+ * that are defined in below array. It accept a full version string
+ * e.g. @jenkins-cd/design-language@0.0.105-TimePrecise
+ * as input and if you do not provide that it will start a prompt.
+ *
+ * We will prune and install BEFORE we install the requested version to make sure that
+ * shrinkwrap will update correctly everytime. We further do a mvn install afterwards
+ * to publish the new hpi to the local .m2 repository
+ */
 const fs = require('fs');
 const async = require('async');
 const exec = require('child_process').exec;


### PR DESCRIPTION
…arameter and skip the dialog with it. Make sure we produce always valid npm-shrinkwrap changes by first prune and install and later publish the libs to maven snapshot

# Description

Better cleanInstall: 
- Allow to pass the full version string as input parameter and skip the dialog with it. 
- Make sure we produce always valid npm-shrinkwrap changes by first prune and install and later publish the libs to maven snapshot

@reviewbybees 
