### PR TITLE
JENKINS-41162-regression-hotfix - explicitly name prop

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
+  "version": "0.0.59",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.58",
+  "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/parameter/components/Boolean.jsx
+++ b/blueocean-core-js/src/js/parameter/components/Boolean.jsx
@@ -8,7 +8,7 @@ export class Boolean extends Component {
         const { defaultParameterValue: { value }, description, name, onChange } = this.props;
         const cleanName = removeMarkupTags(name);
         return (<FormElement title={ cleanName }>
-            <Checkbox {...{ checked: value, label: removeMarkupTags(description), cleanName, onToggle: onChange }} />
+            <Checkbox {...{ checked: value, label: removeMarkupTags(description), name: cleanName, onToggle: onChange }} />
         </FormElement>);
     }
 }

--- a/blueocean-core-js/src/js/parameter/components/Password.jsx
+++ b/blueocean-core-js/src/js/parameter/components/Password.jsx
@@ -13,7 +13,7 @@ export class Password extends Component {
         const cleanName = removeMarkupTags(name);
         return (<FormElement title={ cleanName }>
             <div className="Password">
-                <PasswordInput {...{ defaultValue: value, cleanName, onChange }} />
+                <PasswordInput {...{ defaultValue: value, name: cleanName, onChange }} />
                 { description && <div className="inputDescription">{removeMarkupTags(description)}</div> }
             </div>
             {/* { debugging }*/}

--- a/blueocean-core-js/src/js/parameter/components/String.jsx
+++ b/blueocean-core-js/src/js/parameter/components/String.jsx
@@ -10,7 +10,7 @@ export class String extends Component {
         const cleanName = removeMarkupTags(name);
         return (<FormElement title={ cleanName }>
             <div className="String">
-                <TextInput {...{ defaultValue: value, cleanName, onChange }} />
+                <TextInput {...{ defaultValue: value, name: cleanName, onChange }} />
                 { description && <div className="inputDescription">{removeMarkupTags(description)}</div> }
             </div>
         </FormElement>);

--- a/blueocean-core-js/src/js/parameter/components/Text.jsx
+++ b/blueocean-core-js/src/js/parameter/components/Text.jsx
@@ -9,7 +9,7 @@ export class Text extends Component {
         const cleanName = removeMarkupTags(name);
         return (<FormElement title={ cleanName }>
             <div className="Text">
-                <TextArea {...{ defaultValue: value, cleanName, onChange }} />
+                <TextArea {...{ defaultValue: value, name: cleanName, onChange }} />
                 { description && <div className="inputDescription">{removeMarkupTags(description)}</div> }
             </div>
         </FormElement>);

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
+      "version": "0.0.59",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.58",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.58",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.58.tgz",
+      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.59",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.58",
+    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.58",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.58",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.58.tgz",
+      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
+      "version": "0.0.59",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.59",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.58",
+    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
+      "version": "0.0.59",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.58",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.58",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.58.tgz",
+      "version": "0.0.59-JENKINS-41162-regression-hotfix-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.59-JENKINS-41162-regression-hotfix-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.59-JENKINS-41162-regression-hotfix-1.tgz",
       "dependencies": {
         "@jenkins-cd/design-language": {
           "version": "0.0.102",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.59",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.58",
+    "@jenkins-cd/blueocean-core-js": "0.0.59-JENKINS-41162-regression-hotfix-1",
     "@jenkins-cd/design-language": "0.0.105",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
Fix for regression caused by https://github.com/jenkinsci/blueocean-plugin/pull/771

Fooled by one of the ES6 "enhancements". Need to explicitly name the object property, otherwise the `name` property doesn't get mapped onto the input element.

@reviewbybees 
