### PR TITLE
[JENKINS-40627] Show branches empty state correctly

### DIFF
--- a/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
+++ b/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
@@ -4,7 +4,6 @@ import Markdown from 'react-remarkable';
 import Branches from './Branches';
 
 import PageLoading from './PageLoading';
-import { pipelineBranchesUnsupported } from './PipelinePage';
 import { capable } from '@jenkins-cd/blueocean-core-js';
 import { observer } from 'mobx-react';
 import { MULTIBRANCH_PIPELINE } from '../Capabilities';
@@ -47,7 +46,7 @@ NotSupported.propTypes = {
 @observer
 export class MultiBranch extends Component {
     componentWillMount() {
-        if (this.props.pipeline && this.context.params && !pipelineBranchesUnsupported(this.props.pipeline)) {
+        if (this.props.pipeline && this.context.params && capable(this.props.pipeline, MULTIBRANCH_PIPELINE)) {
             const { organization, pipeline } = this.context.params;
             this.pager = this.context.pipelineService.branchPager(organization, pipeline);
         }
@@ -55,7 +54,7 @@ export class MultiBranch extends Component {
 
     render() {
         const { t, locale, pipeline } = this.props;
-
+        
         if (!capable(pipeline, MULTIBRANCH_PIPELINE)) {
             return (<NotSupported t={t} />);
         }
@@ -63,7 +62,7 @@ export class MultiBranch extends Component {
         const branches = this.pager.data;
 
         if (!this.pager.pending && !branches.length) {
-            return (<EmptyState repoName={this.context.params.pipeline} />);
+            return (<EmptyState t={t} repoName={this.context.params.pipeline} />);
         }
 
         const head = 'pipelinedetail.branches.header';

--- a/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
@@ -21,13 +21,6 @@ import { observable, action } from 'mobx';
 const logger = logging.logger('io.jenkins.blueocean.dashboard.PipelinePage');
 
 const RestPaths = Paths.rest;
-/**
- * returns true if the pipeline is defined and has branchNames
- */
-export function pipelineBranchesUnsupported(pipeline) {
-    return (pipeline && !pipeline.branchNames) ||
-      (pipeline && !pipeline.branchNames.length);
-}
 
 const classicConfigLink = (pipeline) => {
     let link = null;


### PR DESCRIPTION
# Description
To test create a multibranch job with a SCM configured, then go to branches tab and empty state should now show.

See [JENKINS-40627](https://issues.jenkins-ci.org/browse/JENKINS-40627).

ATH https://github.com/jenkinsci/blueocean-acceptance-test/pull/115
 
# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
