### PR TITLE
[FIX-JENKINS-36783-Artifact_download_links_rely_on_mime_type_to_determine…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -4,10 +4,10 @@ import { Icon } from '@jenkins-cd/react-material-icons';
 import Markdown from 'react-remarkable';
 import { observer } from 'mobx-react';
 import mobxUtils from 'mobx-utils';
-import { UrlConfig } from '@jenkins-cd/blueocean-core-js';
+import { UrlConfig, logging } from '@jenkins-cd/blueocean-core-js';
 
+const logger = logging.logger('io.jenkins.blueocean.dashboard.artifacts');
 const { func, object, string } = PropTypes;
-
 const ZipFileDownload = (props) => {
     const { zipFile, t } = props;
     if (!zipFile) {
@@ -105,23 +105,30 @@ export default class RunDetailsArtifacts extends Component {
 
         const style = { fill: '#4a4a4a' };
 
+        const artifactsRendered = artifacts.map(artifact => {
+            const urlArray = artifact.url.split('/');
+            const fileName = urlArray[urlArray.length - 1];
+            logger.debug('artifact - url:', artifact.url, 'artifact - fileName:', fileName);
+            return (
+                <tr key={artifact.url}>
+                    <td>{artifact.path}</td>
+                    <td>
+                        <FileSize bytes={artifact.size} />
+                    </td>
+                    <td className="download">
+                        <a target="_blank" download={fileName} title={t('rundetail.artifacts.button.download', { defaultValue: 'Download the artifact' })} href={`${UrlConfig.getJenkinsRootURL()}${artifact.url}`}>
+                            <Icon style={style} icon="file_download" />
+                        </a>
+                    </td>
+                </tr>
+            );
+        });
+
         return (
             <div>
                 <ArtifactListingLimited artifacts={artifacts} t={t} />
                 <Table headers={headers} className="artifacts-table">
-                    { artifacts.map(artifact => (
-                        <tr key={artifact.url}>
-                            <td>{artifact.path}</td>
-                            <td>
-                                <FileSize bytes={artifact.size} />
-                            </td>
-                            <td className="download">
-                                <a target="_blank" title={t('rundetail.artifacts.button.download', { defaultValue: 'Download the artifact' })} href={`${UrlConfig.getJenkinsRootURL()}${artifact.url}`}>
-                                    <Icon style={style} icon="file_download" />
-                                </a>
-                            </td>
-                        </tr>
-                    ))}
+                    { artifactsRendered }
                     <td colSpan="3"></td>
                 </Table>
                <ZipFileDownload zipFile={zipFile} t={t} />


### PR DESCRIPTION
…_download_vs_view] using download attribute for trigger download

# Description

See [JENKINS-36783](https://issues.jenkins-ci.org/browse/JENKINS-36783).
![screenshot from 2017-02-01 13-23-20](https://cloud.githubusercontent.com/assets/596701/22506601/a7f9b722-e881-11e6-8f0d-328c04e538a8.png)

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
