### PR TITLE
[FIX JENKINS-41487] Hotfix --- 1.6 and 1.15 of the pubsub and sse-gateway plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,12 +218,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pubsub-light</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.14</version>
+            <version>1.15</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Description

pubsub 1.5 of pubsub was not appearing in the update centre because its pom was missing a `<url>` setting.

See [JENKINS-41487](https://issues.jenkins-ci.org/browse/JENKINS-41487).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
