### PR TITLE
[JENKINS-39345] Async bundle startup scripts

### DIFF
--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta4",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
+      "version": "0.0.52-tfbeta5",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {
@@ -294,9 +294,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -384,9 +384,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -552,9 +552,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -688,9 +688,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -752,9 +752,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -816,9 +816,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -992,9 +992,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1056,9 +1056,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1120,9 +1120,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1184,9 +1184,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1268,9 +1268,9 @@
           "dev": true
         },
         "js-tokens": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "from": "js-tokens@^3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "dev": true
         },
         "regenerator-runtime": {

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta5",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
+      "version": "0.0.52",
+      "from": "@jenkins-cd/js-builder@0.0.52",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta3",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
+      "version": "0.0.52-tfbeta4",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta1",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
+      "version": "0.0.52-tfbeta2",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta2",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
+      "version": "0.0.52-tfbeta3",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {
@@ -3082,9 +3082,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.2.0",
+      "version": "3.2.2",
       "from": "ignore@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.2.tgz",
       "dev": true
     },
     "imurmurhash": {

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.51",
-      "from": "@jenkins-cd/js-builder@0.0.51",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.51.tgz",
+      "version": "0.0.52-tfbeta1",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {
@@ -54,9 +54,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "ajv-keywords@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "dev": true
     },
     "align-text": {

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.51",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
+    "@jenkins-cd/js-builder": "0.0.52",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/src/main/java/io/jenkins/blueocean/config/JenkinsJSExtensions.java
+++ b/blueocean-config/src/main/java/io/jenkins/blueocean/config/JenkinsJSExtensions.java
@@ -145,20 +145,22 @@ public class JenkinsJSExtensions {
                         }
 
                         List<Map> extensions = (List<Map>) extensionData.get(PLUGIN_EXT);
-                        for (Map extension : extensions) {
-                            try {
-                                String type = (String) extension.get("type");
-                                if (type != null) {
-                                    BlueExtensionClassContainer extensionClassContainer
-                                        = Jenkins.getInstance().getExtensionList(BlueExtensionClassContainer.class).get(0);
-                                    Map classInfo = (Map) mergeObjects(extensionClassContainer.get(type));
-                                    List classInfoClasses = (List) classInfo.get("_classes");
-                                    classInfoClasses.add(0, type);
-                                    extension.put("_class", type);
-                                    extension.put("_classes", classInfoClasses);
+                        if (extensions != null) {
+                            for (Map extension : extensions) {
+                                try {
+                                    String type = (String) extension.get("type");
+                                    if (type != null) {
+                                        BlueExtensionClassContainer extensionClassContainer
+                                            = Jenkins.getInstance().getExtensionList(BlueExtensionClassContainer.class).get(0);
+                                        Map classInfo = (Map) mergeObjects(extensionClassContainer.get(type));
+                                        List classInfoClasses = (List) classInfo.get("_classes");
+                                        classInfoClasses.add(0, type);
+                                        extension.put("_class", type);
+                                        extension.put("_classes", classInfoClasses);
+                                    }
+                                } catch (Exception e) {
+                                    LOGGER.error("An error occurred when attempting to read type information from jenkins-js-extension.json from: " + dataRes, e);
                                 }
-                            } catch (Exception e) {
-                                LOGGER.error("An error occurred when attempting to read type information from jenkins-js-extension.json from: " + dataRes, e);
                             }
                         }
 

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta1",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta1.tgz"
+      "version": "0.0.33-tfbeta2",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.54",
+  "version": "0.0.55-tfbeta2",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.102",
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta2",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta2.tgz"
+      "version": "0.0.33-tfbeta3",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta4",
+  "version": "0.0.55-tfbeta5",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.102",
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta5",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
+      "version": "0.0.33",
+      "from": "@jenkins-cd/js-extensions@0.0.33",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.54-unpublished",
+  "version": "0.0.54",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.102",
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.32",
-      "from": "@jenkins-cd/js-extensions@0.0.32",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+      "version": "0.0.33-tfbeta1",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta1.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -439,9 +439,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.2",
-      "from": "ast-types@0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
+      "version": "0.9.4",
+      "from": "ast-types@0.9.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.4.tgz"
     },
     "astw": {
       "version": "2.0.0",
@@ -6607,14 +6607,14 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "from": "recast@>=0.11.17 <0.12.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.20.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         }
       }
     },

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta2",
+  "version": "0.0.55-tfbeta3",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.102",
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta3",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
+      "version": "0.0.33-tfbeta4",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta3",
+  "version": "0.0.55-tfbeta4",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.102",
@@ -21,9 +21,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta4",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
+      "version": "0.0.33-tfbeta5",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.54",
+  "version": "0.0.55-tfbeta1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
+    "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.32",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta2",
+  "version": "0.0.55-tfbeta3",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta5",
+  "version": "0.0.55",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta3",
+  "version": "0.0.55-tfbeta4",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta1",
+  "version": "0.0.55-tfbeta2",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.55-tfbeta4",
+  "version": "0.0.55-tfbeta5",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.102",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",

--- a/blueocean-core-js/src/js/config.js
+++ b/blueocean-core-js/src/js/config.js
@@ -22,6 +22,10 @@ export default {
         return this.getSecurityConfig().loginUrl;
     },
 
+    getPluginInfo(pluginId) {
+        return blueocean.jsExtensions.find((pluginInfo) => pluginInfo.hpiPluginId === pluginId);
+    },
+
     /**
      * Set a new "jenkinsConfig" object.
      * Useful for testing in a headless environment.

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -60,7 +60,7 @@ export function execute(done, bundleConfig) {
                         }
                     });
                     // Call the translator to trigger loading.
-                    // Don't specify a key.
+                    // Any random key is fine ... just needs to trigger the loading.
                     translator('xxxx');
                 };
                 pluginInfo.i18nBundles.forEach((bundleNamespace) => loadBundle(bundleNamespace));

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Client bundle startup script for loading i18n resources.
+ * <p>
+ * Ensures that i18n resources are loaded before the bundle starts to execute.
+ */
+
+/**
+ * Load the i18n resources defined for the plugin (in the extensions).
+ *
+ * @param {function} done Callback function. Called once all resources.
+ * @param {object} config Bundle configuration parameters.
+ */
+export function execute(done, config) {
+    if (config.hpiPluginId) {
+        console.log(`**** i18n bundles loaded for ${config.hpiPluginId}`);
+        done();
+    } else {
+        done();
+    }
+}

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -30,7 +30,6 @@
 
 import config from '../config';
 import logging from '../logging';
-import i18nTranslator from './i18n';
 
 const logger = logging.logger('io.jenkins.blueocean.i18n.startup');
 
@@ -44,31 +43,13 @@ export function execute(done, bundleConfig) {
     if (bundleConfig.hpiPluginId) {
         const pluginInfo = config.getPluginInfo(bundleConfig.hpiPluginId);
         if (pluginInfo) {
-            //if (pluginInfo.i18nBundles && pluginInfo.i18nBundles.length > 0) {
-            //    logger.debug(`Plugin ${bundleConfig.hpiPluginId} defines i18n resource bundles that must be loaded:`, pluginInfo.i18nBundles);
-            //    const loadedBundles = [];
-            //    function loadBundle(namespace) {
-            //        const translator = i18nTranslator(bundleConfig.hpiPluginId, namespace, () => {
-            //            if (loadedBundles.indexOf(namespace) === -1) {
-            //                logger.debug(`Loading of resource bundle ${bundleConfig.hpiPluginId}:${namespace} done.`);
-            //                loadedBundles.push(namespace);
-            //                if (loadedBundles.length === pluginInfo.i18nBundles.length) {
-            //                    // All bundles are loaded ... ok for the bundle to execute now (from an i18n pov).
-            //                    logger.debug(`All ${bundleConfig.hpiPluginId} resource bundles loaded.`);
-            //                    done();
-            //                }
-            //            }
-            //        });
-            //        // Call the translator to trigger loading.
-            //        // Don't specify a key.
-            //        translator('xxxx');
-            //    }
-            //    pluginInfo.i18nBundles.forEach((bundleNamespace) => loadBundle(bundleNamespace));
-            //} else {
-            //    logger.debug(`Plugin ${bundleConfig.hpiPluginId} doesn't define any i18n resource bundles.`);
-            //    done();
-            //}
-            done();
+            if (pluginInfo.i18nBundles && pluginInfo.i18nBundles.length > 0) {
+                logger.debug(`Plugin ${bundleConfig.hpiPluginId} defines i18n resource bundles that must be loaded:`, pluginInfo.i18nBundles);
+                done();
+            } else {
+                logger.debug(`Plugin ${bundleConfig.hpiPluginId} doesn't define any i18n resource bundles.`);
+                done();
+            }
         } else {
             logger.warn(`Unexpected error finding pluging info for plugin ${bundleConfig.hpiPluginId}. There should be a preloaded jsExtensions entry.`);
             done();

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -28,16 +28,51 @@
  * Ensures that i18n resources are loaded before the bundle starts to execute.
  */
 
+import config from '../config';
+import logging from '../logging';
+import i18nTranslator from './i18n';
+
+const logger = logging.logger('io.jenkins.blueocean.i18n.startup');
+
 /**
  * Load the i18n resources defined for the plugin (in the extensions).
  *
  * @param {function} done Callback function. Called once all resources.
- * @param {object} config Bundle configuration parameters.
+ * @param {object} bundleConfig Bundle configuration parameters.
  */
-export function execute(done, config) {
-    if (config.hpiPluginId) {
-        console.log(`**** i18n bundles loaded for: ${config.hpiPluginId}`);
-        done();
+export function execute(done, bundleConfig) {
+    if (bundleConfig.hpiPluginId) {
+        const pluginInfo = config.getPluginInfo(bundleConfig.hpiPluginId);
+        if (pluginInfo) {
+            //if (pluginInfo.i18nBundles && pluginInfo.i18nBundles.length > 0) {
+            //    logger.debug(`Plugin ${bundleConfig.hpiPluginId} defines i18n resource bundles that must be loaded:`, pluginInfo.i18nBundles);
+            //    const loadedBundles = [];
+            //    function loadBundle(namespace) {
+            //        const translator = i18nTranslator(bundleConfig.hpiPluginId, namespace, () => {
+            //            if (loadedBundles.indexOf(namespace) === -1) {
+            //                logger.debug(`Loading of resource bundle ${bundleConfig.hpiPluginId}:${namespace} done.`);
+            //                loadedBundles.push(namespace);
+            //                if (loadedBundles.length === pluginInfo.i18nBundles.length) {
+            //                    // All bundles are loaded ... ok for the bundle to execute now (from an i18n pov).
+            //                    logger.debug(`All ${bundleConfig.hpiPluginId} resource bundles loaded.`);
+            //                    done();
+            //                }
+            //            }
+            //        });
+            //        // Call the translator to trigger loading.
+            //        // Don't specify a key.
+            //        translator('xxxx');
+            //    }
+            //    pluginInfo.i18nBundles.forEach((bundleNamespace) => loadBundle(bundleNamespace));
+            //} else {
+            //    logger.debug(`Plugin ${bundleConfig.hpiPluginId} doesn't define any i18n resource bundles.`);
+            //    done();
+            //}
+            done();
+        } else {
+            logger.warn(`Unexpected error finding pluging info for plugin ${bundleConfig.hpiPluginId}. There should be a preloaded jsExtensions entry.`);
+            done();
+        }
     } else {
         done();
     }

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -50,11 +50,11 @@ export function execute(done, bundleConfig) {
                 const loadBundle = (namespace) => {
                     const translator = i18nTranslator(bundleConfig.hpiPluginId, namespace, () => {
                         if (loadedBundles.indexOf(namespace) === -1) {
-                            logger.debug(`Loading of resource bundle ${bundleConfig.hpiPluginId}:${namespace} done.`);
+                            logger.debug(`Loading of i18n resource bundle "${bundleConfig.hpiPluginId}:${namespace}" done.`);
                             loadedBundles.push(namespace);
                             if (loadedBundles.length === pluginInfo.i18nBundles.length) {
                                 // All bundles are loaded ... ok for the bundle to execute now (from an i18n pov).
-                                logger.debug(`All ${bundleConfig.hpiPluginId} resource bundles loaded.`);
+                                logger.log(`All i18n "${bundleConfig.hpiPluginId}" resource bundles loaded.`, pluginInfo.i18nBundles);
                                 done();
                             }
                         }
@@ -65,7 +65,7 @@ export function execute(done, bundleConfig) {
                 };
                 pluginInfo.i18nBundles.forEach((bundleNamespace) => loadBundle(bundleNamespace));
             } else {
-                logger.debug(`Plugin ${bundleConfig.hpiPluginId} doesn't define any i18n resource bundles.`);
+                logger.debug(`Plugin "${bundleConfig.hpiPluginId}" doesn't define any i18n resource bundles.`);
                 done();
             }
         } else {

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -30,6 +30,7 @@
 
 import config from '../config';
 import logging from '../logging';
+import i18nTranslator from './i18n';
 
 const logger = logging.logger('io.jenkins.blueocean.i18n.startup');
 
@@ -45,7 +46,24 @@ export function execute(done, bundleConfig) {
         if (pluginInfo) {
             if (pluginInfo.i18nBundles && pluginInfo.i18nBundles.length > 0) {
                 logger.debug(`Plugin ${bundleConfig.hpiPluginId} defines i18n resource bundles that must be loaded:`, pluginInfo.i18nBundles);
-                done();
+                const loadedBundles = [];
+                const loadBundle = (namespace) => {
+                    const translator = i18nTranslator(bundleConfig.hpiPluginId, namespace, () => {
+                        if (loadedBundles.indexOf(namespace) === -1) {
+                            logger.debug(`Loading of resource bundle ${bundleConfig.hpiPluginId}:${namespace} done.`);
+                            loadedBundles.push(namespace);
+                            if (loadedBundles.length === pluginInfo.i18nBundles.length) {
+                                // All bundles are loaded ... ok for the bundle to execute now (from an i18n pov).
+                                logger.debug(`All ${bundleConfig.hpiPluginId} resource bundles loaded.`);
+                                done();
+                            }
+                        }
+                    });
+                    // Call the translator to trigger loading.
+                    // Don't specify a key.
+                    translator('xxxx');
+                };
+                pluginInfo.i18nBundles.forEach((bundleNamespace) => loadBundle(bundleNamespace));
             } else {
                 logger.debug(`Plugin ${bundleConfig.hpiPluginId} doesn't define any i18n resource bundles.`);
                 done();

--- a/blueocean-core-js/src/js/i18n/bundle-startup.js
+++ b/blueocean-core-js/src/js/i18n/bundle-startup.js
@@ -36,7 +36,7 @@
  */
 export function execute(done, config) {
     if (config.hpiPluginId) {
-        console.log(`**** i18n bundles loaded for ${config.hpiPluginId}`);
+        console.log(`**** i18n bundles loaded for: ${config.hpiPluginId}`);
         done();
     } else {
         done();

--- a/blueocean-core-js/src/js/i18n/i18n.js
+++ b/blueocean-core-js/src/js/i18n/i18n.js
@@ -168,7 +168,9 @@ export default function i18nTranslator(pluginName, namespace, onLoad) {
             translatorCache[translatorCacheKey] = translator;
         }
 
-        return translator(key, params);
+        if (key) {
+            return translator(key, params);
+        }
     };
 }
 

--- a/blueocean-core-js/src/js/i18n/i18n.js
+++ b/blueocean-core-js/src/js/i18n/i18n.js
@@ -171,6 +171,7 @@ export default function i18nTranslator(pluginName, namespace, onLoad) {
         if (key) {
             return translator(key, params);
         }
+        return undefined;
     };
 }
 

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
+      "version": "0.0.55-tfbeta2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -46,7 +46,7 @@
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta2",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "from": "../js-extensions",
       "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -12,6 +12,11 @@
           "from": "@jenkins-cd/design-language@0.0.102",
           "resolved": "https://registry.npmjs.org/@jenkins-cd/design-language/-/design-language-0.0.102.tgz"
         },
+        "@jenkins-cd/js-extensions": {
+          "version": "0.0.32",
+          "from": "@jenkins-cd/js-extensions@0.0.32",
+          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+        },
         "react-router": {
           "version": "3.0.0",
           "from": "react-router@3.0.0",
@@ -45,9 +50,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.32",
-      "from": "@jenkins-cd/js-extensions@0.0.32",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+      "version": "0.0.33-tfbeta1",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -514,9 +519,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.2",
-      "from": "ast-types@0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
+      "version": "0.9.4",
+      "from": "ast-types@0.9.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.4.tgz"
     },
     "astw": {
       "version": "2.0.0",
@@ -6809,14 +6814,14 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "from": "recast@>=0.11.17 <0.12.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.20.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta5",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
+      "version": "0.0.52",
+      "from": "@jenkins-cd/js-builder@0.0.52",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta3",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
+      "version": "0.0.52-tfbeta4",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta1",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
+      "version": "0.0.52-tfbeta2",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
+      "version": "0.0.55-tfbeta3",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -45,9 +45,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta2",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta3",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.51",
-      "from": "@jenkins-cd/js-builder@0.0.51",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.51.tgz",
+      "version": "0.0.52-tfbeta1",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {
@@ -3463,7 +3463,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dev": true
         },
@@ -3483,7 +3483,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.6 <3.1.0",
+          "from": "nopt@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "dev": true,
           "optional": true
@@ -3563,7 +3563,7 @@
         },
         "rc": {
           "version": "1.1.6",
-          "from": "rc@>=1.1.6 <1.2.0",
+          "from": "rc@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "dev": true,
           "optional": true,
@@ -3682,7 +3682,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.1 <2.3.0",
+          "from": "tar@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dev": true
         },
@@ -4341,7 +4341,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
@@ -4715,7 +4715,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "from": "js-yaml@>=3.6.0 <4.0.0",
+      "from": "js-yaml@>=3.5.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz"
     },
     "jsbn": {
@@ -5633,7 +5633,7 @@
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "minimatch@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
@@ -5719,7 +5719,7 @@
     },
     "ms": {
       "version": "0.7.2",
-      "from": "ms@>=0.7.1 <0.8.0",
+      "from": "ms@0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "multimatch": {
@@ -5971,7 +5971,7 @@
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-inspect": {
@@ -7674,7 +7674,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -8361,7 +8361,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <5.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta5",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
+      "version": "0.0.55",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -45,9 +45,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta5",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
+      "version": "0.0.33",
+      "from": "@jenkins-cd/js-extensions@0.0.33",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta2",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
+      "version": "0.0.52-tfbeta3",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,19 +3,14 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.54",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.54",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.54.tgz",
+      "version": "0.0.55-tfbeta1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
           "from": "@jenkins-cd/design-language@0.0.102",
           "resolved": "https://registry.npmjs.org/@jenkins-cd/design-language/-/design-language-0.0.102.tgz"
-        },
-        "@jenkins-cd/js-extensions": {
-          "version": "0.0.32",
-          "from": "@jenkins-cd/js-extensions@0.0.32",
-          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
         },
         "react-router": {
           "version": "3.0.0",
@@ -50,8 +45,8 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta1",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
+      "version": "0.0.33-tfbeta2",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
       "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
@@ -3468,7 +3463,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dev": true
         },
@@ -3488,7 +3483,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <3.1.0",
+          "from": "nopt@>=3.0.6 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "dev": true,
           "optional": true
@@ -3568,7 +3563,7 @@
         },
         "rc": {
           "version": "1.1.6",
-          "from": "rc@>=1.1.0 <1.2.0",
+          "from": "rc@>=1.1.6 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "dev": true,
           "optional": true,
@@ -3687,7 +3682,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.0 <2.3.0",
+          "from": "tar@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dev": true
         },

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta4",
-      "from": "../blueocean-core-js",
-      "resolved": "file:../blueocean-core-js",
+      "version": "0.0.55-tfbeta5",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -45,9 +45,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta4",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta5",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta3",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
+      "version": "0.0.55-tfbeta4",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -45,9 +45,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta3",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
+      "version": "0.0.33-tfbeta4",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.55-tfbeta4",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
+      "from": "../blueocean-core-js",
+      "resolved": "file:../blueocean-core-js",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta4",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
+      "version": "0.0.52-tfbeta5",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
       "dev": true,
       "dependencies": {
         "underscore.string": {
@@ -46,8 +46,8 @@
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta4",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
+      "from": "../js-extensions",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,9 +39,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
+    "@jenkins-cd/blueocean-core-js": "0.0.55",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
+    "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,9 +39,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.54",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,9 +39,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.51",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.54",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.32",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,9 +39,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,9 +39,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
+    "@jenkins-cd/js-builder": "0.0.52",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
@@ -10,13 +10,15 @@ import {
     TabLink,
     WeatherIcon,
 } from '@jenkins-cd/design-language';
-import { i18nTranslator, NotFound, User, Paths } from '@jenkins-cd/blueocean-core-js';
+import { i18nTranslator, NotFound, User, Paths, logging } from '@jenkins-cd/blueocean-core-js';
 import { Icon } from '@jenkins-cd/react-material-icons';
 import PageLoading from './PageLoading';
 import { buildOrganizationUrl, buildPipelineUrl, buildClassicConfigUrl } from '../util/UrlUtils';
 import { documentTitle } from './DocumentTitle';
 import { observer } from 'mobx-react';
 import { observable, action } from 'mobx';
+
+const logger = logging.logger('io.jenkins.blueocean.dashboard.PipelinePage');
 
 const RestPaths = Paths.rest;
 /**
@@ -68,6 +70,7 @@ export class PipelinePage extends Component {
         const isReady = !!pipeline;
 
         if (!pipeline && this.error) {
+            logger.log(`Error finding pipeline page for ${fullName}.`, this.error);
             return <NotFound />;
         }
 

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.54",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.54",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.54.tgz",
+      "version": "0.0.55-tfbeta1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.32",
-      "from": "@jenkins-cd/js-extensions@0.0.32",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+      "version": "0.0.33-tfbeta2",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -508,9 +508,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.2",
-      "from": "ast-types@0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
+      "version": "0.9.4",
+      "from": "ast-types@0.9.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.4.tgz"
     },
     "astw": {
       "version": "2.0.0",
@@ -6776,14 +6776,14 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "from": "recast@>=0.11.17 <0.12.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.20.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta5",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
+      "version": "0.0.55",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta5",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
+      "version": "0.0.33",
+      "from": "@jenkins-cd/js-extensions@0.0.33",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta5",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
+      "version": "0.0.52",
+      "from": "@jenkins-cd/js-builder@0.0.52",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta2",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
+      "version": "0.0.52-tfbeta3",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
+      "version": "0.0.55-tfbeta3",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta2",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta3",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta1",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
+      "version": "0.0.52-tfbeta2",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta3",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
+      "version": "0.0.55-tfbeta4",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta3",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
+      "version": "0.0.33-tfbeta4",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.55-tfbeta4",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
+      "from": "../blueocean-core-js",
+      "resolved": "file:../blueocean-core-js",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -31,15 +31,15 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta4",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
+      "version": "0.0.52-tfbeta5",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta4",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
+      "from": "../js-extensions",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta3",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
+      "version": "0.0.52-tfbeta4",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta4",
-      "from": "../blueocean-core-js",
-      "resolved": "file:../blueocean-core-js",
+      "version": "0.0.55-tfbeta5",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta4",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta5",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
+      "version": "0.0.55-tfbeta2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -38,7 +38,7 @@
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta2",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "from": "../js-extensions",
       "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.51",
-      "from": "@jenkins-cd/js-builder@0.0.51",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.51.tgz",
+      "version": "0.0.52-tfbeta1",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.51",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,9 +35,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,9 +35,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
+    "@jenkins-cd/js-builder": "0.0.52",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,9 +35,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.54",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.32",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,9 +35,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
+    "@jenkins-cd/blueocean-core-js": "0.0.55",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
+    "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,9 +35,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -47,6 +47,7 @@ builder.src([
 builder.bundle('src/main/js/blueocean.js')
     .inDir('target/classes/io/jenkins/blueocean')
     .less('src/main/less/blueocean.less')
+    .onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
     .export("@jenkins-cd/blueocean-core-js")
     .export("@jenkins-cd/design-language")
     .export("@jenkins-cd/js-extensions")

--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -47,7 +47,7 @@ builder.src([
 builder.bundle('src/main/js/blueocean.js')
     .inDir('target/classes/io/jenkins/blueocean')
     .less('src/main/less/blueocean.less')
-    .onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
+    .onStartup('./src/main/js/init')
     .export("@jenkins-cd/blueocean-core-js")
     .export('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup') // remove once JENKINS-39646 fixes back-door bundle module leakage
     .export("@jenkins-cd/design-language")

--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -49,6 +49,7 @@ builder.bundle('src/main/js/blueocean.js')
     .less('src/main/less/blueocean.less')
     .onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
     .export("@jenkins-cd/blueocean-core-js")
+    .export('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup') // remove once JENKINS-39646 fixes back-door bundle module leakage
     .export("@jenkins-cd/design-language")
     .export("@jenkins-cd/js-extensions")
     .export('react')

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta5",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
+      "version": "0.0.52",
+      "from": "@jenkins-cd/js-builder@0.0.52",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta5",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
+      "version": "0.0.55",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -42,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta5",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
+      "version": "0.0.33",
+      "from": "@jenkins-cd/js-extensions@0.0.33",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.55-tfbeta4",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
+      "from": "../blueocean-core-js",
+      "resolved": "file:../blueocean-core-js",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -36,15 +36,15 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta4",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
+      "version": "0.0.52-tfbeta5",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta5.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta4",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
+      "from": "../js-extensions",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta2",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
+      "version": "0.0.52-tfbeta3",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta4",
-      "from": "../blueocean-core-js",
-      "resolved": "file:../blueocean-core-js",
+      "version": "0.0.55-tfbeta5",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta5.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -42,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta4",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta5",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta5",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta5.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,19 +3,14 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.54",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.54",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.54.tgz",
+      "version": "0.0.55-tfbeta1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
           "from": "@jenkins-cd/design-language@0.0.102",
           "resolved": "https://registry.npmjs.org/@jenkins-cd/design-language/-/design-language-0.0.102.tgz"
-        },
-        "@jenkins-cd/js-extensions": {
-          "version": "0.0.32",
-          "from": "@jenkins-cd/js-extensions@0.0.32",
-          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
         },
         "history": {
           "version": "3.2.1",
@@ -47,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta1",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta1.tgz"
+      "version": "0.0.33-tfbeta2",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta1",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
+      "version": "0.0.52-tfbeta2",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta2.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.51",
-      "from": "@jenkins-cd/js-builder@0.0.51",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.51.tgz",
+      "version": "0.0.52-tfbeta1",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta3",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
+      "version": "0.0.55-tfbeta4",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta4.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -42,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta3",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
+      "version": "0.0.33-tfbeta4",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta4.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
+      "version": "0.0.55-tfbeta3",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta3.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -42,9 +42,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.33-tfbeta2",
-      "from": "../js-extensions",
-      "resolved": "file:../js-extensions"
+      "version": "0.0.33-tfbeta3",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta3",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta3.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -36,9 +36,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.52-tfbeta3",
-      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta3.tgz",
+      "version": "0.0.52-tfbeta4",
+      "from": "@jenkins-cd/js-builder@0.0.52-tfbeta4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.52-tfbeta4.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -12,6 +12,11 @@
           "from": "@jenkins-cd/design-language@0.0.102",
           "resolved": "https://registry.npmjs.org/@jenkins-cd/design-language/-/design-language-0.0.102.tgz"
         },
+        "@jenkins-cd/js-extensions": {
+          "version": "0.0.32",
+          "from": "@jenkins-cd/js-extensions@0.0.32",
+          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+        },
         "history": {
           "version": "3.2.1",
           "from": "history@>=3.0.0 <4.0.0",
@@ -42,9 +47,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.32",
-      "from": "@jenkins-cd/js-extensions@0.0.32",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.32.tgz"
+      "version": "0.0.33-tfbeta1",
+      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.33-tfbeta1.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -260,9 +265,9 @@
       "optional": true
     },
     "ast-types": {
-      "version": "0.9.2",
-      "from": "ast-types@0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
+      "version": "0.9.4",
+      "from": "ast-types@0.9.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.4.tgz"
     },
     "astw": {
       "version": "2.0.0",
@@ -4392,14 +4397,14 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "from": "recast@>=0.11.17 <0.12.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.20.tgz",
       "dependencies": {
         "esprima": {
-          "version": "3.1.2",
+          "version": "3.1.3",
           "from": "esprima@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
           "version": "0.5.6",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.55-tfbeta1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta1.tgz",
+      "version": "0.0.55-tfbeta2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.55-tfbeta2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.55-tfbeta2.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",
@@ -43,7 +43,7 @@
     },
     "@jenkins-cd/js-extensions": {
       "version": "0.0.33-tfbeta2",
-      "from": "@jenkins-cd/js-extensions@0.0.33-tfbeta2",
+      "from": "../js-extensions",
       "resolved": "file:../js-extensions"
     },
     "@jenkins-cd/js-modules": {

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,9 +29,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,9 +29,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.54",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.32",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,9 +29,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.54",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta1",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta1",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta2",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
+    "@jenkins-cd/js-builder": "0.0.52",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,9 +29,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta5",
+    "@jenkins-cd/blueocean-core-js": "0.0.55",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta5",
+    "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.51",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,9 +29,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta3",
+    "@jenkins-cd/blueocean-core-js": "0.0.55-tfbeta4",
     "@jenkins-cd/design-language": "0.0.105",
-    "@jenkins-cd/js-extensions": "0.0.33-tfbeta3",
+    "@jenkins-cd/js-extensions": "0.0.33-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/src/main/js/blueocean.js
+++ b/blueocean-web/src/main/js/blueocean.js
@@ -1,11 +1,6 @@
 try {
-    // Initialise the Blue Ocean app.
-    const init = require('./init.jsx');
-
-    init.initialize(() => {
-        // start the App
-        require('./main.jsx');
-    });
+    // start the App
+    require('./main.jsx');
 } catch (e) {
     console.error('Error starting Blue Ocean.', e);
 }

--- a/blueocean-web/src/main/js/init.js
+++ b/blueocean-web/src/main/js/init.js
@@ -1,4 +1,5 @@
-exports.initialize = function (oncomplete) {
+
+export function execute(done, bundleConfig) {
     // Get the extension list metadata from Jenkins.
     // Might want to do some flux fancy-pants stuff for this.
     const appRoot = document.getElementsByTagName("head")[0].getAttribute("data-appurl");
@@ -12,5 +13,7 @@ exports.initialize = function (oncomplete) {
         }
     });
 
-    oncomplete();
-};
+    // Bootstrap the i18n resources too...
+    const i18nBootstrap = require('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup');
+    i18nBootstrap.execute(done, bundleConfig);
+}

--- a/blueocean-web/src/main/js/jenkins-js-extension.yaml
+++ b/blueocean-web/src/main/js/jenkins-js-extension.yaml
@@ -1,2 +1,0 @@
-i18nBundles:
-  - jenkins.plugins.blueocean.web.Messages

--- a/blueocean-web/src/main/js/jenkins-js-extension.yaml
+++ b/blueocean-web/src/main/js/jenkins-js-extension.yaml
@@ -1,0 +1,2 @@
+i18nBundles:
+  - jenkins.plugins.blueocean.web.Messages

--- a/blueocean-web/src/main/js/jenkins-js-extensions.yaml
+++ b/blueocean-web/src/main/js/jenkins-js-extensions.yaml
@@ -1,4 +1,0 @@
-# Extensions in this plugin
-extensions:
-  - component: AboutNavLink
-    extensionPoint: jenkins.topNavigation.menu

--- a/js-extensions/@jenkins-cd/js-builder.js
+++ b/js-extensions/@jenkins-cd/js-builder.js
@@ -48,6 +48,7 @@ exports.install = function(builder) {
             .import('@jenkins-cd/js-extensions@any')
             .import('@jenkins-cd/design-language@any')
             .import("@jenkins-cd/blueocean-core-js@any")
+            .import('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup@any') // remove once JENKINS-39646 fixes back-door bundle module leakage
             .import('react@any', {
                 aliases: ['react/lib/React'] // in case a module requires react through the back door
             })

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -199,7 +199,17 @@ function findI18nBundles() {
             for (var i = 0; i < files.length; i++) {
                 var file = files[i];
                 if (propertiesFileMatcher.test(file)) {
-                    // Strip off the different parts we don't want. It might be that
+                    // We're only interested in adding the "basename" for a given resource bundle.
+                    // So when we have a bundle with multiple variants (language, country etc) as
+                    // shown below, we are only interested in the name "base" bundle file i.e.
+                    // "Messages.properties" in the case of this example.
+                    //
+                    //  ├── Messages_de.properties
+                    //  ├── Messages_es.properties
+                    //  ├── Messages_fr.properties
+                    //  └── Messages.properties    (base)
+                    //
+                    // So, we strip off the different parts we don't want. It might be that
                     // resource bundle basenames can have underscores in them according
                     // to specs (I didn't find a ref one way or the other), but trying to match
                     // language/country/variant codes exactly and strip them off is going to

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -154,6 +154,7 @@ function transformToJSX() {
 function createBundle(jsxFile) {
     __builder.bundle(jsxFile)
         .namespace(maven.getArtifactId())
+        .onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
         .inDir('target/classes/org/jenkins/ui/jsmodules/' + maven.getArtifactId());
 }
 

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -172,16 +172,41 @@ function findI18nBundles() {
     var bundleFileDir = getPluginResourceBundleDir();
 
     if (fs.existsSync(bundleFileDir)) {
+        var files = fs.readdirSync(bundleFileDir);
+        if (files) {
+            var cpPrefix = getPluginResourceBundleClasspath();
+            var propertiesFileMatcher = /\.properties$/; // endswith ".properties"
+            var everythingAfterFirstUnderscoreMatcher = /_.*$/;
 
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                if (propertiesFileMatcher.test(file)) {
+                    // Strip off the different parts we don't want. It might be that
+                    // resource bundle basenames can have underscores in them according
+                    // to specs (I didn't find a ref one way or the other), but trying to match
+                    // language/country/variant codes exactly and strip them off is going to
+                    // make the code a pita to impl/understand, so lets just say we only detect
+                    // basenames that do NOT contain underscores. If someone insists on using
+                    // underscores they can manually define the bundles in the yaml file.
+                    file = file.replace(propertiesFileMatcher, '');
+                    file = file.replace(everythingAfterFirstUnderscoreMatcher, '');
+
+                    var resourceBundleBaseName = cpPrefix + '.' + file;
+                    if (bundles.indexOf(resourceBundleBaseName) === -1) {
+                        bundles.push(resourceBundleBaseName);
+                    }
+                }
+            }
+        }
     }
 
     return bundles;
 }
 
-function getPluginResourceBundleDir() => {
+function getPluginResourceBundleDir() {
     return 'src/main/resources/jenkins/plugins/' + maven.getArtifactId().replace(/-/g, '/');
 }
 
-function getPluginResourceBundleClasspath() => {
+function getPluginResourceBundleClasspath() {
     return 'jenkins.plugins.' + maven.getArtifactId().replace(/-/g, '.');
 }

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -24,6 +24,10 @@ exports.bundle = function() {
             // Generate a bundle for the extensions.
             createBundle(jsxFile);
 
+            if (!extensionsJSON.i18nBundles) {
+                extensionsJSON.i18nBundles = findI18nBundles();
+            }
+
             return extensionsJSON;
         }
     } catch (e) {
@@ -56,7 +60,7 @@ exports.yamlToJSON = function(sourceFile, targetFile, transformer) {
     if (transformer) {
         asJSON = transformer(asJSON);
     }
-    
+
     var parentDir = paths.parentDir(targetFile);
     if (!fs.existsSync(parentDir)) {
         paths.mkdirp(parentDir);
@@ -161,4 +165,23 @@ function assertHasJenkinsJsExtensionsDependency(message) {
     if(!hasJenkinsJsExtensionsDep()) {
         dependencies.exitOnMissingDependency('@jenkins-cd/js-extensions', message);
     }
+}
+
+function findI18nBundles() {
+    var bundles = [];
+    var bundleFileDir = getPluginResourceBundleDir();
+
+    if (fs.existsSync(bundleFileDir)) {
+
+    }
+
+    return bundles;
+}
+
+function getPluginResourceBundleDir() => {
+    return 'src/main/resources/jenkins/plugins/' + maven.getArtifactId().replace(/-/g, '/');
+}
+
+function getPluginResourceBundleClasspath() => {
+    return 'jenkins.plugins.' + maven.getArtifactId().replace(/-/g, '.');
 }

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -155,6 +155,9 @@ function transformToJSX() {
 
             jsxFileContent += "    Extension.store._registerComponentInstance('" + extension.extensionPoint + "', '" + maven.getArtifactId() + "', '" + extension.component + "', " + extension.importAs + ");\n";
         }
+
+        jsxFileContent += "    Extension.store._onPluginComponentRegistrationComplete('" + maven.getArtifactId() + "');\n";
+
         jsxFileContent += "});";
 
         fs.writeFileSync(jsxFilePath, jsxFileContent);

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -90,6 +90,11 @@ function transformToJSON() {
 
     paths.mkdirp('target/classes');
     return exports.yamlToJSON(jsExtensionsYAMLFile, jsonFile, function(json) {
+        if (!json) {
+            json = {
+                extensions: []
+            };
+        }
         if (maven.isHPI()) {
             json.hpiPluginId = maven.getArtifactId();
         }

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -201,7 +201,7 @@ function findI18nBundles() {
                 if (propertiesFileMatcher.test(file)) {
                     // We're only interested in adding the "basename" for a given resource bundle.
                     // So when we have a bundle with multiple variants (language, country etc) as
-                    // shown below, we are only interested in the name "base" bundle file i.e.
+                    // shown below, we are only interested in the name of the "base" bundle file i.e.
                     // "Messages.properties" in the case of this example.
                     //
                     //  ├── Messages_de.properties

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "babel-cli": "6.10.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -23,6 +23,7 @@
     "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
+    "@jenkins-cd/logging": "^0.0.6",
     "babel-cli": "6.10.1",
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
@@ -45,6 +46,7 @@
     "envify": "3.4.1"
   },
   "peerDependencies": {
+    "@jenkins-cd/logging": "^0.0.6",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   }

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta3",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "babel-cli": "6.10.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33-tfbeta1",
+  "version": "0.0.33-tfbeta2",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.51",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "babel-cli": "6.10.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta1",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta2",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "babel-cli": "6.10.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33-tfbeta2",
+  "version": "0.0.33-tfbeta3",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33-tfbeta4",
+  "version": "0.0.33-tfbeta5",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
+    "@jenkins-cd/js-builder": "0.0.52",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "@jenkins-cd/logging": "^0.0.6",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.32",
+  "version": "0.0.33-tfbeta1",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.52-tfbeta4",
+    "@jenkins-cd/js-builder": "0.0.52-tfbeta5",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "@jenkins-cd/logging": "^0.0.6",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33-tfbeta3",
+  "version": "0.0.33-tfbeta4",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33-tfbeta5",
+  "version": "0.0.33",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/src/ExtensionStore.js
+++ b/js-extensions/src/ExtensionStore.js
@@ -2,6 +2,9 @@
  * ExtensionStore is responsible for maintaining extension metadata
  * including type/capability info
  */
+
+let iota = 0;
+
 export default class ExtensionStore {
     /**
      *  FIXME this is NOT a constructor, as there's no common way to
@@ -109,6 +112,8 @@ export default class ExtensionStore {
      * @return The version string for the named plugin, or undefined if the plugin is not installed/active.
      */
     getPluginVersion(pluginName) {
+        console.log(`***** getPluginVersion ${this.iota}`);
+
         for(var i = 0; i < this.extensionPointList.length; i++) {
             var pluginMetadata = this.extensionPointList[i];
             if (pluginMetadata.hpiPluginId === pluginName) {
@@ -158,6 +163,10 @@ export default class ExtensionStore {
         if (this.extensionPointList) {
             return;
         }
+
+        this.iota = iota++;
+        console.log(`***** _initExtensionPointList ${this.iota}`);
+
         // We clone the data because we add to it.
         this.extensionPointList = JSON.parse(JSON.stringify(this.extensionData));
         for(var i1 = 0; i1 < this.extensionPointList.length; i1++) {

--- a/js-extensions/src/ExtensionStore.js
+++ b/js-extensions/src/ExtensionStore.js
@@ -3,6 +3,10 @@
  * including type/capability info
  */
 
+import * as logging from '@jenkins-cd/logging';
+
+const logger = logging.logger('io.jenkins.blueocean.jsextensions.ExtensionStore');
+
 export default class ExtensionStore {
     /**
      *  FIXME this is NOT a constructor, as there's no common way to
@@ -55,6 +59,13 @@ export default class ExtensionStore {
             return;
         }
         throw new Error(`Unable to locate plugin for ${extensionPointId} / ${pluginId} / ${component}`);
+    }
+
+    /**
+     * On plugin component registration complete
+     */
+    _onPluginComponentRegistrationComplete(pluginId) {
+        logger.log('All js-extensions for plugin "%s" are now registered.', pluginId);
     }
 
     /**
@@ -182,9 +193,12 @@ export default class ExtensionStore {
     _loadBundles(extensionPointId, onload) {
         var extensionPointMetadatas = this.extensionPoints[extensionPointId];
         if (extensionPointMetadatas && extensionPointMetadatas.loaded) {
+            logger.debug('Bundles for extension point "%s" already loaded.', extensionPointId);
             onload(extensionPointMetadatas);
             return;
         }
+
+        logger.debug('Bundles for extension point "%s" not yet loaded. Initiating async load.', extensionPointId);
 
         extensionPointMetadatas = this.extensionPoints[extensionPointId] = this.extensionPoints[extensionPointId] || [];
 
@@ -202,8 +216,10 @@ export default class ExtensionStore {
             if (!pluginMetadata.loadCountMonitors) {
                 pluginMetadata.loadCountMonitors = [];
                 pluginMetadata.loadCountMonitors.push(loadCountMonitor);
+                logger.debug('Initiating js-extensions bundle loading for plugin "%s". Triggered by extensionPointId "%s".', pluginMetadata.hpiPluginId, extensionPointId);
                 jsModules.importModule(pluginMetadata.hpiPluginId + ':jenkins-js-extension')
                     .onFulfilled(() => {
+                        logger.log('js-extensions bundle for plugin "%s" loaded.', pluginMetadata.hpiPluginId);
                         pluginMetadata.bundleLoaded = true;
                         for (var i = 0; i < pluginMetadata.loadCountMonitors.length; i++) {
                             pluginMetadata.loadCountMonitors[i].dec();

--- a/js-extensions/src/ExtensionStore.js
+++ b/js-extensions/src/ExtensionStore.js
@@ -3,8 +3,6 @@
  * including type/capability info
  */
 
-let iota = 0;
-
 export default class ExtensionStore {
     /**
      *  FIXME this is NOT a constructor, as there's no common way to
@@ -112,8 +110,6 @@ export default class ExtensionStore {
      * @return The version string for the named plugin, or undefined if the plugin is not installed/active.
      */
     getPluginVersion(pluginName) {
-        console.log(`***** getPluginVersion ${this.iota}`);
-
         for(var i = 0; i < this.extensionPointList.length; i++) {
             var pluginMetadata = this.extensionPointList[i];
             if (pluginMetadata.hpiPluginId === pluginName) {
@@ -163,9 +159,6 @@ export default class ExtensionStore {
         if (this.extensionPointList) {
             return;
         }
-
-        this.iota = iota++;
-        console.log(`***** _initExtensionPointList ${this.iota}`);
 
         // We clone the data because we add to it.
         this.extensionPointList = JSON.parse(JSON.stringify(this.extensionData));


### PR DESCRIPTION
# Description

So we can attach async "startup scripts" to bundles, allowing us to ensure that e.g. i18n resources are loaded before the bundle executes ( [JENKINS-39345](https://issues.jenkins-ci.org/browse/JENKINS-39345) ).

Depends on https://github.com/jenkinsci/js-builder/pull/11

Other probably uses of this feature would be js extension metadata, allowing us to ensure that it's loaded before the extensions are executed etc. CC @kzantow.

Not really possible to write any additional meaningful automated tests for this imo (we actually already have an ATH test), unless someone has a good idea that I'm missing. To manually test ... just switch languages and see that the switch happens immediately, where as before, it only switched after clicking on something in the ui and causing a rerender.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes. https://ci.blueocean.io/job/ATH-Jenkinsfile/job/master/1222/

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
