### PR TITLE
max-width of column filter was incorrect

### DIFF
--- a/blueocean-dashboard/src/main/less/forms/column-filter.less
+++ b/blueocean-dashboard/src/main/less/forms/column-filter.less
@@ -120,7 +120,7 @@
         top: 100%;
         left: 0;
         min-width: 100%;
-        max-width: 200% !important;
+        max-width: 200%;
         max-height: 20em;
         padding: 0;
     }


### PR DESCRIPTION
# Description

ended up being translated to `max-width: 200% !important !important` when the less was compiled and browser marked the max-width property as invalid, causing the width to be as long as the content

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

