### PR TITLE
[FIX JENKINS-41638] "Open Blue Ocean" popup for when the jenkins url doesn't match current url

### DIFF
--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -9,17 +9,56 @@ function getAppUrl() {
     }
 }
 
-$(document).ready(() => {
+function aHref(tryBlueOceanUrl) {
     var tryBlueOcean = $('<a id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</a>');
+    tryBlueOcean.attr('href', tryBlueOceanUrl);
+    return tryBlueOcean;
+}
+
+function configureJenkinsUrl() {
+    var tryBlueOcean = $('<span id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</span>');
+    var tryBlueOceanClickHandler = function() {
+        // Remove the click handler, preventing it from picking up clicks
+        // on the the popup (below).
+        tryBlueOcean.off();
+
+        var popup = $(`<span class="unable-to-open"><h3>Unable to Open Blue Ocean</h3>The configured Jenkins URL does not match the current URL.<p/><a href="${getAppUrl()}/configure">Please configure the Jenkins URL</a></span>`);
+        tryBlueOcean.append(popup);
+        popup.css({
+            top: tryBlueOcean.outerHeight() + 10,
+            right: (0 - (popup.outerWidth()/2 - tryBlueOcean.outerWidth()/2))
+        });
+        popup.click(function(event) {
+            event.stopPropagation();
+            popup.remove();
+            tryBlueOcean.click(tryBlueOceanClickHandler);
+        });
+
+        // if the link is clicked on
+        $('a', popup).click(function() {
+            event.stopPropagation();
+            popup.empty();
+            popup.append('<h3>Redirecting to System Configuration</h3><h3>Please wait ...</h3>');
+        });
+    };
+    tryBlueOcean.click(tryBlueOceanClickHandler);
+    return tryBlueOcean;
+}
+
+$(document).ready(() => {
     var contextUrlDiv = $('#blueocean-context-url');
     var tryBlueOceanUrl;
 
     if (contextUrlDiv.length === 1) {
+        var everythingAfterSlashBlue = /\/blue.*$/;
         tryBlueOceanUrl = contextUrlDiv.attr('data-context-url');
+        if (window.location.href.indexOf(tryBlueOceanUrl.replace(everythingAfterSlashBlue, '')) === 0) {
+            $('#page-head #header').append(aHref(tryBlueOceanUrl));
+        } else {
+            $('#page-head #header').append(configureJenkinsUrl());
+        }
     } else {
         tryBlueOceanUrl = `${getAppUrl()}/blue`;
+        $('#page-head #header').append(aHref(tryBlueOceanUrl));
     }
-    tryBlueOcean.attr('href', tryBlueOceanUrl);
-
-    $('#page-head #header').append(tryBlueOcean);
 });

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -17,7 +17,7 @@ function aHref(tryBlueOceanUrl) {
 
 function configureJenkinsUrl() {
     var tryBlueOcean = $('<span id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</span>');
-    var tryBlueOceanClickHandler = function() {
+    var tryBlueOceanClickHandler = function () {
         // Remove the click handler, preventing it from picking up clicks
         // on the the popup (below).
         tryBlueOcean.off();
@@ -28,14 +28,14 @@ function configureJenkinsUrl() {
             top: tryBlueOcean.outerHeight() + 10,
             right: (0 - (popup.outerWidth()/2 - tryBlueOcean.outerWidth()/2))
         });
-        popup.click(function(event) {
+        popup.click((event) => {
             event.stopPropagation();
             popup.remove();
             tryBlueOcean.click(tryBlueOceanClickHandler);
         });
 
         // if the link is clicked on
-        $('a', popup).click(function() {
+        $('a', popup).click(() => {
             event.stopPropagation();
             popup.empty();
             popup.append('<h3>Redirecting to System Configuration</h3><h3>Please wait ...</h3>');

--- a/blueocean-web/src/main/less/try.less
+++ b/blueocean-web/src/main/less/try.less
@@ -11,6 +11,25 @@
   border: 1px solid;
   border-radius: 3px;
   text-decoration: none;
+
+  .unable-to-open {
+      cursor: default;
+      padding: 10px;
+      position: absolute;
+      width: 300px;
+      z-index: 1000;
+      background-color: #ff0000;
+      border-radius: 3px;
+
+      h3 {
+          text-align: center;
+      }
+
+      a {
+          color: white;
+          font-weight: bold;
+      }
+  }
 }
 
 .try-blueocean.header-callout:hover {


### PR DESCRIPTION
# Description

See [JENKINS-41638](https://issues.jenkins-ci.org/browse/JENKINS-41638).

Basically ... a check on the current browser url, comparing it to the expected Blue Ocean url (which is constructed based on the configured Jenkins URL. If the bit before "/blue" doesn't match, then show a "configure the Jenkins URL" popup when the user clicks to open blue ocean.

See this little recording: https://youtu.be/tTV4wuoxEeA

I didn't make any real effort wrt styling the little popup. I'm not the designer, so not going to waste time. Maybe @brody could direct please?

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
