### PR TITLE
Consume new workflow-api fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.7</version>
+            <version>2.12-alpha</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.12-alpha</version>
+            <version>2.12-alpha-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
# Description

Test the fixes in https://github.com/jenkinsci/workflow-api-plugin/pull/33 against Blue Ocean CI coverage to see that there are no regressions introduced.

See the wad of linked JIRA issues there, which are tied to Blue Ocean consumption of workflow-api.

Special case here, since it's just a dependency bump.

