### PR TITLE
[FIX-JENKINS-41691-Regression_Title_is_incorrect_for_Dashboard] Revert pa…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -6,7 +6,6 @@ import Extensions from '@jenkins-cd/js-extensions';
 import CreatePipelineLink from './CreatePipelineLink';
 import PipelineRowItem from './PipelineRowItem';
 import PageLoading from './PageLoading';
-import { documentTitle } from './DocumentTitle';
 
 import { observer } from 'mobx-react';
 
@@ -34,13 +33,7 @@ export class Pipelines extends Component {
 
     render() {
         const pipelines = this.pager.data;
-        const { organization = 'Jenkins', location = {} } = this.context.params;
-
-        if (!pipelines || this.pager.pending) {
-            this.props.setTitle(translate('common.pager.loading', { defaultValue: 'Loading...' }));
-        } else {
-            this.props.setTitle(organization);
-        }
+        const { organization, location = {} } = this.context.params;
 
         const orgLink = organization ?
             <Link
@@ -129,4 +122,4 @@ Pipelines.propTypes = {
     setTitle: func,
 };
 
-export default documentTitle(Pipelines);
+export default Pipelines;


### PR DESCRIPTION
Revert partly PR-#775 and fix various regressions with it

# Description

See [JENKINS-41691](https://issues.jenkins-ci.org/browse/JENKINS-41691).

Fix prefix and page title

![screenshot from 2017-02-03 11-20-26](https://cloud.githubusercontent.com/assets/596701/22587653/d5f5d17e-ea02-11e6-997a-f19838df1e4d.png)


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
