### PR TITLE
[FIX JENKINS-41638] "Open Blue Ocean" construction by replacing the classic object path with the blue ocean object path

### DIFF
--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -85,6 +85,8 @@ public class BlueOceanWebURLBuilder {
                     } else {
                         return new TryBlueOceanURLs(blueUrl);
                     }
+                } else if (object instanceof Item) {
+                    return new TryBlueOceanURLs(getBlueHome(), ((Item) object).getUrl());
                 }
             }
         }

--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -60,14 +60,14 @@ public class BlueOceanWebURLBuilder {
     }
 
     /**
-     * Construct a Blue Ocean web URL for the Jenkins {@link ModelObject}
+     * Get the {@link TryBlueOceanURLs} instance for the {@link ModelObject}
      * associated with the current Stapler request.
      *
-     * @return The most appropriate Blue Ocean web URL for the current classic
+     * @return The {@link TryBlueOceanURLs} instance for the current classic
      * Jenkins page. The URL to the Blue Ocean homepage is returned if a more
      * appropriate URL is not found.
      */
-    public static @Nonnull String toBlueOceanURL() {
+    public static @Nonnull TryBlueOceanURLs getTryBlueOceanURLs() {
         StaplerRequest staplerRequest = Stapler.getCurrentRequest();
         List<Ancestor> list = staplerRequest.getAncestors();
 
@@ -80,13 +80,17 @@ public class BlueOceanWebURLBuilder {
             if (object instanceof ModelObject) {
                 String blueUrl = toBlueOceanURL((ModelObject) object);
                 if (blueUrl != null) {
-                    return blueUrl;
+                    if (object instanceof Item) {
+                        return new TryBlueOceanURLs(blueUrl, ((Item) object).getUrl());
+                    } else {
+                        return new TryBlueOceanURLs(blueUrl);
+                    }
                 }
             }
         }
 
         // Otherwise just return Blue Ocean home.
-        return getBlueHome();
+        return new TryBlueOceanURLs(getBlueHome());
     }
 
     /**
@@ -129,17 +133,7 @@ public class BlueOceanWebURLBuilder {
     }
 
     private static String getBlueHome() {
-        String rootUrl = Jenkins.getInstance().getRootUrl();
-
-        if (rootUrl == null) {
-            throw new IllegalStateException("Unable to determine Jenkins root URL.");
-        }
-
-        if (rootUrl.endsWith("/")) {
-            rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
-        }
-
-        return rootUrl + "/blue";
+        return "blue";
     }
 
     private static BlueOceanModelMapping getPipelineModelMapping(Job job) {

--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -34,7 +34,6 @@ import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.rest.BluePipelineFactory;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
-import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Ancestor;
@@ -82,6 +81,8 @@ public class BlueOceanWebURLBuilder {
                 if (blueUrl != null) {
                     if (object instanceof Item) {
                         return new TryBlueOceanURLs(blueUrl, ((Item) object).getUrl());
+                    } else if (object instanceof Run) {
+                        return new TryBlueOceanURLs(blueUrl, ((Run) object).getUrl());
                     } else {
                         return new TryBlueOceanURLs(blueUrl);
                     }

--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/TryBlueOceanURLs.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/TryBlueOceanURLs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,23 +23,36 @@
  */
 package io.jenkins.blueocean;
 
-import hudson.Extension;
-import hudson.model.PageDecorator;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 /**
- * Stapler page decorator for decorating classic Jenkins pages with visual
- * prompts to the user that will hopefully entice/remind them into giving
- * Blue ocean a try.
- *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-@Extension
 @Restricted(NoExternalUse.class)
-public class TryBlueOceanPageDecorator extends PageDecorator {
+public class TryBlueOceanURLs {
 
-    public TryBlueOceanURLs getTryBlueOceanURLs() {
-        return BlueOceanWebURLBuilder.getTryBlueOceanURLs();
+    private final String blueOceanURL;
+    private final String classicURL;
+
+    TryBlueOceanURLs(@Nonnull String blueOceanURL) {
+        this.blueOceanURL = blueOceanURL;
+        this.classicURL = null;
+    }
+
+    TryBlueOceanURLs(@Nonnull String blueOceanURL, @Nonnull String classicURL) {
+        this.blueOceanURL = blueOceanURL;
+        this.classicURL = classicURL;
+    }
+
+    public @Nonnull String getBlueOceanURL() {
+        return blueOceanURL;
+    }
+
+    public @CheckForNull String getClassicURL() {
+        return classicURL;
     }
 }

--- a/blueocean-dashboard/src/main/resources/io/jenkins/blueocean/TryBlueOceanPageDecorator/header.jelly
+++ b/blueocean-dashboard/src/main/resources/io/jenkins/blueocean/TryBlueOceanPageDecorator/header.jelly
@@ -4,6 +4,7 @@
   The following Stapler adjunct adds the "Try Blue Ocean JavaScript bundle to
   every page in "classic" Jenkins.
   -->
-  <div id="blueocean-context-url" data-context-url="${it.getBlueOceanURL()}" />
+  <j:set var="tryURLs" value="${it.tryBlueOceanURLs}"/>
+  <div id="blueocean-context-url" data-context-url="${tryURLs.blueOceanURL}" data-classic-url="${tryURLs.classicURL}" />
   <st:adjunct includes="io.jenkins.blueocean.try"/>
 </j:jelly>

--- a/blueocean-dashboard/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
+++ b/blueocean-dashboard/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
@@ -123,7 +123,7 @@ public class BlueOceanWebURLBuilderTest {
     }
 
     private void assertURL(String expected, String actual) throws IOException {
-        Assert.assertEquals(jenkinsRule.getURL().toString() + expected, actual);
+        Assert.assertEquals(expected, actual);
     }
 
     @Before

--- a/blueocean-dashboard/src/test/java/io/jenkins/blueocean/preload/StatePreloaderTest.java
+++ b/blueocean-dashboard/src/test/java/io/jenkins/blueocean/preload/StatePreloaderTest.java
@@ -51,7 +51,7 @@ public class StatePreloaderTest extends BaseTest {
         // Lets request the activity page for that project. The page should
         // contain some prefetched javascript for the pipeline
         // details + the runs on the page
-        String projectBlueUrl = BlueOceanWebURLBuilder.toBlueOceanURL(freestyleProject);
+        String projectBlueUrl = j.jenkins.getRootUrl() + BlueOceanWebURLBuilder.toBlueOceanURL(freestyleProject);
         Document doc = Jsoup.connect(projectBlueUrl + "/activity/").get();
         String script = doc.select("head script").toString();
 

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -9,13 +9,17 @@ $(document).ready(() => {
         var blueUrl = contextUrlDiv.attr('data-context-url');
         var classicUrl = contextUrlDiv.attr('data-classic-url');
         if (classicUrl) {
-            tryBlueOceanUrl = window.location.href.replace(classicUrl, blueUrl);
-        } else {
-            tryBlueOceanUrl = `./blue`;
+            var indexOfContext = window.location.href.indexOf(classicUrl);
+            if (indexOfContext !== -1) {
+                tryBlueOceanUrl = window.location.href.substring(0, indexOfContext) + blueUrl;
+            }
         }
-    } else {
+    }
+
+    if (!tryBlueOceanUrl) {
         tryBlueOceanUrl = `./blue`;
     }
+
     tryBlueOcean.attr('href', tryBlueOceanUrl);
 
     $('#page-head #header').append(tryBlueOcean);

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -1,23 +1,20 @@
 var $ = require('jquery-detached').getJQuery();
 
-function getAppUrl() {
-    const rootUrl = $('head').attr('data-rooturl');
-    if (!rootUrl) {
-        return '';
-    } else {
-        return rootUrl;
-    }
-}
-
 $(document).ready(() => {
     var tryBlueOcean = $('<a id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</a>');
     var contextUrlDiv = $('#blueocean-context-url');
     var tryBlueOceanUrl;
 
     if (contextUrlDiv.length === 1) {
-        tryBlueOceanUrl = contextUrlDiv.attr('data-context-url');
+        var blueUrl = contextUrlDiv.attr('data-context-url');
+        var classicUrl = contextUrlDiv.attr('data-classic-url');
+        if (classicUrl) {
+            tryBlueOceanUrl = window.location.href.replace(classicUrl, blueUrl);
+        } else {
+            tryBlueOceanUrl = `./blue`;
+        }
     } else {
-        tryBlueOceanUrl = `${getAppUrl()}/blue`;
+        tryBlueOceanUrl = `./blue`;
     }
     tryBlueOcean.attr('href', tryBlueOceanUrl);
 

--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -1,7 +1,6 @@
 var $ = require('jquery-detached').getJQuery();
 
 $(document).ready(() => {
-    var tryBlueOcean = $('<a id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</a>');
     var contextUrlDiv = $('#blueocean-context-url');
     var tryBlueOceanUrl;
 
@@ -20,7 +19,7 @@ $(document).ready(() => {
         tryBlueOceanUrl = `./blue`;
     }
 
+    var tryBlueOcean = $('<a id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</a>');
     tryBlueOcean.attr('href', tryBlueOceanUrl);
-
     $('#page-head #header').append(tryBlueOcean);
 });


### PR DESCRIPTION
# Description

... so that it no longer matters if the configured Jenkins URL is different to current browser URL e.g. from outside a proxy.

See [JENKINS-41638](https://issues.jenkins-ci.org/browse/JENKINS-41638).

To test ... run a local Jenkins with this change ... run something like `ngrok` locally ... browse to the Jenkins via the `ngrok` URL  e.g. browsing to `http://555862b4.ngrok.io/jenkins/job/ATH/job/activateFolder/` should result in an "Open Blue Ocean" linking to `http://555862b4.ngrok.io/jenkins/blue/organizations/jenkins/ATH/branches` Vs it trying to use the configured Jenkins URL (`localhost:8080` etc)..

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
