### PR TITLE
[FIX JENKINS-42293] use <head> rooturl when there's no Stapler object to extract the root context from

### DIFF
--- a/blueocean-web/src/main/js/try.js
+++ b/blueocean-web/src/main/js/try.js
@@ -16,7 +16,13 @@ $(document).ready(() => {
     }
 
     if (!tryBlueOceanUrl) {
-        tryBlueOceanUrl = `./blue`;
+        // Unable to find a backend Stapler context path for the current page.
+        // Only option left is to assume that the rooturl in the <head>
+        // is accurate. This *might* not be 100% accurate if there's funky
+        // reverse proxying or url rewriting happening on a proxy/intermediary
+        // sitting between Jenkins and the browser/client.
+        var rooturl = $('head').attr('data-rooturl');
+        tryBlueOceanUrl = rooturl + '/blue';
     }
 
     var tryBlueOcean = $('<a id="open-blueocean-in-context" class="try-blueocean header-callout">Open Blue Ocean</a>');


### PR DESCRIPTION
# Description

See [JENKINS-42293](https://issues.jenkins-ci.org/browse/JENKINS-42293).

To manually test ... go to the plugin manager in classic and press the "Open Blue Ocean" button ... it should work.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

