### PR TITLE
Order primary branches at the top so that 'master' appears at the top…

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -31,6 +31,15 @@ public class BranchContainerImpl extends BluePipelineContainer {
             BranchImpl pipeline1 = (BranchImpl)_pipeline1;
             BranchImpl pipeline2 = (BranchImpl)_pipeline2;
 
+            // If one pipeline isnt the primary there is no need to go further
+            if(pipeline1.getBranch().isPrimary() && !pipeline2.getBranch().isPrimary()) {
+                return -1;
+            }
+
+            if(!pipeline1.getBranch().isPrimary() && pipeline2.getBranch().isPrimary()) {
+                return 1;
+            }
+
             // If One pipeline isnt a favorite there is no need to go further.
             if(pipeline1.isFavorite() && !pipeline2.isFavorite()) {
                 return -1;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -32,11 +32,13 @@ public class BranchContainerImpl extends BluePipelineContainer {
             BranchImpl pipeline2 = (BranchImpl)_pipeline2;
 
             // If one pipeline isnt the primary there is no need to go further
-            if(pipeline1.getBranch().isPrimary() && !pipeline2.getBranch().isPrimary()) {
+            if(pipeline1.getBranch() != null && pipeline1.getBranch().isPrimary()
+                && pipeline2.getBranch() != null && !pipeline2.getBranch().isPrimary()) {
                 return -1;
             }
 
-            if(!pipeline1.getBranch().isPrimary() && pipeline2.getBranch().isPrimary()) {
+            if(pipeline1.getBranch() != null && !pipeline1.getBranch().isPrimary()
+                && pipeline2.getBranch() != null && pipeline2.getBranch().isPrimary()) {
                 return 1;
             }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -32,13 +32,11 @@ public class BranchContainerImpl extends BluePipelineContainer {
             BranchImpl pipeline2 = (BranchImpl)_pipeline2;
 
             // If one pipeline isnt the primary there is no need to go further
-            if(pipeline1.getBranch() != null && pipeline1.getBranch().isPrimary()
-                && pipeline2.getBranch() != null && !pipeline2.getBranch().isPrimary()) {
+            if(pipeline1.getBranch().isPrimary() && !pipeline2.getBranch().isPrimary()) {
                 return -1;
             }
 
-            if(pipeline1.getBranch() != null && !pipeline1.getBranch().isPrimary()
-                && pipeline2.getBranch() != null && pipeline2.getBranch().isPrimary()) {
+            if(!pipeline1.getBranch().isPrimary() && pipeline2.getBranch().isPrimary()) {
                 return 1;
             }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -20,7 +20,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.*;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
 
 /**
  * @author Vivek Pandey
@@ -62,9 +64,6 @@ public class BranchImpl extends PipelineImpl {
     public Branch getBranch() {
         ObjectMetadataAction om = job.getAction(ObjectMetadataAction.class);
         PrimaryInstanceMetadataAction pima = job.getAction(PrimaryInstanceMetadataAction.class);
-        if (om == null && pima == null) {
-            return null;
-        }
         String url = om != null && om.getObjectUrl() != null ? om.getObjectUrl() : null;
         return new Branch(url, pima != null);
     }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -46,8 +46,16 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static io.jenkins.blueocean.rest.model.BlueRun.DATE_FORMAT_STRING;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.*;
-import static org.junit.Assert.*;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_JOB;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,7 +99,9 @@ public class MultiBranchTest extends PipelineBaseTest {
     public void testGetURL() {
         Job job = mock(Job.class);
         BranchImpl branch = new BranchImpl(job, new Link("foo"));
-        assertNull(branch.getBranch());
+        assertNotNull(branch.getBranch());
+        assertNull(branch.getBranch().getUrl());
+        assertFalse(branch.getBranch().isPrimary());
         ObjectMetadataAction oma = new ObjectMetadataAction("My Branch", "A feature branch", "https://path/to/branch");
         when(job.getAction(ObjectMetadataAction.class)).thenReturn(oma);
         assertEquals("https://path/to/branch", branch.getBranch().getUrl());
@@ -101,7 +111,9 @@ public class MultiBranchTest extends PipelineBaseTest {
     public void testBranchInfo() {
         Job job = mock(Job.class);
         BranchImpl branch = new BranchImpl(job, new Link("foo"));
-        assertNull(branch.getBranch());
+        assertNotNull(branch.getBranch());
+        assertNull(branch.getBranch().getUrl());
+        assertFalse(branch.getBranch().isPrimary());
         ObjectMetadataAction oma = new ObjectMetadataAction("My Branch", "A feature branch", "https://path/to/branch");
         when(job.getAction(ObjectMetadataAction.class)).thenReturn(oma);
         assertEquals("https://path/to/branch", branch.getBranch().getUrl());


### PR DESCRIPTION
… of branches tab, branch filter, etc ahead of favorites

To test go to the branch tab or branch filter and see that `master` is at the top.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

