### PR TITLE
Feature/jenkins 38598 message enricher org folder indexing

### DIFF
--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
@@ -56,8 +56,8 @@ public class JobIndexingMessageEnricher extends MessageEnricher {
             Enum indexingResult;
 
             if (jobChannelItem instanceof OrganizationFolder) {
-                indexingStatus = OrgFolder.job_orgfolder_indexing_status;
-                indexingResult = OrgFolder.job_orgfolder_indexing_result;
+                indexingStatus = EventProps.Job.job_orgfolder_indexing_status;
+                indexingResult = EventProps.Job.job_orgfolder_indexing_result;
             } else if (jobChannelItem instanceof MultiBranchProject) {
                 jobChannelMessage.set(EventProps.Job.job_ismultibranch, "true");
                 indexingStatus = EventProps.Job.job_multibranch_indexing_status;
@@ -97,10 +97,4 @@ public class JobIndexingMessageEnricher extends MessageEnricher {
             }
         }
     }
-}
-
-// TODO: move to pubsub-light's EventProps?
-enum OrgFolder {
-    job_orgfolder_indexing_result,
-    job_orgfolder_indexing_status,
 }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
@@ -56,8 +56,8 @@ public class JobIndexingMessageEnricher extends MessageEnricher {
             Enum indexingResult;
 
             if (jobChannelItem instanceof OrganizationFolder) {
-                indexingStatus = EventProps.Job.job_orgfolder_indexing_status;
-                indexingResult = EventProps.Job.job_orgfolder_indexing_result;
+                indexingStatus = JobIndexing.EventProps.job_orgfolder_indexing_status;
+                indexingResult = JobIndexing.EventProps.job_orgfolder_indexing_result;
             } else if (jobChannelItem instanceof MultiBranchProject) {
                 jobChannelMessage.set(EventProps.Job.job_ismultibranch, "true");
                 indexingStatus = EventProps.Job.job_multibranch_indexing_status;
@@ -95,6 +95,13 @@ public class JobIndexingMessageEnricher extends MessageEnricher {
                     jobChannelMessage.set(indexingStatus, "INDEXING");
                 }
             }
+        }
+    }
+
+    public interface JobIndexing{
+        enum EventProps {
+            job_orgfolder_indexing_status,
+            job_orgfolder_indexing_result
         }
     }
 }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/JobIndexingMessageEnricher.java
@@ -39,10 +39,12 @@ import org.jenkinsci.plugins.pubsub.QueueTaskMessage;
 import javax.annotation.Nonnull;
 
 /**
+ * MessageEnricher that adds information when MultiBranchProject or OrganizationFolder indexing succeeds or fails.
+ *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 @Extension
-public class MultiBranchProjectEnricher extends MessageEnricher {
+public class JobIndexingMessageEnricher extends MessageEnricher {
 
     @Override
     public void enrich(@Nonnull Message message) {


### PR DESCRIPTION
# Description
- **Refer to commit accdc27 as it better illustrates the actual changes. The rename I did makes the usual diff hard to read unfortunately**
- Related to #700 and [JENKINS-39794](https://issues.jenkins-ci.org/browse/JENKINS-39794): the goal is to enrich the message when an org folder indexing succeeds or fails

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
