### PR TITLE
[FIX JENKINS-42068] Ignore queue-enter MBP indexing event in `core-js:services/DefaultSSEHandler.js`

### DIFF
--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.75-tf-JENKINS-42068-1",
+  "version": "0.0.75",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.74",
+  "version": "0.0.75-tf-JENKINS-42068-1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -74,7 +74,7 @@ export class DefaultSSEHandler {
     queueEnter(event) {
         // Ignore the event if there's no branch name. Usually indicates
         // that the event is wrt MBP indexing.
-        if (!event.blueocean_job_branch_name) {
+        if (event.job_ismultibranch && !event.blueocean_job_branch_name) {
             return;
         }
 

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -72,6 +72,12 @@ export class DefaultSSEHandler {
         }
     }
     queueEnter(event) {
+        // Ignore the event if there's no branch name. Usually indicates
+        // that the event is wrt MBP indexing.
+        if (!event.blueocean_job_branch_name) {
+            return;
+        }
+
         const queueId = event.job_run_queueId;
         const self = `${event.blueocean_job_rest_url}queue/${queueId}/`;
         const id = this.activityService.getExpectedBuildNumber(event);

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.74",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.74",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.74.tgz"
+      "version": "0.0.75-tf-JENKINS-42068-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.75-tf-JENKINS-42068-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
+      "version": "0.0.75",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.74",
+    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.75",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.74",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.74",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.74.tgz"
+      "version": "0.0.75-tf-JENKINS-42068-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.75-tf-JENKINS-42068-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
+      "version": "0.0.75",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.75",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.74",
+    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.74",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.74",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.74.tgz"
+      "version": "0.0.75-tf-JENKINS-42068-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.75-tf-JENKINS-42068-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.75-tf-JENKINS-42068-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75-tf-JENKINS-42068-1.tgz"
+      "version": "0.0.75",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.75",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.75.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.116",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.75",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.74",
+    "@jenkins-cd/blueocean-core-js": "0.0.75-tf-JENKINS-42068-1",
     "@jenkins-cd/design-language": "0.0.116",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
# Description

[See JENKINS-42068](https://issues.jenkins-ci.org/browse/JENKINS-42068)

Side effect of the new MBP indexing events. Results in an "undefined" row inserted into the list of branches in a MBP.

<img width="1007" alt="screenshot 2017-02-16 17 39 11" src="https://cloud.githubusercontent.com/assets/429311/23036720/c841b1f0-f47b-11e6-9b40-facef07950e5.png">

@reviewbybees esp @cliffmeyers 
