### PR TITLE
[FIX JENKINS-41662] Input submissions not working if another browser loads the same input step

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/InputStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/InputStepImpl.java
@@ -19,7 +19,10 @@ public class InputStepImpl extends BlueInputStep {
 
     public InputStepImpl(InputStep inputStep, Reachable parent) {
         this.inputStep = inputStep;
-        this.inputStep.setId(UUID.randomUUID().toString().replaceAll("-", ""));
+        if (inputStep.getId() == null) {
+            // TODO: Why are we resetting the input ID to something random?
+            this.inputStep.setId(UUID.randomUUID().toString().replaceAll("-", ""));
+        }
         this.self = parent.getLink().rel("input");
     }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/InputStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/InputStepImpl.java
@@ -20,7 +20,7 @@ public class InputStepImpl extends BlueInputStep {
     public InputStepImpl(InputStep inputStep, Reachable parent) {
         this.inputStep = inputStep;
         if (inputStep.getId() == null) {
-            // TODO: Why are we resetting the input ID to something random?
+            // Make sure the input step has an ID.
             this.inputStep.setId(UUID.randomUUID().toString().replaceAll("-", ""));
         }
         this.self = parent.getLink().rel("input");


### PR DESCRIPTION
# Description

See [JENKINS-41662](https://issues.jenkins-ci.org/browse/JENKINS-41662).

`io.jenkins.blueocean.rest.impl.pipeline.InputStepImpl` has some unusual code, resetting the ID of the underlying pipeline `InputStep` instance to a random ID. The result of this ... two browsers load the same input step ... the first browser is screwed because the id it is using to submit against no longer corresponds to a valid ID because the load from the second browser caused it to be changed via `io.jenkins.blueocean.rest.impl.pipeline.InputStepImpl`.

@vivek hey Vivek ... can you look at this and tell us what was the intention behind the original impl, if you can still remember (I know you are like me and getting old ... memory failing ;) ).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

