### PR TITLE
[FIX JENKINS-41425] Fix UI issues where Job name is not encoded (has slashes etc)

### DIFF
--- a/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
+++ b/blueocean-dashboard/src/main/java/io/jenkins/blueocean/BlueOceanWebURLBuilder.java
@@ -124,7 +124,7 @@ public class BlueOceanWebURLBuilder {
         } else if (classicModelObject instanceof Item) {
             Resource blueResource = BluePipelineFactory.resolve((Item) classicModelObject);
             if (blueResource instanceof BlueMultiBranchPipeline) {
-                return getOrgPrefix() + "/" + encodeURIComponent(((BluePipeline) blueResource).getFullName()) + "/branches";
+                return getOrgPrefix() + "/" + encodeURIComponent(decodeURIComponent(((BluePipeline) blueResource).getFullName())) + "/branches";
             }
         }
 
@@ -149,13 +149,13 @@ public class BlueOceanWebURLBuilder {
             return new BlueOceanModelMapping(
                 multibranchJob,
                 multibranchJobResource,
-                getOrgPrefix() + "/" + encodeURIComponent(multibranchJobResource.getFullName())
+                getOrgPrefix() + "/" + encodeURIComponent(decodeURIComponent(multibranchJobResource.getFullName()))
             );
         } else {
             return new BlueOceanModelMapping(
                 job,
                 blueResource,
-                getOrgPrefix() + "/" + encodeURIComponent(blueResource.getFullName())
+                getOrgPrefix() + "/" + encodeURIComponent(decodeURIComponent(blueResource.getFullName()))
             );
         }
     }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -26,6 +26,7 @@ package io.jenkins.blueocean.events;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import io.jenkins.blueocean.commons.BlueUrlTokenizer;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
@@ -62,9 +63,10 @@ public class BlueMessageEnricher extends MessageEnricher {
             JobChannelMessage jobChannelMessage = (JobChannelMessage) message;
             Item jobChannelItem = jobChannelMessage.getJobChannelItem();
             Link jobUrl = LinkResolver.resolveLink(jobChannelItem);
+            String fullJobName = BlueUrlTokenizer.reconstructJobNamePath(jobChannelItem.getName(), jobChannelItem.getFullName());
 
             jobChannelMessage.set(BlueEventProps.blueocean_job_rest_url, jobUrl.getHref());
-            jobChannelMessage.set(BlueEventProps.blueocean_job_pipeline_name, jobChannelItem.getFullName());
+            jobChannelMessage.set(BlueEventProps.blueocean_job_pipeline_name, fullJobName);
             if (jobChannelItem instanceof WorkflowJob) {
                 ItemGroup<? extends Item> parent = jobChannelItem.getParent();
                 if (parent instanceof WorkflowMultiBranchProject) {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -374,7 +374,12 @@ public class AbstractPipelineImpl extends BluePipeline {
             // encoded. This will be a no-op if the string is not encoded.
             string = URLDecoder.decode(string, "UTF-8");
             // And encode ...
-            return URLEncoder.encode(string, "UTF-8");
+            string = URLEncoder.encode(string, "UTF-8");
+            // The Java URLEncoder encodes spaces as "+", while the javascript
+            // encodeURIComponent function encodes them as "%20". We need to make them
+            // consistent with how it's done in encodeURIComponent, so replace the
+            // "+" with "%20".
+            return string.replace("+", "%20");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("Unexpected exception re-encoding the pipeline name.", e);
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Iterators;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractItem;
-import hudson.model.Action;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
@@ -32,14 +31,17 @@ import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.WebMethod;
-import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.json.JsonBody;
 import org.kohsuke.stapler.verb.DELETE;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -143,7 +145,11 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     @Override
     public String getFullName(){
-        return job.getFullName();
+        // Lets make sure that the fullName is properly encoded etc.
+        // The name part of the fullName can contain unencoded characters
+        // if the Job was programmatically created, causing screwups
+        // when mapping those URLs to Blue Ocean web/rest URLs. See JENKINS-41425.
+        return reconstructJobNamePath(job.getName(), job.getFullName(), "/");
     }
 
     @Override
@@ -178,22 +184,54 @@ public class AbstractPipelineImpl extends BluePipeline {
         return OrganizationImpl.INSTANCE.getLink().rel("pipelines").rel(getRecursivePathFromFullName(this));
     }
 
-    public static String getRecursivePathFromFullName(BluePipeline pipeline){
-        StringBuilder pipelinePath = new StringBuilder();
-        String[] names = pipeline.getFullName().split("/");
-        int count = 1;
-        if(names.length > 1) { //nested
-            for (String n : names) {
-                if(count == 1){
-                    pipelinePath.append(n);
-                }else{
-                    pipelinePath.append("/pipelines/").append(n);
-                }
-                count++;
-            }
-        }else{
-            pipelinePath.append(pipeline.getFullName());
+    public static String getRecursivePathFromFullName(BluePipeline pipeline) {
+        if (pipeline instanceof AbstractPipelineImpl) {
+            // Slight optimization to eliminate multiple calls to reconstructJobNamePath().
+            // See AbstractPipelineImpl.getFullName() and how it calls reconstructJobNamePath().
+            AbstractPipelineImpl abstractPipeline = (AbstractPipelineImpl) pipeline;
+            return reconstructJobNamePath(abstractPipeline.job.getName(), abstractPipeline.job.getFullName(), "/pipelines/");
+        } else {
+            return reconstructJobNamePath(pipeline.getName(), pipeline.getFullName(), "/pipelines/");
         }
+    }
+
+    private static String reconstructJobNamePath(String name, String fullName, String separator){
+        StringBuilder pipelinePath = new StringBuilder();
+        String fullPath;
+        List<String> pathTokens;
+
+        //
+        // The Job "fullName" is typically suffixed with the "name".
+        // The name is NOT part of the path to the job, so lets remove
+        // it from the fullName before we parse and reconstruct the path.
+        // This, along with reencoding of the name, helps us to eliminate
+        // the problems where a Job is programatically created with a name
+        // that's not URL encoded and contains characters that should be
+        // encoded e.g. slashes (see JENKINS-41425).
+        //
+        if (fullName.endsWith(name)) {
+            fullPath = fullName.substring(0, fullName.length() - name.length());
+            pathTokens = new ArrayList<>();
+            pathTokens.addAll(Arrays.asList(fullPath.split("/")));
+            pathTokens.add(urlReencode(name));
+        } else {
+            fullPath = fullName;
+            pathTokens = Arrays.asList(fullPath.split("/"));
+        }
+
+        for (String n : pathTokens) {
+            if (n.length() == 0) {
+                // Ignore empty strings. Can be caused by
+                // leading/trailing slashes.
+                continue;
+            }
+            // Don't add the separator to the start of the path.
+            if(pipelinePath.length() > 0){
+                pipelinePath.append(separator);
+            }
+            pipelinePath.append(n);
+        }
+
         return pipelinePath.toString();
     }
 
@@ -322,4 +360,23 @@ public class AbstractPipelineImpl extends BluePipeline {
         return user != null && Favorites.isFavorite(user, job);
     }
 
+    /**
+     * Re-encode the supplied string.
+     * <p>
+     * Use this on strings that may already be encoded, but are not guaranteed to
+     * be e.g. Job names (see JENKINS-41425).
+     * @param string The string to be re-encoded.
+     * @return The re-encoded string.
+     */
+    private static String urlReencode(String string) {
+        try {
+            // Decode the string in case it's already encoded, or partially
+            // encoded. This will be a no-op if the string is not encoded.
+            string = URLDecoder.decode(string, "UTF-8");
+            // And encode ...
+            return URLEncoder.encode(string, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Unexpected exception re-encoding the pipeline name.", e);
+        }
+    }
 }


### PR DESCRIPTION
# Description

See [JENKINS-41425](https://issues.jenkins-ci.org/browse/JENKINS-41425).

The pages are rendering now with these changes. Needs some tests etc.

I think @vivek needs to have a close look at this since he obviously has the bigger picture here wrt the REST API etc. Maybe he'll want to take this altogether.

To test, I used the script console to programmatically create a Job with slashes in the name e.g.

```groovy
def jenkins = Jenkins.getInstance();

jenkins.createProject(org.jenkinsci.plugins.workflow.job.WorkflowJob, "a/job/with/slashes");
```

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
