### PR TITLE
[FIX JENKINS-42137] Don't fetch run data on an event if it not already in the store

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.82",
+  "version": "0.0.83-tf-JENKINS-42137-1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
+      "version": "0.0.83-tf-JENKINS-42137-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.83-tf-JENKINS-42137-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.83-tf-JENKINS-42137-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",
@@ -3456,7 +3456,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dev": true
         },
@@ -3476,7 +3476,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <3.1.0",
+          "from": "nopt@>=3.0.6 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "dev": true,
           "optional": true
@@ -3556,7 +3556,7 @@
         },
         "rc": {
           "version": "1.1.6",
-          "from": "rc@>=1.1.0 <1.2.0",
+          "from": "rc@>=1.1.6 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "dev": true,
           "optional": true,
@@ -3675,7 +3675,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.0 <2.3.0",
+          "from": "tar@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "dev": true
         },

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82",
+    "@jenkins-cd/blueocean-core-js": "0.0.83-tf-JENKINS-42137-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
+      "version": "0.0.83-tf-JENKINS-42137-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.83-tf-JENKINS-42137-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.83-tf-JENKINS-42137-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82",
+    "@jenkins-cd/blueocean-core-js": "0.0.83-tf-JENKINS-42137-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.82",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.82",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.82.tgz"
+      "version": "0.0.83-tf-JENKINS-42137-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.83-tf-JENKINS-42137-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.83-tf-JENKINS-42137-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.121",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.82",
+    "@jenkins-cd/blueocean-core-js": "0.0.83-tf-JENKINS-42137-1",
     "@jenkins-cd/design-language": "0.0.121",
     "@jenkins-cd/js-extensions": "0.0.33",
     "@jenkins-cd/js-modules": "0.0.8",


### PR DESCRIPTION
# Description

Only fetch job activity data if we have a pager instance for it. I think this is the right thing to do. It seems to work + eliminates that unwanted REST call for pipelines not yet visited by the UI.

See [JENKINS-42137](https://issues.jenkins-ci.org/browse/JENKINS-42137).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

