### PR TITLE
why not include editor, the proper way

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -81,6 +81,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>blueocean-autofavorite</artifactId>
         </dependency>
+        
+        <dependency>
+          <groupId>io.jenkins.blueocean</groupId>
+          <artifactId>blueocean-pipeline-editor</artifactId>        
+        </dependency>
+
 
         <!-- Test deps -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,12 @@
             <artifactId>favorite</artifactId>
             <version>2.0.4</version>
         </dependency>
+        <dependency>
+          <groupId>io.jenkins.blueocean</groupId>
+          <artifactId>blueocean-pipeline-editor</artifactId>        
+          <version>0.1-preview-4</version>
+        </dependency>
+        
 
         <!-- Needed for blueocean-display-url plugin -->
         <dependency>


### PR DESCRIPTION
We can include the editor this way, worked for me locally. See how this works. 

cc @i386 @kzantow I think this is how it could happen - right? 

https://issues.jenkins-ci.org/browse/JENKINS-42134