### PR TITLE
[JENKINS-41501] Activity pagination should not render nothing while p…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -54,7 +54,7 @@ export class Activity extends Component {
     render() {
         const { pipeline, t, locale } = this.props;
         const runs = this.pager.data;
-        if (!pipeline || this.pager.pending) {
+        if (!pipeline) {
             return null;
         }
 

--- a/blueocean-dashboard/src/test/js/activity-spec.js
+++ b/blueocean-dashboard/src/test/js/activity-spec.js
@@ -149,7 +149,7 @@ const contextNoData = {
       activityService: {
         activityPager() {
           return {
-            data: undefined,
+            data: [],
             pending: true,
           }
         }
@@ -177,8 +177,9 @@ describe("Activity", () => {
   });
 
   it("does not render without data", () => {
-    const wrapper =  shallow(<Activity pipeline={pipeline} capabilities={capabilities}/>, { context: contextNoData}).node;
-    assert.isNull(wrapper);
+    const wrapper =  shallow(<Activity pipeline={pipeline}  t={ ()=>{} } capabilities={capabilities}/>, { context: contextNoData});
+    assert.equal(wrapper.find('Runs').length, 0)
+  
   });
 });
 


### PR DESCRIPTION
…ending

# Description

This PR stops flashing of activity tab when show more is pushed. I don't think its worth adding an ath test to cover this. In the future we should probably standardise an approach to rendering while loading though.

To test hit show more on activity panel when you have >25 runs.

See [JENKINS-41501](https://issues.jenkins-ci.org/browse/JENKINS-41501).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
