### PR TITLE
[JENKINS-41499_Regression_show_complete_log_button_has_shifted_to_the…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/LogConsole.jsx
@@ -123,13 +123,13 @@ export class LogConsole extends Component {
         // const logUrl =`?start=0#${prefix || ''}log-${0}`
         const logUrl = url && url.includes(suffix) ? url : `${url}${suffix}`;
 
-        return (<div className="log-body">
+        return (<div className="log-wrapper">
             { isLoading && <div className="loadingContainer" id={`${prefix}log-${0}`}>
                 <Progress />
             </div>}
 
 
-            { !isLoading && <pre>
+            { !isLoading && <div className="log-body"><pre>
                 { hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
                     <a
                       target="_blank"
@@ -156,7 +156,7 @@ export class LogConsole extends Component {
                         <span className="line">{line}</span>
                     </div>
                 </p>)}
-            </pre> }
+            </pre></div> }
 
         </div>);
     }

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -349,6 +349,10 @@ a.pipelineRedirectLink svg {
         margin: 0;
         box-sizing: border-box;
         font-size: 1.2rem;
+        .fullLog {
+            display: flex;
+            justify-content: center;
+        }
     }
     p {
         padding: 0 15px 0 55px;


### PR DESCRIPTION
…_left] fix background bug on loading long log steps and center full log button

# Description

See [JENKINS-41499](https://issues.jenkins-ci.org/browse/JENKINS-41499).

![screenshot from 2017-01-31 12-02-17](https://cloud.githubusercontent.com/assets/596701/22462337/27dabb56-e7ad-11e6-9dc4-089fec6de7b0.png)


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
