### PR TITLE
[FIX JENKINS-38751] Escape back to Jenkins classic

### DIFF
--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.81-ivanbeta1",
+  "version": "0.0.82",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.121",
@@ -2738,7 +2738,7 @@
     },
     "flow-bin": {
       "version": "0.34.0",
-      "from": "flow-bin@>=0.34.0 <0.35.0",
+      "from": "flow-bin@0.34.0",
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.34.0.tgz",
       "dev": true
     },

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.82-tf-JENKINS-38751-1",
+  "version": "0.0.82",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.81",
+  "version": "0.0.82-tf-JENKINS-38751-1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/config.js
+++ b/blueocean-core-js/src/js/config.js
@@ -70,7 +70,7 @@ export default {
         if (!config.isLoaded) {
             this.loadUrls();
         }
-        return (config.jenkinsRootURL !== undefined ? config.jenkinsRootURL : '/jenkins');
+        return (typeof config.jenkinsRootURL === 'string' ? config.jenkinsRootURL : '/jenkins');
     },
 
     getRestRoot() {

--- a/blueocean-core-js/src/js/config.js
+++ b/blueocean-core-js/src/js/config.js
@@ -70,7 +70,7 @@ export default {
         if (!config.isLoaded) {
             this.loadUrls();
         }
-        return config.jenkinsRootURL || '/jenkins';
+        return (config.jenkinsRootURL !== undefined ? config.jenkinsRootURL : '/jenkins');
     },
 
     getRestRoot() {

--- a/blueocean-core-js/src/js/index.js
+++ b/blueocean-core-js/src/js/index.js
@@ -123,4 +123,5 @@ export {
     getRestUrl,
     buildUrl,
     relativeUrl,
+    toClassicJobPage,
 } from './utils/UrlUtils';

--- a/blueocean-core-js/src/js/utils/UrlUtils.js
+++ b/blueocean-core-js/src/js/utils/UrlUtils.js
@@ -257,7 +257,7 @@ export function relativeUrl(location, ...args) {
  * it was unable to decode the page URL.
  */
 export function toClassicJobPage(pageUrl, isMultibranch = false) {
-    const pageUrlTokens = pageUrl.split('/');
+    const pageUrlTokens = pageUrl.split('/').filter((token) => typeof token === 'string' && token !== '');
 
     // Remove all path elements up to and including the Jenkins
     // organization name.

--- a/blueocean-core-js/src/js/utils/UrlUtils.js
+++ b/blueocean-core-js/src/js/utils/UrlUtils.js
@@ -249,3 +249,67 @@ export function buildUrl(...args) {
 export function relativeUrl(location, ...args) {
     return endSlash(location.pathname) + buildUrl.apply(null, args);
 }
+
+/**
+ * Check is the current Blue ocean page a pipeline page and if so,
+ * decode it to the corresponding classic Jenkins Job page.
+ * @returns {string|undefined} The classic job page, or undefined if
+ * it was unable to decode the page URL.
+ */
+export function toClassicJobPage(pageUrl, isMultibranch = false) {
+    const pageUrlTokens = pageUrl.split('/');
+
+    // Remove all path elements up to and including the Jenkins
+    // organization name.
+    let token = pageUrlTokens.shift();
+    while (token !== undefined && token !== 'organizations') {
+        token = pageUrlTokens.shift();
+    }
+
+    if (pageUrlTokens.length > 1) {
+        // The next token is the actual organization name e.g. "jenkins".
+        // Remove that since we don't need it.
+        pageUrlTokens.shift();
+
+        // The next token is the "full" job name, URL encoded.
+        const fullJobName = decodeURIComponent(pageUrlTokens.shift());
+        const fullJobNameTokens = fullJobName.split('/');
+        const classicJobFullName = '/job/' + fullJobNameTokens.join('/job/');
+
+        if (pageUrlTokens.length > 1) {
+            // The next token being "detail" indicates that we're looking
+            // at a branch.
+            if (pageUrlTokens.shift() === 'detail') {
+                // is going to be something like one of:
+                // - detail/[freestyleA/activity]
+                // - detail/[freestyleA/2/pipeline]
+                if (isMultibranch) {
+                    const branchName = pageUrlTokens.shift(); // "freestyleA"
+                    const classicJobBranch = classicJobFullName + '/job/' + branchName;
+
+                    // And if there's more than one token left then we have
+                    // the detail/freestyleA/[2/pipeline] variant. The next
+                    // token is the runId
+                    if (pageUrlTokens.length > 1) {
+                        return classicJobBranch + '/' + pageUrlTokens.shift(); // "2"
+                    }
+
+                    return classicJobBranch;
+                } else if (pageUrlTokens.length > 2) {
+                    // And if there's more than two tokens left then we have
+                    // the detail/[freestyleA/2/pipeline] variant.
+                    // Next token is the branch name - not really a branch name !!
+                    // Ignoring it.
+                    pageUrlTokens.shift(); // "freestyleA"
+                    // And the next token is the runId.
+                    const runId = pageUrlTokens.shift(); // "2"
+                    return classicJobFullName + '/' + runId;
+                }
+            }
+        }
+
+        return classicJobFullName;
+    }
+
+    return undefined;
+}

--- a/blueocean-core-js/src/less/header.less
+++ b/blueocean-core-js/src/less/header.less
@@ -29,6 +29,8 @@
 
 .ContentPageHeader-user {
 
+    display: flex;
+    height: 100%;
     padding-left: 1em;
 
     * {
@@ -49,6 +51,24 @@
         background: none;
         min-width: 0;
         border-color: white;
+    }
+
+    .user-component {
+        display: inline-block;
+        align-items: center;
+        height: 100%;
+
+        &.icon {
+            padding-top: 13px;
+            svg {
+                fill: white;
+                width: 24px;
+                height: 24px;
+            }
+        }
+        &.button-bar {
+            padding-top: 11px;
+        }
     }
 }
 

--- a/blueocean-core-js/test/js/UrlUtils-spec.js
+++ b/blueocean-core-js/test/js/UrlUtils-spec.js
@@ -1,0 +1,32 @@
+import { assert } from 'chai';
+
+import { toClassicJobPage } from '../../src/js/utils/UrlUtils';
+
+describe('UrlUtils', () => {
+    it('toClassicJobPage - Non Multibranch', () => {
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/freestyleA/detail/freestyleA/activity', false),
+            '/job/freestyleA');
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/freestyleA/detail/freestyleA/2/pipeline', false),
+            '/job/freestyleA/2');
+
+        // In a folder
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/Foo%2FBar/activity', false),
+            '/job/Foo/job/Bar');
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/Foo%2FBar/detail/Bar/1/pipeline', false),
+            '/job/Foo/job/Bar/1');
+    });
+
+    it('toClassicJobPage - Multibranch', () => {
+        // A job down in a folder
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/folder1%2Ffolder2%2FATH/activity', true),
+            '/job/folder1/job/folder2/job/ATH');
+        assert.equal(toClassicJobPage(
+            '/jenkins/blue/organizations/jenkins/folder1%2Ffolder2%2FATH/detail/master/1/pipeline', true),
+            '/job/folder1/job/folder2/job/ATH/job/master/1');
+    });
+});

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82-tf-JENKINS-38751-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
+      "version": "0.0.82",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.81",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.81",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.81.tgz"
+      "version": "0.0.82-tf-JENKINS-38751-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",
@@ -3456,7 +3456,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dev": true
         },
@@ -3476,7 +3476,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.6 <3.1.0",
+          "from": "nopt@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "dev": true,
           "optional": true
@@ -3556,7 +3556,7 @@
         },
         "rc": {
           "version": "1.1.6",
-          "from": "rc@>=1.1.6 <1.2.0",
+          "from": "rc@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "dev": true,
           "optional": true,
@@ -3675,7 +3675,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.1 <2.3.0",
+          "from": "tar@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dev": true
         },
@@ -4329,7 +4329,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
@@ -4703,7 +4703,7 @@
     },
     "js-yaml": {
       "version": "3.7.0",
-      "from": "js-yaml@>=3.6.0 <4.0.0",
+      "from": "js-yaml@>=3.5.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz"
     },
     "jsbn": {
@@ -5621,7 +5621,7 @@
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "minimatch@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
@@ -5707,7 +5707,7 @@
     },
     "ms": {
       "version": "0.7.2",
-      "from": "ms@>=0.7.1 <0.8.0",
+      "from": "ms@0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "multimatch": {
@@ -5959,7 +5959,7 @@
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-inspect": {
@@ -7668,7 +7668,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -8350,7 +8350,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <5.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.82",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.81",
+    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -48,7 +48,7 @@ const classicJobRunLink = (pipeline, branch, runId) => {
         runUrl = `${rootPath(pipeline.fullName)}${encodeURIComponent(runId)}`;
     }
     return (
-        <a href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>
+        <a className="exit_to_app" href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>
             <Icon size={ 24 } icon="exit_to_app" style={ { fill: '#fff' } } />
         </a>
     );

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -48,7 +48,7 @@ const classicJobRunLink = (pipeline, branch, runId) => {
         runUrl = `${rootPath(pipeline.fullName)}${encodeURIComponent(runId)}`;
     }
     return (
-        <a className="exit_to_app" href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>
+        <a className="rundetails_exit_to_app" href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>
             <Icon size={ 24 } icon="exit_to_app" style={ { fill: '#fff' } } />
         </a>
     );

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -43,9 +43,9 @@ const classicConfigLink = (pipeline) => {
 const classicJobRunLink = (pipeline, branch, runId) => {
     let runUrl;
     if (pipeline.branchNames) {
-        runUrl = `${rootPath(pipeline.fullName)}job/${branch}/${runId}`;
+        runUrl = `${rootPath(pipeline.fullName)}job/${encodeURIComponent(branch)}/${encodeURIComponent(runId)}`;
     } else {
-        runUrl = `${rootPath(pipeline.fullName)}${runId}`;
+        runUrl = `${rootPath(pipeline.fullName)}${encodeURIComponent(runId)}`;
     }
     return (
         <a href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -5,6 +5,7 @@ import { i18nTranslator, ReplayButton, RunButton, logging } from '@jenkins-cd/bl
 import { Icon } from '@jenkins-cd/react-material-icons';
 
 import {
+    rootPath,
     buildOrganizationUrl,
     buildPipelineUrl,
     buildRunDetailsUrl,
@@ -23,6 +24,9 @@ const { func, object, any, string } = PropTypes;
 const { rest: RestPaths } = Paths;
 const logger = logging.logger('io.jenkins.blueocean.dashboard.RunDetails');
 
+const translate = i18nTranslator('blueocean-dashboard');
+const webTranslate = i18nTranslator('blueocean-web');
+
 const classicConfigLink = (pipeline) => {
     let link = null;
     if (Security.permit(pipeline).configure()) {
@@ -36,7 +40,19 @@ const classicConfigLink = (pipeline) => {
     return link;
 };
 
-const translate = i18nTranslator('blueocean-dashboard');
+const classicJobRunLink = (pipeline, branch, runId) => {
+    let runUrl;
+    if (pipeline.branchNames) {
+        runUrl = `${rootPath(pipeline.fullName)}job/${branch}/${runId}`;
+    } else {
+        runUrl = `${rootPath(pipeline.fullName)}${runId}`;
+    }
+    return (
+        <a href={ runUrl } style={ { height: '24px' } } title={webTranslate('go.to.classic', { defaultValue: 'Go to classic' })}>
+            <Icon size={ 24 } icon="exit_to_app" style={ { fill: '#fff' } } />
+        </a>
+    );
+};
 
 @observer
 class RunDetails extends Component {
@@ -195,6 +211,7 @@ class RunDetails extends Component {
                        buttonType="stop-only"
             />,
             classicConfigLink(pipeline),
+            classicJobRunLink(pipeline, params.branch, params.runId),
         ];
 
         return (

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.81",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.81",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.81.tgz"
+      "version": "0.0.82-tf-JENKINS-38751-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82-tf-JENKINS-38751-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
+      "version": "0.0.82",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.82",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.81",
+    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82-tf-JENKINS-38751-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
+      "version": "0.0.82",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.81",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.81",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.81.tgz"
+      "version": "0.0.82-tf-JENKINS-38751-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.82-tf-JENKINS-38751-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82-tf-JENKINS-38751-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.82",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.81",
+    "@jenkins-cd/blueocean-core-js": "0.0.82-tf-JENKINS-38751-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -81,9 +81,11 @@ class App extends Component {
             <AdminLink t={translate} />,
         ];
 
+        let classicUrl = UrlConfig.getJenkinsRootURL();
+
         const userComponents = [
             <div className="user-component icon" title={translate('go.to.classic', { defaultValue: 'Go to classic' })}>
-                <Icon icon="exit_to_app" />
+                <a href={classicUrl}><Icon icon="exit_to_app" /></a>
             </div>,
             <div className="user-component button-bar layout-small inverse">
                 { loginOrLogout(translate) }

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -14,6 +14,7 @@ import { ToastDrawer } from './components/ToastDrawer';
 import { BackendConnectFailure } from './components/BackendConnectFailure';
 import { DevelopmentFooter } from './DevelopmentFooter';
 import { useStrict } from 'mobx';
+import { Icon } from '@jenkins-cd/react-material-icons';
 useStrict(true);
 
 const LOGGER = logging.logger('io.jenkins.blueocean.web.routing');
@@ -81,7 +82,10 @@ class App extends Component {
         ];
 
         const userComponents = [
-            <div className="button-bar layout-small inverse">
+            <div className="user-component icon">
+                <Icon icon="exit_to_app" />
+            </div>,
+            <div className="user-component button-bar layout-small inverse">
                 { loginOrLogout(translate) }
             </div>
         ];

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -82,7 +82,7 @@ class App extends Component {
         ];
 
         const userComponents = [
-            <div className="user-component icon">
+            <div className="user-component icon" title={translate('go.to.classic', { defaultValue: 'Go to classic' })}>
                 <Icon icon="exit_to_app" />
             </div>,
             <div className="user-component button-bar layout-small inverse">

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -89,6 +89,14 @@ class App extends Component {
             classicUrl = UrlConfig.getJenkinsRootURL();
         }
 
+        // Make sure there's a leading slash so that
+        // the url is rooted...
+        if (!classicUrl || classicUrl === '') {
+            classicUrl = '/';
+        } else if (classicUrl.charAt(0) !== '/') {
+            classicUrl = '/' + classicUrl;
+        }
+
         const userComponents = [
             <div className="user-component icon" title={translate('go.to.classic', { defaultValue: 'Go to classic' })}>
                 <a href={classicUrl}><Icon icon="exit_to_app" /></a>

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -99,7 +99,7 @@ class App extends Component {
 
         const userComponents = [
             <div className="user-component icon" title={translate('go.to.classic', { defaultValue: 'Go to classic' })}>
-                <a href={classicUrl}><Icon icon="exit_to_app" /></a>
+                <a className="exit_to_app" href={classicUrl}><Icon icon="exit_to_app" /></a>
             </div>,
             <div className="user-component button-bar layout-small inverse">
                 { loginOrLogout(translate) }

--- a/blueocean-web/src/main/js/main.jsx
+++ b/blueocean-web/src/main/js/main.jsx
@@ -99,7 +99,7 @@ class App extends Component {
 
         const userComponents = [
             <div className="user-component icon" title={translate('go.to.classic', { defaultValue: 'Go to classic' })}>
-                <a className="exit_to_app" href={classicUrl}><Icon icon="exit_to_app" /></a>
+                <a className="main_exit_to_app" href={classicUrl}><Icon icon="exit_to_app" /></a>
             </div>,
             <div className="user-component button-bar layout-small inverse">
                 { loginOrLogout(translate) }

--- a/blueocean-web/src/main/resources/jenkins/plugins/blueocean/web/Messages.properties
+++ b/blueocean-web/src/main/resources/jenkins/plugins/blueocean/web/Messages.properties
@@ -34,3 +34,4 @@ parameter.error.title=Error
 # the parameterMessage keys assume that you will parse them with a markdown parser
 inputParameter.error.message=This pipeline uses input types that are unsupported. Use [Jenkins Classic]({0}) to resolve parametrized build.
 inputParameter.error.title=Error
+go.to.classic=Go to classic


### PR DESCRIPTION
# Description

See [JENKINS-38751](https://issues.jenkins-ci.org/browse/JENKINS-38751).

Can be manually tested. Look for the "escape to app" widget in the headers (main and run details).

![screenshot 2017-02-22 16 44 16](https://cloud.githubusercontent.com/assets/429311/23221935/44b2719c-f91e-11e6-93b3-1af7d39e387f.png)

ATH tests: https://github.com/jenkinsci/blueocean-acceptance-test/pull/123

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
