### PR TITLE
[FIX-JENKINS-41340-Favorite_header_on_dashboard_is_still_visible_when_the…

### DIFF
--- a/blueocean-personalization/src/main/js/components/DashboardCards.jsx
+++ b/blueocean-personalization/src/main/js/components/DashboardCards.jsx
@@ -93,10 +93,10 @@ export class DashboardCards extends Component {
           message={t('dashboardCard.input.required', { defaultValue: 'Input required' })}
           cards={pausedCards}
         />) : null;
-        const favoriteCardsStack = (<StackOutput
+        const favoriteCardsStack = favoriteCards.size > 0 ? (<StackOutput
           message={t('dashboardCard.input.favorite', { defaultValue: 'Favorites' })}
           cards={favoriteCards}
-        />);
+        />) : null;
 
         return (
             <FavoritesProvider store={this.props.store}>

--- a/blueocean-personalization/src/main/less/extensions.less
+++ b/blueocean-personalization/src/main/less/extensions.less
@@ -9,6 +9,8 @@
 
     .favorites-card-stack-heading {
         margin-bottom: 8px;
+        font-size: 14px;
+        font-weight: 600;
     }
 
     .pipeline-card {


### PR DESCRIPTION
…re_are_no_favourites] do not show the favoriteCardsStack if no favorites are selected

# Description

See [JENKINS-41340](https://issues.jenkins-ci.org/browse/JENKINS-41340).

Used https://app.zeplin.io/project.html#pid=57eb0b8835431a24309f0d6d&sid=57eb4165928941b44adec613

![screenshot from 2017-01-27 13-27-48](https://cloud.githubusercontent.com/assets/596701/22371128/8dfd8280-e495-11e6-8e9e-fdcf363cdbd4.png)
![screenshot from 2017-01-27 13-27-06](https://cloud.githubusercontent.com/assets/596701/22371129/8e008ca0-e495-11e6-8275-d2ff14af2334.png)



# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
