### PR TITLE
JENKINS-41433# User permission api

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -1,7 +1,9 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import com.google.common.collect.ImmutableMap;
+import hudson.model.Item;
 import hudson.model.User;
-import hudson.plugins.favorite.user.FavoriteUserProperty;
+import hudson.security.ACL;
 import hudson.tasks.Mailer;
 import hudson.tasks.UserAvatarResolver;
 import io.jenkins.blueocean.commons.ServiceException;
@@ -9,11 +11,16 @@ import io.jenkins.blueocean.rest.ApiHead;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueFavoriteContainer;
+import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BlueUser;
+import io.jenkins.blueocean.rest.model.BlueUserPermission;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.Stapler;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * {@link BlueUser} implementation backed by in-memory {@link User}
@@ -77,8 +84,62 @@ public class UserImpl extends BlueUser {
     }
 
     @Override
+    public BlueUserPermission getPermission() {
+        Authentication authentication = Jenkins.getAuthentication();
+        String name = authentication.getName();
+        final boolean[] ad = new boolean[1];
+        final Map<String,Boolean> pipelinePermission = new HashMap<>();
+
+        if(name.equals(user.getId())){
+            ad[0] = isAdmin();
+            pipelinePermission.putAll(getPipelinePermissions());
+        }else if(!name.equals(user.getId()) && Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            // authenticated user is different from requested user and authenticated user is admin,
+            // we will let it impersonate requested user
+            try {
+                ACL.impersonate(user.impersonate(), new Runnable() {
+                    @Override
+                    public void run() {
+                        ad[0] = isAdmin();
+                        pipelinePermission.putAll(getPipelinePermissions());
+                    }
+                });
+            }catch (UsernameNotFoundException e){
+                return null;
+            }
+        }else{ //different than the logged in user and logged in user is not admin
+            return null;
+        }
+
+        return new BlueUserPermission() {
+            @Override
+            public boolean isAdministration() {
+                return ad[0];
+            }
+
+            @Override
+            public Map<String, Boolean> getPipelinePermission() {
+                return pipelinePermission;
+            }
+        };
+    }
+
+    @Override
     public Link getLink() {
         return (parent != null)?parent.getLink().rel(getId()): ApiHead.INSTANCE().getLink().rel("users/"+getId());
+    }
+
+    private boolean isAdmin(){
+        return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER);
+    }
+
+    private Map<String, Boolean> getPipelinePermissions(){
+        return ImmutableMap.of(
+                BluePipeline.CREATE_PERMISSION, Jenkins.getInstance().hasPermission(Item.CREATE),
+                BluePipeline.READ_PERMISSION, Jenkins.getInstance().hasPermission(Item.READ),
+                BluePipeline.START_PERMISSION, Jenkins.getInstance().hasPermission(Item.BUILD),
+                BluePipeline.STOP_PERMISSION, Jenkins.getInstance().hasPermission(Item.CANCEL)
+        );
     }
 
 }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
@@ -18,6 +18,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Vivek Pandey
  */
@@ -27,9 +31,9 @@ public class ProfileApiTest extends BaseTest{
         User system = j.jenkins.getUser("SYSTEM");
         get("/users/", List.class);
         Map response = get("/users/"+system.getId());
-        Assert.assertEquals(system.getId(), response.get("id"));
-        Assert.assertEquals(system.getFullName(), response.get("fullName"));
-        Assert.assertEquals("http://avatar.example/i/img.png", response.get("avatar"));
+        assertEquals(system.getId(), response.get("id"));
+        assertEquals(system.getFullName(), response.get("fullName"));
+        assertEquals("http://avatar.example/i/img.png", response.get("avatar"));
     }
 
     //XXX: There is no method on User API to respond to POST or PUT or PATH. Since there are other tests that
@@ -39,8 +43,8 @@ public class ProfileApiTest extends BaseTest{
     public void postCrumbTest() throws Exception {
         User system = j.jenkins.getUser("SYSTEM");
         Map response = post("/users/"+system.getId()+"/", Collections.emptyMap());
-        Assert.assertEquals(system.getId(), response.get("id"));
-        Assert.assertEquals(system.getFullName(), response.get("fullName"));
+        assertEquals(system.getId(), response.get("id"));
+        assertEquals(system.getFullName(), response.get("fullName"));
     }
 
     //UX-159
@@ -56,8 +60,8 @@ public class ProfileApiTest extends BaseTest{
     public void putMimeTest() throws Exception {
         User system = j.jenkins.getUser("SYSTEM");
         Map response = put("/users/"+system.getId()+"/", Collections.emptyMap());
-        Assert.assertEquals(system.getId(), response.get("id"));
-        Assert.assertEquals(system.getFullName(), response.get("fullName"));
+        assertEquals(system.getId(), response.get("id"));
+        assertEquals(system.getFullName(), response.get("fullName"));
     }
 
     @Test
@@ -72,8 +76,8 @@ public class ProfileApiTest extends BaseTest{
         User system = j.jenkins.getUser("SYSTEM");
 
         Map response = patch("/users/"+system.getId()+"/", Collections.emptyMap());
-        Assert.assertEquals(system.getId(), response.get("id"));
-        Assert.assertEquals(system.getFullName(), response.get("fullName"));
+        assertEquals(system.getId(), response.get("id"));
+        assertEquals(system.getFullName(), response.get("fullName"));
     }
 
     @Test
@@ -101,8 +105,8 @@ public class ProfileApiTest extends BaseTest{
 
         //Call is made as anonymous user, email should be null
         Map response = get("/users/"+alice.getId());
-        Assert.assertEquals(alice.getId(), response.get("id"));
-        Assert.assertEquals(alice.getFullName(), response.get("fullName"));
+        assertEquals(alice.getId(), response.get("id"));
+        assertEquals(alice.getFullName(), response.get("fullName"));
         Assert.assertNull(response.get("email"));
 
         //make a request on bob's behalf to get alice's user details, should get null email
@@ -111,20 +115,20 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(getJwtToken(j.jenkins,"bob", "bob"))
             .get("/users/"+alice.getId()).build(Map.class);
 
-        Assert.assertEquals(alice.getId(), r.get("id"));
-        Assert.assertEquals(alice.getFullName(), r.get("fullName"));
+        assertEquals(alice.getId(), r.get("id"));
+        assertEquals(alice.getFullName(), r.get("fullName"));
         Assert.assertTrue(bob.hasPermission(Jenkins.ADMINISTER));
         //bob is admin so can see alice email
-        Assert.assertEquals("alice@jenkins-ci.org",r.get("email"));
+        assertEquals("alice@jenkins-ci.org",r.get("email"));
 
         r = new RequestBuilder(baseUrl)
             .status(200)
             .jwtToken(getJwtToken(j.jenkins,"alice", "alice"))
             .get("/users/"+alice.getId()).build(Map.class);
 
-        Assert.assertEquals(alice.getId(), r.get("id"));
-        Assert.assertEquals(alice.getFullName(), r.get("fullName"));
-        Assert.assertEquals("alice@jenkins-ci.org",r.get("email"));
+        assertEquals(alice.getId(), r.get("id"));
+        assertEquals(alice.getFullName(), r.get("fullName"));
+        assertEquals("alice@jenkins-ci.org",r.get("email"));
     }
 
     @Test
@@ -148,13 +152,13 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(token)
             .build(List.class);
 
-        Assert.assertEquals(1, l.size());
+        assertEquals(1, l.size());
         Map pipeline = (Map)((Map)l.get(0)).get("item");
 
         validatePipeline(p, pipeline);
 
         String href = getHrefFromLinks((Map)l.get(0),"self");
-        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/pipeline1/favorite/", href);
+        assertEquals("/blue/rest/organizations/jenkins/pipelines/pipeline1/favorite/", href);
         map = new RequestBuilder(baseUrl)
             .put(href.substring("/blue/rest".length()))
             .jwtToken(token)
@@ -168,7 +172,7 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(token)
             .build(List.class);
 
-        Assert.assertEquals(0, l.size());
+        assertEquals(0, l.size());
 
         new RequestBuilder(baseUrl)
             .get("/users/"+user.getId()+"/favorites/")
@@ -200,14 +204,14 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(token)
             .build(List.class);
 
-        Assert.assertEquals(1, l.size());
+        assertEquals(1, l.size());
         Map pipeline = (Map)((Map)l.get(0)).get("item");
 
         validatePipeline(p, pipeline);
 
         String href = getHrefFromLinks((Map)l.get(0),"self");
 
-        Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/pipeline1/favorite/", href);
+        assertEquals("/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/pipeline1/favorite/", href);
 
         map = new RequestBuilder(baseUrl)
             .put(href.substring("/blue/rest".length()))
@@ -222,7 +226,7 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(token)
             .build(List.class);
 
-        Assert.assertEquals(0, l.size());
+        assertEquals(0, l.size());
 
 
         new RequestBuilder(baseUrl)
@@ -244,7 +248,7 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(token)
             .build(List.class);
 
-        Assert.assertEquals(0, l.size());
+        assertEquals(0, l.size());
 
     }
 
@@ -287,9 +291,17 @@ public class ProfileApiTest extends BaseTest{
             .status(200)
             .build(Map.class);
 
-        Assert.assertEquals(user.getFullName(), u.get("fullName"));
-        Assert.assertEquals("alice@jenkins-ci.org", u.get("email"));
-        Assert.assertEquals(user.getId(), u.get("id"));
+        assertEquals(user.getFullName(), u.get("fullName"));
+        assertEquals("alice@jenkins-ci.org", u.get("email"));
+        assertEquals(user.getId(), u.get("id"));
+        Map permission = (Map) u.get("permission");
+        assertNotNull(permission);
+        assertTrue((Boolean) permission.get("administrator"));
+        Map pipelinePerm = (Map) permission.get("pipeline");
+        assertEquals(true, pipelinePerm.get("start"));
+        assertEquals(true, pipelinePerm.get("create"));
+        assertEquals(true, pipelinePerm.get("read"));
+        assertEquals(true, pipelinePerm.get("stop"));
     }
 
 
@@ -345,7 +357,7 @@ public class ProfileApiTest extends BaseTest{
             .jwtToken(getJwtToken(j.jenkins))
             .build(List.class);
 
-        Assert.assertEquals(0, l.size());
+        assertEquals(0, l.size());
         Assert.assertNull(User.current());
     }
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUser.java
@@ -18,6 +18,8 @@ public abstract class BlueUser extends Resource {
     public static final String FULL_NAME="fullName";
     public static final String EMAIL="email";
     public static final String FAVORITES = "favorites";
+    private static final String PERMISSION = "permission";
+    private static final String AVATAR = "avatar";
 
     /**
      * @return The id of the user
@@ -38,8 +40,12 @@ public abstract class BlueUser extends Resource {
     // restricted to authorized users only
     public abstract String getEmail();
 
-    @Exported
+    @Exported(name = AVATAR)
     public abstract String getAvatar();
 
+    @Navigable
     public abstract BlueFavoriteContainer getFavorites();
+
+    @Exported(name = PERMISSION, inline = true)
+    public abstract BlueUserPermission getPermission();
 }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUserPermission.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueUserPermission.java
@@ -1,0 +1,28 @@
+package io.jenkins.blueocean.rest.model;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.util.Map;
+
+/**
+ * User's permissions.
+ *
+ * @author Vivek Pandey
+ */
+@ExportedBean
+public abstract class BlueUserPermission {
+    private static final String ADMINISTRATOR = "administrator";
+    private static final String PIPELINE = "pipeline";
+    private static final String CREDENTIAL = "credential";
+
+    /**
+     * true if user has administrator privilege false otherwise
+     */
+    @Exported(name = ADMINISTRATOR)
+    public abstract boolean isAdministration();
+
+    /* pipeline or job permission */
+    @Exported(name = PIPELINE)
+    public abstract Map<String, Boolean> getPipelinePermission();
+}


### PR DESCRIPTION
# Description

See [JENKINS-41433](https://issues.jenkins-ci.org/browse/JENKINS-41433).

- Create two users on Jenkins with different pipeline permissions, keep one of the user admin and another not
- curl -v -u userid:password http://localhost:8080/jenkins/blue/rest/organizations/jenkins/users/:uid/

```
{
   "permission" : null,
   "avatar" : null,
   "_class" : "io.jenkins.blueocean.service.embedded.rest.UserImpl",
   "fullName" : "admin",
   "_links" : {
      "favorites" : {
         "href" : "/blue/rest/organizations/jenkins/users/admin/favorites/",
         "_class" : "io.jenkins.blueocean.rest.hal.Link"
      },
      "self" : {
         "href" : "/blue/rest/organizations/jenkins/users/admin/",
         "_class" : "io.jenkins.blueocean.rest.hal.Link"
      }
   },
   "email" : "admin@c.com",
   "id" : "admin"
}
```

> User with admin privilege can see other user's permissions. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 