### PR TITLE
[FIX-JENKINS-36783_Artifact_download_links_rely_on_mime_type_to_determine…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -111,7 +111,11 @@ export default class RunDetailsArtifacts extends Component {
             logger.debug('artifact - url:', artifact.url, 'artifact - fileName:', fileName);
             return (
                 <tr key={artifact.url}>
-                    <td>{artifact.path}</td>
+                    <td>
+                        <a target="_blank" title={t('rundetail.artifacts.button.open', { defaultValue: 'Download the artifact' })} href={`${UrlConfig.getJenkinsRootURL()}${artifact.url}`}>
+                            {artifact.path}
+                        </a>
+                    </td>
                     <td>
                         <FileSize bytes={artifact.size} />
                     </td>

--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -112,7 +112,7 @@ export default class RunDetailsArtifacts extends Component {
             return (
                 <tr key={artifact.url}>
                     <td>
-                        <a target="_blank" title={t('rundetail.artifacts.button.open', { defaultValue: 'Download the artifact' })} href={`${UrlConfig.getJenkinsRootURL()}${artifact.url}`}>
+                        <a target="_blank" title={t('rundetail.artifacts.button.open', { defaultValue: 'Open the artifact' })} href={`${UrlConfig.getJenkinsRootURL()}${artifact.url}`}>
                             {artifact.path}
                         </a>
                     </td>

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages.properties
@@ -88,6 +88,7 @@ pipelinedetail.pullrequests.header.status=Status
 pipelinedetail.pullrequests.header.summary=Summary
 #run details
 rundetail.artifacts.button.download=Download the artifact
+rundetail.artifacts.button.open=Open the artifact
 rundetail.artifacts.button.downloadAll.text=Download All
 rundetail.artifacts.button.downloadAll.title=Download all artifact as zip
 rundetail.artifacts.header.name=Name

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_de.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_de.properties
@@ -51,6 +51,7 @@ pipelinedetail.pullrequests.header.status=Status
 pipelinedetail.pullrequests.header.summary=Zusammenfassung
 #run details
 rundetail.artifacts.button.download=Artefakt herunterladen
+rundetail.artifacts.button.open=Artefakt \u00f6ffnen
 rundetail.artifacts.header.name=Name
 rundetail.artifacts.header.size=Gr\u00F6sse
 rundetail.changes.header.author=Autor

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_es.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_es.properties
@@ -51,6 +51,7 @@ pipelinedetail.pullrequests.header.status=Estado
 pipelinedetail.pullrequests.header.summary=Resumen
 #run details
 rundetail.artifacts.button.download=Descargar el artefacto
+rundetail.artifacts.button.open=Abrir el artefacto
 rundetail.artifacts.header.name=Nombre
 rundetail.artifacts.header.size=Tama\u00F1o
 rundetail.changes.header.author=Autor

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_fr.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_fr.properties
@@ -51,6 +51,7 @@ pipelinedetail.pullrequests.header.status=\u00c9tat
 pipelinedetail.pullrequests.header.summary=R\u00e9sum\u00e9
 #run details
 rundetail.artifacts.button.download=T\u00e9l\u00e9charger l'artefact
+rundetail.artifacts.button.open=Ouvrir l'artefact
 rundetail.artifacts.button.downloadAll.text=Tout t\u00e9l\u00e9charger
 rundetail.artifacts.button.downloadAll.title=T\u00e9l\u00e9charger tous les artefacts comme zip
 rundetail.artifacts.header.name=Nom


### PR DESCRIPTION
…_download_vs_view] Click on the artifact name and open the file in new browser window

# Description

See [JENKINS-36783](https://issues.jenkins-ci.org/browse/JENKINS-36783).

Add link as had been missing in the first implementation. Spotted by @oleg-nenashev 

![jenkins-36783_es](https://cloud.githubusercontent.com/assets/596701/22559632/075c1f66-e972-11e6-9d1d-ab5830232ff2.png)


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
