### PR TITLE
JENKINS-41439# Fix to handle invalid access token correctly

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
@@ -252,6 +252,24 @@ public class ServiceException extends RuntimeException implements HttpResponse {
             super(METHOD_NOT_ALLOWED, errorMessage, throwable);
         }
     }
+
+    public static class PreconditionRequired extends ServiceException{
+
+        public PreconditionRequired(String message) {
+            super(PRECONDITION_REQUIRED, message);
+        }
+
+        public PreconditionRequired(String message, Throwable throwable ) {
+            super(PRECONDITION_REQUIRED, message, throwable);
+        }
+
+        public PreconditionRequired(ErrorMessage errorMessage) {
+            super(PRECONDITION_REQUIRED, errorMessage, null);
+        }
+        public PreconditionRequired(ErrorMessage errorMessage, Throwable throwable ) {
+            super(PRECONDITION_REQUIRED, errorMessage, throwable);
+        }
+    }
     public static final int BAD_REQUEST = 400;
     public static final int UNAUTHORIZED = 401;
     public static final int FORBIDDEN = 403;
@@ -260,6 +278,7 @@ public class ServiceException extends RuntimeException implements HttpResponse {
     public static final int UNSUPPORTED_MEDIA_TYPE = 415;
     public static final int CONFLICT = 409;
     public static final int UNPROCESSABLE_ENTITY = 422;
+    public static final int PRECONDITION_REQUIRED = 428;
     public static final int TOO_MANY_REQUESTS = 429;
     public static final int INTERNAL_SERVER_ERROR = 500;
     public static final int NOT_IMPLEMENTED = 501;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -1,7 +1,7 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.model.Cause;
 import hudson.model.TopLevelItem;
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.List;
 
 /**
@@ -72,13 +73,13 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequestIm
 
         TopLevelItem item = null;
         try {
-
+            if(credentialId != null) {
+                validateCredentialId(credentialId, apiUrl);
+            }
             item = create(Jenkins.getInstance(), getName(), DESCRIPTOR, CustomOrganizationFolderDescriptor.class);
 
             if (item instanceof OrganizationFolder) {
                 if(credentialId != null) {
-                    validateCredentialId(credentialId, (AbstractFolder) item);
-
                     //Find domain attached to this credentialId, if present check if it's BlueOcean specific domain then
                     //add the properties otherwise simply use it
                     Domain domain = CredentialsUtils.findDomain(credentialId, authenticatedUser);
@@ -129,23 +130,42 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequestIm
         return null;
     }
 
-     static void validateCredentialId(String credentialId, AbstractFolder item) throws IOException {
+
+    static void validateCredentialId(String credentialId,  String apiUrl) throws IOException {
         if (credentialId != null && !credentialId.trim().isEmpty()) {
-            Credentials credentials = CredentialsUtils.findCredential(credentialId, Credentials.class, new BlueOceanDomainRequirement());
+            StandardUsernamePasswordCredentials credentials = CredentialsUtils.findCredential(credentialId, StandardUsernamePasswordCredentials.class, new BlueOceanDomainRequirement());
             if (credentials == null) {
-                try {
-                    item.delete();
-                } catch (InterruptedException e) {
-                    throw new ServiceException.UnexpectedErrorException("Invalid credentialId: " +
-                            credentialId + ". Failure during cleaning up folder: " + item.getName() + ". Error: " +
-                            e.getMessage(), e);
-                }
                 throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to create Git pipeline")
                         .add(new ErrorMessage.Error("scmConfig.credentialId",
                                 ErrorMessage.Error.ErrorCodes.INVALID.toString(),
                                 "Invalid credentialId")));
 
+            } else {
+                String accessToken = credentials.getPassword().getPlainText();
+                validateGithubAccessToken(accessToken, apiUrl);
             }
+        }
+    }
+
+    private static void deleteOnError(AbstractFolder item){
+        try {
+            item.delete();
+        } catch (InterruptedException | IOException e) {
+            throw new ServiceException.UnexpectedErrorException("Failure during cleaning up folder: " + item.getName() + ". Error: " +
+                    e.getMessage(), e);
+        }
+
+    }
+
+    private static void validateGithubAccessToken(String accessToken, String apiUrl) throws IOException {
+        try {
+            HttpURLConnection connection =  GithubScm.connect(apiUrl+"/user", accessToken);
+            GithubScm.validateAccessTokenScopes(connection);
+        } catch (Exception e) {
+            if(e instanceof ServiceException){
+                throw e;
+            }
+            throw new ServiceException.UnexpectedErrorException("Failure validating github access token: "+e.getMessage(), e);
         }
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineUpdateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineUpdateRequest.java
@@ -86,7 +86,7 @@ public class GithubPipelineUpdateRequest extends BluePipelineUpdateRequest {
                 }
                 GitHubSCMNavigator gitHubSCMNavigator = new GitHubSCMNavigator(apiUrl, orgName, credentialId, credentialId);
 
-                GithubPipelineCreateRequest.validateCredentialId(credentialId, folder);
+                GithubPipelineCreateRequest.validateCredentialId(credentialId, apiUrl);
 
                 if (scmConfig != null && scmConfig.getConfig().get("repos") instanceof List) {
                     for (String r : (List<String>) scmConfig.getConfig().get("repos")) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -193,7 +193,7 @@ public class GithubScm extends Scm {
         return credentialId;
     }
 
-    public static class RateLimitHandlerImpl extends RateLimitHandler{
+    static class RateLimitHandlerImpl extends RateLimitHandler{
         @Override
         public void onError(IOException e, HttpURLConnection httpURLConnection) throws IOException {
             throw new ServiceException.BadRequestExpception("API rate limit reached."+e.getMessage(), e);
@@ -273,7 +273,7 @@ public class GithubScm extends Scm {
         return connection;
     }
 
-    private void validateAccessTokenScopes(HttpURLConnection connection) {
+    static void validateAccessTokenScopes(HttpURLConnection connection) {
         //check for user:email or user AND repo scopes
         String scopesHeader = connection.getHeaderField("X-OAuth-Scopes");
         if(scopesHeader == null){


### PR DESCRIPTION
# Description

See [JENKINS-41439](https://issues.jenkins-ci.org/browse/JENKINS-41439).

@cliffmeyers Revoked tokens or tokens whose scope is changed to not carry required scope is reported as 428 error.

Regarding other issue of reporting error if credential's access token is invalid and report it as error while rendering credentialId: its not going to be possible. Main reason is, credentialId is a property in the bean and we can't fail serialization of entire bean as stapler has already started writing to output stream. Besides there are issues of calling GitHub api eagerly and might impact rate limit.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 