### PR TITLE
[JENKINS-42148] single repo missing jenkinsfile

### DIFF
--- a/blueocean-dashboard/src/main/js/creation/github/GithubCreationState.js
+++ b/blueocean-dashboard/src/main/js/creation/github/GithubCreationState.js
@@ -21,6 +21,7 @@ const GithubCreationState = new Enum({
     PENDING_CREATION_EVENTS: 'pending_creation_events',
     STEP_COMPLETE_EVENT_ERROR: 'step_complete_event_error',
     STEP_COMPLETE_EVENT_TIMEOUT: 'step_complete_event_timeout',
+    STEP_COMPLETE_MISSING_JENKINSFILE: 'step_complete_missing_jenkinsfile',
     STEP_COMPLETE_SUCCESS: 'step_complete_success',
 });
 

--- a/blueocean-dashboard/src/main/js/creation/github/GithubFlowManager.js
+++ b/blueocean-dashboard/src/main/js/creation/github/GithubFlowManager.js
@@ -17,11 +17,13 @@ import GithubConfirmDiscoverStep from './steps/GithubConfirmDiscoverStep';
 import GithubRepositoryStep from './steps/GithubRepositoryStep';
 import GithubCompleteStep from './steps/GithubCompleteStep';
 
-const LOGGER = logging.logger('io.jenkins.blueocean.github-pipeline.GithubFlowManager');
+const LOGGER = logging.logger('io.jenkins.blueocean.github-pipeline');
 const MIN_DELAY = 500;
 const FIRST_PAGE = 1;
 const PAGE_SIZE = 100;
 const SSE_TIMEOUT_DELAY = 1000 * 60;
+const PIPELINE_CHECK_DELAY = 1000 * 5;
+
 
 export default class GithubFlowManager extends FlowManager {
 
@@ -78,6 +80,7 @@ export default class GithubFlowManager extends FlowManager {
             this.stateId === STATE.PENDING_CREATION_EVENTS ||
             this.stateId === STATE.STEP_COMPLETE_EVENT_ERROR ||
             this.stateId === STATE.STEP_COMPLETE_EVENT_TIMEOUT ||
+            this.stateId === STATE.STEP_COMPLETE_MISSING_JENKINSFILE ||
             this.stateId === STATE.STEP_COMPLETE_SUCCESS;
     }
 
@@ -217,6 +220,7 @@ export default class GithubFlowManager extends FlowManager {
         const { isFound, isOrgFolder, orgFolder } = result;
 
         if (isFound && isOrgFolder) {
+            LOGGER.debug(`selected existing org folder: ${orgFolder.name}`);
             this.existingOrgFolder = orgFolder;
 
             this.renderStep({
@@ -225,6 +229,8 @@ export default class GithubFlowManager extends FlowManager {
                 afterStateId: STATE.STEP_CHOOSE_ORGANIZATION,
             });
         } else if (!result.isFound) {
+            LOGGER.debug('selected new organization');
+
             this.renderStep({
                 stateId: STATE.STEP_CHOOSE_DISCOVER,
                 stepElement: <GithubChooseDiscoverStep />,
@@ -378,16 +384,20 @@ export default class GithubFlowManager extends FlowManager {
 
     @action
     _saveOrgFolderSuccess(orgFolder) {
+        LOGGER.debug(`org folder saved successfully: ${orgFolder.name}`);
         this.changeState(STATE.PENDING_CREATION_EVENTS);
         this.savedOrgFolder = orgFolder;
     }
 
     _saveOrgFolderFailure() {
+        LOGGER.error('org folder save failed!');
         this.changeState(STATE.STEP_COMPLETE_SAVING_ERROR);
     }
 
     _initListeners() {
         this._cleanupListeners();
+
+        LOGGER.debug('listening for org folder and multibranch indexing events...');
 
         this._sseSubscribeId = sseService.registerHandler(event => this._onSseEvent(event));
         this._sseTimeoutId = setTimeout(() => {
@@ -396,6 +406,10 @@ export default class GithubFlowManager extends FlowManager {
     }
 
     _cleanupListeners() {
+        if (this._sseSubscribeId || this._sseTimeoutId) {
+            LOGGER.debug('cleaning up existing SSE listeners');
+        }
+
         if (this._sseSubscribeId) {
             sseService.removeHandler(this._sseSubscribeId);
             this._sseSubscribeId = null;
@@ -414,6 +428,10 @@ export default class GithubFlowManager extends FlowManager {
             return;
         }
 
+        if (LOGGER.isDebugEnabled()) {
+            this._logEvent(event);
+        }
+
         if (event.job_orgfolder_indexing_result === 'FAILURE') {
             this._finishListening(STATE.STEP_COMPLETE_EVENT_ERROR);
         }
@@ -426,19 +444,48 @@ export default class GithubFlowManager extends FlowManager {
             this._finishListening(STATE.STEP_COMPLETE_SUCCESS);
         }
 
-        const repoName = event.blueocean_job_pipeline_name.split('/').pop();
-
-        if (!this.selectedAutoDiscover && event.job_multibranch_indexing_result === 'SUCCESS' && this.selectedRepository.name === repoName) {
-            this.savedPipeline = {
-                organization: event.jenkins_org,
-                fullName: event.job_name,
-            };
-            this._incrementPipelineCount();
-            this._finishListening(STATE.STEP_COMPLETE_SUCCESS);
+        if (!this.selectedAutoDiscover && event.job_orgfolder_indexing_result === 'SUCCESS') {
+            const pipelineFullName = `${this.selectedOrganization.name}/${this.selectedRepository.name}`;
+            this._checkForSingleRepoCreation(pipelineFullName);
+            this._cleanupListeners();
         }
+    }
 
-        if (LOGGER.isDebugEnabled()) {
-            this._logEvent(event);
+    /**
+     * Complete creation process after an individual pipeline was created.
+     * @param pipeline
+     * @private
+     */
+    _completeSingleRepo(pipeline) {
+        this.savedPipeline = pipeline;
+        LOGGER.info(`creation succeeeded for ${pipeline.fullName}`);
+
+        this._incrementPipelineCount();
+        this._finishListening(STATE.STEP_COMPLETE_SUCCESS);
+    }
+
+    /**
+     * Check for creation of a single pipeline within an org folder
+     * @param pipelineName
+     * @private
+     */
+    _checkForSingleRepoCreation(pipelineName) {
+        LOGGER.debug('org folder indexing completed but no pipeline has been created (yet?)');
+        LOGGER.debug(`will check for single repo creation of ${pipelineName} in ${PIPELINE_CHECK_DELAY}ms`);
+
+        setTimeout(() => {
+            this._creationApi.findExistingOrgFolderPipeline(pipelineName)
+                .then(data => this._checkForSingleRepoCreationComplete(data));
+        }, PIPELINE_CHECK_DELAY);
+    }
+
+    _checkForSingleRepoCreationComplete({ isFound, pipeline }) {
+        LOGGER.debug(`check for pipeline complete. created? ${isFound}`);
+
+        if (isFound) {
+            this._completeSingleRepo(pipeline);
+        } else {
+            this._finishListening(STATE.STEP_COMPLETE_MISSING_JENKINSFILE);
         }
     }
 
@@ -455,6 +502,7 @@ export default class GithubFlowManager extends FlowManager {
     }
 
     _onSseTimeout() {
+        LOGGER.debug(`wait for events timed out after ${SSE_TIMEOUT_DELAY}ms`);
         this.changeState(STATE.STEP_COMPLETE_EVENT_TIMEOUT);
         this._cleanupListeners();
     }

--- a/blueocean-dashboard/src/main/js/creation/github/api/GithubCreationApi.js
+++ b/blueocean-dashboard/src/main/js/creation/github/api/GithubCreationApi.js
@@ -54,6 +54,30 @@ export class GithubCreationApi {
         };
     }
 
+    findExistingOrgFolderPipeline(pipelineName) {
+        const path = UrlConfig.getJenkinsRootURL();
+        const pipelineUrl = Utils.cleanSlashes(`${path}/blue/rest/organizations/jenkins/pipelines/${pipelineName}`);
+        return this._fetch(pipelineUrl)
+            .then(response => capabilityAugmenter.augmentCapabilities(response))
+            .then(
+                pipeline => this._findExistingOrgFolderPipelineSuccess(pipeline),
+                () => this._findExistingOrgFolderPipelineFailure(),
+            );
+    }
+
+    _findExistingOrgFolderPipelineSuccess(pipeline) {
+        return {
+            isFound: true,
+            pipeline,
+        };
+    }
+
+    _findExistingOrgFolderPipelineFailure() {
+        return {
+            isFound: false,
+        };
+    }
+
     createOrgFolder(credentialId, organization, repoNames = []) {
         const path = UrlConfig.getJenkinsRootURL();
         const createUrl = Utils.cleanSlashes(`${path}/blue/rest/organizations/jenkins/pipelines/`);


### PR DESCRIPTION
# Description
- As discussed, if the user selects "single repo", indexing finishes and the pipeline wasn't created, we'll assume there is no Jenkinsfile and provide a button that opens the editor. Note: editor doesn't actually open yet, pending some integration done presumably in a separate PR.
- I added a lot more console logging to more easily debug what's going on. In Chrome, open dev tools, go to "Application" tab, then on the left "Storage" -> "Local Storage" for your jenkins (localhost:8080 typically) then find `jenkins-instance/logging/categories:io.jenkins.blueocean.github-pipeline` and make sure it's set to `DEBUG` - you may have to run the app once for this key to appear automatically. After setting the value, refresh your browser for it to take effect.
- See [JENKINS-42148](https://issues.jenkins-ci.org/browse/JENKINS-42148).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
