### PR TITLE
[FIX-JENKINS-41053] error in personalization when selecting job with no runs

### DIFF
--- a/blueocean-personalization/src/main/js/components/DashboardCards.jsx
+++ b/blueocean-personalization/src/main/js/components/DashboardCards.jsx
@@ -67,7 +67,7 @@ export class DashboardCards extends Component {
                   />
               </div>);
               // if we are in paused state fill the pause array and return null
-              if (favorite.item.latestRun.state === 'PAUSED') {
+              if (favorite.item.latestRun && favorite.item.latestRun.state === 'PAUSED') {
                   pausedCards.push(responseElement);
                   return null;
               }

--- a/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
+++ b/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
@@ -8,6 +8,47 @@ import { shallow } from 'enzyme';
 import { DashboardCards } from '../../../main/js/components/DashboardCards';
 import { CapabilityTestUtils } from '../CapabilityTestUtils';
 
+const noLatestRun = [{
+    "_class": "io.jenkins.blueocean.service.embedded.rest.FavoriteImpl",
+    "_links": {
+        "self": {
+            "_class": "io.jenkins.blueocean.rest.hal.Link",
+            "href": "/blue/rest/users/cmeyers/favorites/jdl2%252Fdocker-test/"
+        }
+    },
+    "item": {
+        "_class": "io.jenkins.blueocean.rest.impl.pipeline.BranchImpl",
+        "_links": {
+            "self": {
+                "_class": "io.jenkins.blueocean.rest.hal.Link",
+                "href": "/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/"
+            },
+            "actions": {
+                "_class": "io.jenkins.blueocean.rest.hal.Link",
+                "href": "/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/actions/"
+            },
+            "runs": {
+                "_class": "io.jenkins.blueocean.rest.hal.Link",
+                "href": "/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/runs/"
+            },
+            "queue": {
+                "_class": "io.jenkins.blueocean.rest.hal.Link",
+                "href": "/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/queue/"
+            }
+        },
+        "actions": [],
+        "displayName": "docker-test",
+        "estimatedDurationInMillis": 390126,
+        "fullDisplayName": "jdl2/docker-test",
+        "fullName": "jdl2/docker-test",
+        "lastSuccessfulRun": "http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/jdl2/branches/docker-test/runs/3/",
+        "name": "docker-test",
+        "organization": "jenkins",
+        "weatherScore": 100,
+        "pullRequest": null
+    }
+}];
+
 describe('DashboardCards', () => {
     let favorites;
     let testUtils;
@@ -32,6 +73,13 @@ describe('DashboardCards', () => {
     it('renders without error for empty props', () => {
         const wrapper = shallow(
             <DashboardCards />
+        );
+
+        assert.isOk(wrapper);
+    });
+    it.only('renders without error for favorites props that has empty latestRun', () => {
+        const wrapper = shallow(
+            <DashboardCards favorites={noLatestRun}/>
         );
 
         assert.isOk(wrapper);

--- a/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
+++ b/blueocean-personalization/src/test/js/components/DashboardCards-spec.jsx
@@ -77,7 +77,7 @@ describe('DashboardCards', () => {
 
         assert.isOk(wrapper);
     });
-    it.only('renders without error for favorites props that has empty latestRun', () => {
+    it('renders without error for favorites props that has empty latestRun', () => {
         const wrapper = shallow(
             <DashboardCards favorites={noLatestRun}/>
         );


### PR DESCRIPTION
# Description

See [JENKINS-41053](https://issues.jenkins-ci.org/browse/JENKINS-41053).

Fix bug when favorite had no previous run and add unit test for that case

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
