### PR TITLE
[FIX JENKINS-40755] Disable settings link when user does not have edit permissions

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.68-tf-JENKINS-40755-2",
+  "version": "0.0.68",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.67",
+  "version": "0.0.68-tf-JENKINS-40755-2",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/security.js
+++ b/blueocean-core-js/src/js/security.js
@@ -20,6 +20,7 @@ const permit = (subject) => {
 
     return {
         read: () => checkPermissions('read'),
+        configure: () => checkPermissions('configure'),
         create: () => checkPermissions('create'),
         start: () => checkPermissions('start'),
         stop: () => checkPermissions('stop'),

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.68-tf-JENKINS-40755-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
+      "version": "0.0.68",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.67",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.67",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.67.tgz"
+      "version": "0.0.68-tf-JENKINS-40755-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",
@@ -4324,7 +4324,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
@@ -4698,7 +4698,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "from": "js-yaml@>=3.6.0 <4.0.0",
+      "from": "js-yaml@>=3.5.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz"
     },
     "jsbn": {
@@ -5616,7 +5616,7 @@
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "minimatch@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
@@ -5702,7 +5702,7 @@
     },
     "ms": {
       "version": "0.7.2",
-      "from": "ms@>=0.7.1 <0.8.0",
+      "from": "ms@0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "multimatch": {
@@ -5954,7 +5954,7 @@
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-inspect": {
@@ -7658,7 +7658,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -8340,7 +8340,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <5.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.68",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.67",
+    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
@@ -7,7 +7,7 @@ import {
     TabLink,
     WeatherIcon,
 } from '@jenkins-cd/design-language';
-import { i18nTranslator, NotFound, User, Paths, ContentPageHeader, logging, AppConfig, Security } from '@jenkins-cd/blueocean-core-js';
+import { i18nTranslator, NotFound, Paths, ContentPageHeader, logging, AppConfig, Security } from '@jenkins-cd/blueocean-core-js';
 import { Icon } from '@jenkins-cd/react-material-icons';
 import PageLoading from './PageLoading';
 import { buildOrganizationUrl, buildPipelineUrl, buildClassicConfigUrl } from '../util/UrlUtils';

--- a/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelinePage.jsx
@@ -7,7 +7,7 @@ import {
     TabLink,
     WeatherIcon,
 } from '@jenkins-cd/design-language';
-import { i18nTranslator, NotFound, User, Paths, ContentPageHeader, logging, AppConfig } from '@jenkins-cd/blueocean-core-js';
+import { i18nTranslator, NotFound, User, Paths, ContentPageHeader, logging, AppConfig, Security } from '@jenkins-cd/blueocean-core-js';
 import { Icon } from '@jenkins-cd/react-material-icons';
 import PageLoading from './PageLoading';
 import { buildOrganizationUrl, buildPipelineUrl, buildClassicConfigUrl } from '../util/UrlUtils';
@@ -21,7 +21,7 @@ const RestPaths = Paths.rest;
 
 const classicConfigLink = (pipeline) => {
     let link = null;
-    if (!User.current().isAnonymous()) {
+    if (Security.permit(pipeline).configure()) {
         link = <a href={buildClassicConfigUrl(pipeline)} target="_blank"><Icon size={24} icon="settings" style={{ fill: '#fff' }} /></a>;
     }
     return link;

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -15,7 +15,7 @@ import { RunDetailsHeader } from './RunDetailsHeader';
 import { RunRecord } from './records';
 import { FullScreen } from './FullScreen';
 import PageLoading from './PageLoading';
-import { Paths, capable, locationService } from '@jenkins-cd/blueocean-core-js';
+import { Paths, capable, locationService, Security } from '@jenkins-cd/blueocean-core-js';
 import { observer } from 'mobx-react';
 import { User } from '@jenkins-cd/blueocean-core-js';
 
@@ -26,7 +26,7 @@ const logger = logging.logger('io.jenkins.blueocean.dashboard.RunDetails');
 
 const classicConfigLink = (pipeline) => {
     let link = null;
-    if (!User.current().isAnonymous()) {
+    if (Security.permit(pipeline).configure()) {
         let url = buildClassicConfigUrl(pipeline);
         link = (
             <a href={ url } target="_blank" style={ { height: '24px' } }>

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -17,7 +17,6 @@ import { FullScreen } from './FullScreen';
 import PageLoading from './PageLoading';
 import { Paths, capable, locationService, Security } from '@jenkins-cd/blueocean-core-js';
 import { observer } from 'mobx-react';
-import { User } from '@jenkins-cd/blueocean-core-js';
 
 const { func, object, any, string } = PropTypes;
 

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.68-tf-JENKINS-40755-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
+      "version": "0.0.68",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.67",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.67",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.67.tgz"
+      "version": "0.0.68-tf-JENKINS-40755-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.67",
+    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.68",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -304,6 +304,7 @@ public class AbstractPipelineImpl extends BluePipeline {
     public static Map<String, Boolean> getPermissions(AbstractItem item){
         return ImmutableMap.of(
             BluePipeline.CREATE_PERMISSION, item.getACL().hasPermission(Item.CREATE),
+            BluePipeline.CONFIGURE_PERMISSION, item.getACL().hasPermission(Item.CONFIGURE),
             BluePipeline.READ_PERMISSION, item.getACL().hasPermission(Item.READ),
             BluePipeline.START_PERMISSION, item.getACL().hasPermission(Item.BUILD),
             BluePipeline.STOP_PERMISSION, item.getACL().hasPermission(Item.CANCEL)

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
@@ -41,6 +41,9 @@ public abstract class BluePipeline extends Resource {
     /** Create pipeline */
     public static final String CREATE_PERMISSION = "create";
 
+    /** Configure pipeline */
+    public static final String CONFIGURE_PERMISSION = "configure";
+
     /** Read pipeline permission */
     public static final String READ_PERMISSION = "read";
 

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.68-tf-JENKINS-40755-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
+      "version": "0.0.68",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.67",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.67",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.67.tgz"
+      "version": "0.0.68-tf-JENKINS-40755-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.68-tf-JENKINS-40755-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.68-tf-JENKINS-40755-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.112",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.68",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.67",
+    "@jenkins-cd/blueocean-core-js": "0.0.68-tf-JENKINS-40755-2",
     "@jenkins-cd/design-language": "0.0.112",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
# Description

See [JENKINS-40755](https://issues.jenkins-ci.org/browse/JENKINS-40755).

Hmmm ... not sure how we can do an ATH test for this without the ability to login and set permissions. Manual testing obviously involves adding a user with just read permissions and checking that they don't get the settings link.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
