### PR TITLE
JENKINS-41372# Fix to show correct Link header start parameter

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BaseTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BaseTest.java
@@ -300,7 +300,7 @@ public abstract class BaseTest {
     }
 
 
-    private String getBaseUrl(String path){
+    protected String getBaseUrl(String path){
         return baseUrl + path;
     }
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -2,6 +2,8 @@ package io.jenkins.blueocean.service.embedded;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -42,7 +44,6 @@ import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.ToolInstallations;
-import org.jvnet.hudson.test.recipes.WithPlugin;
 import org.kohsuke.stapler.export.Exported;
 
 import java.io.IOException;
@@ -53,6 +54,7 @@ import java.util.Stack;
 import java.util.concurrent.ExecutionException;
 
 import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.*;
 
 /**
  * @author Vivek Pandey
@@ -68,6 +70,20 @@ public class PipelineApiTest extends BaseTest {
         validatePipeline(p, response);
     }
 
+    @Test
+    public void linkStartLimitTest() throws IOException, UnirestException {
+        MockFolder folder = j.createFolder("folder1");
+        Project p = folder.createProject(FreeStyleProject.class, "test1");
+
+        HttpResponse<String> response = Unirest.get(getBaseUrl("/organizations/jenkins/pipelines/folder1/pipelines/"))
+                .header("Accept-Encoding","")
+                .header("Authorization", "Bearer "+jwtToken)
+                .asString();
+
+        String link = response.getHeaders().get("Link").get(0);
+
+        assertEquals("</jenkins/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/?start=0&limit=100>; rel=\"next\"", link);
+    }
 
     @Test
     public void getNestedFolderPipelineTest() throws IOException {
@@ -80,35 +96,35 @@ public class PipelineApiTest extends BaseTest {
 
         List<Map> topFolders = get("/organizations/jenkins/pipelines/", List.class);
 
-        Assert.assertEquals(1, topFolders.size());
+        assertEquals(1, topFolders.size());
 
         Map response = get("/organizations/jenkins/pipelines/folder1/pipelines/folder2/pipelines/test2");
         validatePipeline(p2, response);
 
         List<Map> pipelines = get("/organizations/jenkins/pipelines/folder1/pipelines/folder2/pipelines/", List.class);
-        Assert.assertEquals(1, pipelines.size());
+        assertEquals(1, pipelines.size());
         validatePipeline(p2, pipelines.get(0));
 
         pipelines = get("/organizations/jenkins/pipelines/folder1/pipelines/", List.class);
-        Assert.assertEquals(3, pipelines.size());
-        Assert.assertEquals("folder2", pipelines.get(0).get("name"));
-        Assert.assertEquals("folder1/folder2", pipelines.get(0).get("fullName"));
-        Assert.assertEquals("folder1/My%20folder2", pipelines.get(0).get("fullDisplayName"));
+        assertEquals(3, pipelines.size());
+        assertEquals("folder2", pipelines.get(0).get("name"));
+        assertEquals("folder1/folder2", pipelines.get(0).get("fullName"));
+        assertEquals("folder1/My%20folder2", pipelines.get(0).get("fullDisplayName"));
 
         response = get("/organizations/jenkins/pipelines/folder1");
-        Assert.assertEquals("folder1", response.get("name"));
-        Assert.assertEquals("folder1", response.get("displayName"));
-        Assert.assertEquals(2, response.get("numberOfFolders"));
-        Assert.assertEquals(1, response.get("numberOfPipelines"));
-        Assert.assertEquals("folder1", response.get("fullName"));
+        assertEquals("folder1", response.get("name"));
+        assertEquals("folder1", response.get("displayName"));
+        assertEquals(2, response.get("numberOfFolders"));
+        assertEquals(1, response.get("numberOfPipelines"));
+        assertEquals("folder1", response.get("fullName"));
 
         String clazz = (String) response.get("_class");
 
         response = get("/classes/"+clazz+"/");
-        Assert.assertNotNull(response);
+        assertNotNull(response);
 
         List<String> classes = (List<String>) response.get("classes");
-        Assert.assertTrue(!classes.contains("hudson.model.Job")
+        assertTrue(!classes.contains("hudson.model.Job")
             && classes.contains("io.jenkins.blueocean.rest.model.BluePipeline")
             && classes.contains("io.jenkins.blueocean.rest.model.BluePipelineFolder")
             && classes.contains("com.cloudbees.hudson.plugins.folder.AbstractFolder"));
@@ -122,7 +138,7 @@ public class PipelineApiTest extends BaseTest {
         Project p1 = j.createFreeStyleProject("pipeline1");
 
         List<Map> responses = get("/search/?q=type:pipeline", List.class);
-        Assert.assertEquals(2, responses.size());
+        assertEquals(2, responses.size());
         validatePipeline(p1, responses.get(0));
         validatePipeline(p2, responses.get(1));
 
@@ -141,20 +157,20 @@ public class PipelineApiTest extends BaseTest {
         }
 
         List<Map> responses = get("/search/?q=type:pipeline", List.class);
-        Assert.assertEquals(100, responses.size());
+        assertEquals(100, responses.size());
 
         responses = get("/search/?q=type:pipeline&limit=110", List.class);
-        Assert.assertEquals(110, responses.size());
+        assertEquals(110, responses.size());
 
 
         responses = get("/search/?q=type:pipeline&limit=50", List.class);
-        Assert.assertEquals(50, responses.size());
+        assertEquals(50, responses.size());
 
         responses = get("/organizations/jenkins/pipelines/", List.class);
-        Assert.assertEquals(100, responses.size());
+        assertEquals(100, responses.size());
 
         responses = get("/organizations/jenkins/pipelines/?limit=40", List.class);
-        Assert.assertEquals(40, responses.size());
+        assertEquals(40, responses.size());
     }
 
 
@@ -168,10 +184,10 @@ public class PipelineApiTest extends BaseTest {
         String clazz = (String) response.get("_class");
 
         response = get("/classes/"+clazz+"/");
-        Assert.assertNotNull(response);
+        assertNotNull(response);
 
         List<String> classes = (List<String>) response.get("classes");
-        Assert.assertTrue(classes.contains("hudson.model.Job")
+        assertTrue(classes.contains("hudson.model.Job")
             && !classes.contains("org.jenkinsci.plugins.workflow.job.WorkflowJob")
             && !classes.contains("io.jenkins.blueocean.rest.model.BlueBranch"));
     }
@@ -183,7 +199,7 @@ public class PipelineApiTest extends BaseTest {
 
         delete("/organizations/jenkins/pipelines/pipeline1/");
 
-        Assert.assertNull(j.jenkins.getItem(p.getName()));
+        assertNull(j.jenkins.getItem(p.getName()));
     }
 
 
@@ -198,7 +214,7 @@ public class PipelineApiTest extends BaseTest {
         List<Map> resp = get("/organizations/jenkins/pipelines/", List.class);
         Project[] projects = {p1,p2};
 
-        Assert.assertEquals(projects.length, resp.size());
+        assertEquals(projects.length, resp.size());
 
         for(int i=0; i<projects.length; i++){
             Map p = resp.get(i);
@@ -216,7 +232,7 @@ public class PipelineApiTest extends BaseTest {
         List<Map> resp = get("/search?q=type:pipeline;organization:jenkins", List.class);
         Project[] projects = {p1,p2};
 
-        Assert.assertEquals(projects.length, resp.size());
+        assertEquals(projects.length, resp.size());
 
         for(int i=0; i<projects.length; i++){
             Map p = resp.get(i);
@@ -248,7 +264,7 @@ public class PipelineApiTest extends BaseTest {
         p.getPublishersList().add(new JUnitResultArchiver("*.xml"));
         FreeStyleBuild b = p.scheduleBuild2(0).get();
         TestResultAction resultAction = b.getAction(TestResultAction.class);
-        Assert.assertEquals("io.jenkins.blueocean.jsextensions.JenkinsJSExtensionsTest",resultAction.getResult().getSuites().iterator().next().getName());
+        assertEquals("io.jenkins.blueocean.jsextensions.JenkinsJSExtensionsTest",resultAction.getResult().getSuites().iterator().next().getName());
         j.assertBuildStatusSuccess(b);
         Map resp = get("/organizations/jenkins/pipelines/pipeline4/runs/"+b.getId());
 
@@ -283,7 +299,7 @@ public class PipelineApiTest extends BaseTest {
         List<Map> resp = get("/search?q=type:run;organization:jenkins;pipeline:pipeline5;latestOnly:true", List.class);
         Run[] run = {b};
 
-        Assert.assertEquals(run.length, resp.size());
+        assertEquals(run.length, resp.size());
 
         for(int i=0; i<run.length; i++){
             Map lr = resp.get(i);
@@ -299,7 +315,7 @@ public class PipelineApiTest extends BaseTest {
         j.assertBuildStatusSuccess(b);
 
         List<Map> resp = get("/organizations/jenkins/pipelines/pipeline6/runs", List.class);
-        Assert.assertEquals(1, resp.size());
+        assertEquals(1, resp.size());
 
         Map lr = resp.get(0);
         validateRun(b, lr);
@@ -317,7 +333,7 @@ public class PipelineApiTest extends BaseTest {
         }while(b.hasntStartedYet());
 
         Map resp = put("/organizations/jenkins/pipelines/p1/runs/"+b.getId()+"/stop/?blocking=true&timeOutInSecs=2", Map.class);
-        Assert.assertEquals("ABORTED", resp.get("result"));
+        assertEquals("ABORTED", resp.get("result"));
     }
 
 
@@ -338,7 +354,7 @@ public class PipelineApiTest extends BaseTest {
 
         List<Map> resp = get("/search?q=type:run;organization:jenkins;pipeline:pipeline1", List.class);
 
-        Assert.assertEquals(builds.size(), resp.size());
+        assertEquals(builds.size(), resp.size());
         for(int i=0; i< builds.size(); i++){
             Map p = resp.get(i);
             FreeStyleBuild b = builds.pop();
@@ -360,7 +376,7 @@ public class PipelineApiTest extends BaseTest {
 
         List<Map> resp = get("/search?q=type:pipeline", List.class);
 
-        Assert.assertEquals(6, resp.size());
+        assertEquals(6, resp.size());
     }
 
     @Test
@@ -381,11 +397,11 @@ public class PipelineApiTest extends BaseTest {
 
         List<Map> resp = get("/search?q=type:run;organization:jenkins", List.class);
 
-        Assert.assertEquals(4, resp.size());
+        assertEquals(4, resp.size());
         for(int i=0; i< 4; i++){
             Map p = resp.get(i);
             String pipeline = (String) p.get("pipeline");
-            Assert.assertNotNull(pipeline);
+            assertNotNull(pipeline);
             validateRun(buildMap.get(pipeline).pop(), p);
         }
     }
@@ -414,8 +430,8 @@ public class PipelineApiTest extends BaseTest {
 
         List artifacts = get("/organizations/jenkins/pipelines/pipeline1/runs/"+b.getId()+"/artifacts", List.class);
 
-        Assert.assertEquals(1, artifacts.size());
-        Assert.assertEquals("fizz", ((Map) artifacts.get(0)).get("name"));
+        assertEquals(1, artifacts.size());
+        assertEquals("fizz", ((Map) artifacts.get(0)).get("name"));
     }
 
     @Test
@@ -432,9 +448,9 @@ public class PipelineApiTest extends BaseTest {
         Jenkins.getInstance().getQueue().schedule(p1, 0, new ParametersAction(new StringParameterValue("test","test2")), new CauseAction(new Cause.UserIdCause()));
 
         List queue = request().get("/organizations/jenkins/pipelines/pipeline1/queue").build(List.class);
-        Assert.assertEquals(queue.size(),2);
-        Assert.assertEquals(((Map) queue.get(0)).get("expectedBuildNumber"), 4);
-        Assert.assertEquals(((Map) queue.get(1)).get("expectedBuildNumber"), 3);
+        assertEquals(queue.size(),2);
+        assertEquals(((Map) queue.get(0)).get("expectedBuildNumber"), 4);
+        assertEquals(((Map) queue.get(1)).get("expectedBuildNumber"), 3);
     }
 
     @Test
@@ -450,14 +466,14 @@ public class PipelineApiTest extends BaseTest {
 
         Map r = request().post("/organizations/jenkins/pipelines/pipeline3/runs/").build(Map.class);
 
-        Assert.assertNotNull(p3.getQueueItem());
+        assertNotNull(p3.getQueueItem());
         String id = Long.toString(p3.getQueueItem().getId());
-        Assert.assertEquals(id, r.get("id"));
+        assertEquals(id, r.get("id"));
 
         delete("/organizations/jenkins/pipelines/pipeline3/queue/"+id+"/");
         Queue.Item item = j.jenkins.getQueue().getItem(Long.parseLong(id));
-        Assert.assertTrue(item instanceof Queue.LeftItem);
-        Assert.assertTrue(((Queue.LeftItem)item).isCancelled());
+        assertTrue(item instanceof Queue.LeftItem);
+        assertTrue(((Queue.LeftItem)item).isCancelled());
     }
 
     @Test
@@ -468,7 +484,7 @@ public class PipelineApiTest extends BaseTest {
         Map<String,Object> response = get("/organizations/jenkins/pipelines/pipeline1");
         validatePipeline(p, response);
 
-        Assert.assertEquals("hello world!", response.get("hello"));
+        assertEquals("hello world!", response.get("hello"));
     }
 
     @Extension(ordinal = 3)
@@ -505,43 +521,43 @@ public class PipelineApiTest extends BaseTest {
     public void testCapabilityAnnotation(){
         Map resp = get("/classes/"+TestPipelineImpl.class.getName());
         List<String> classes = (List<String>) resp.get("classes");
-        Assert.assertEquals("io.jenkins.blueocean.rest.annotation.test.TestPipeline", classes.get(0));
-        Assert.assertEquals("io.jenkins.blueocean.rest.annotation.test.TestPipelineExample", classes.get(1));
+        assertEquals("io.jenkins.blueocean.rest.annotation.test.TestPipeline", classes.get(0));
+        assertEquals("io.jenkins.blueocean.rest.annotation.test.TestPipelineExample", classes.get(1));
     }
 
     @Test
     public void testClassesQueryWithPost(){
         // get classes for given class
         Map resp = get("/classes/"+TestPipelineImpl.class.getName());
-        Assert.assertNotNull(resp);
+        assertNotNull(resp);
         List<String> classes = (List<String>) resp.get("classes");
-        Assert.assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
+        assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
 
 
         // should return empty map
         resp = post("/classes/", Collections.EMPTY_MAP);
-        Assert.assertNotNull(resp);
+        assertNotNull(resp);
         Map m = (Map) resp.get("map");
-        Assert.assertTrue(m.isEmpty());
+        assertTrue(m.isEmpty());
 
         resp = post("/classes/", ImmutableMap.of("q", ImmutableList.of("io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl",TestPipelineImpl.class.getName())));
-        Assert.assertNotNull(resp);
+        assertNotNull(resp);
         m = (Map) resp.get("map");
-        Assert.assertNotNull(m);
-        Assert.assertEquals(2, m.size());
+        assertNotNull(m);
+        assertEquals(2, m.size());
 
 
         Map v = (Map) m.get("io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl");
-        Assert.assertNotNull(v);
+        assertNotNull(v);
 
         classes = (List<String>) v.get("classes");
-        Assert.assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
+        assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
 
         v = (Map) m.get(TestPipelineImpl.class.getName());
-        Assert.assertNotNull(v);
+        assertNotNull(v);
 
         classes = (List<String>) v.get("classes");
-        Assert.assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
+        assertTrue(classes.contains("io.jenkins.blueocean.rest.model.BluePipeline"));
     }
 
 
@@ -555,10 +571,10 @@ public class PipelineApiTest extends BaseTest {
         validatePipeline(p, response);
 
         Map<String,Boolean> permissions = (Map<String, Boolean>) response.get("permissions");
-        Assert.assertTrue(permissions.get("create"));
-        Assert.assertTrue(permissions.get("start"));
-        Assert.assertTrue(permissions.get("stop"));
-        Assert.assertTrue(permissions.get("read"));
+        assertTrue(permissions.get("create"));
+        assertTrue(permissions.get("start"));
+        assertTrue(permissions.get("stop"));
+        assertTrue(permissions.get("read"));
     }
 
     @Test
@@ -577,7 +593,7 @@ public class PipelineApiTest extends BaseTest {
         Assert.assertFalse(permissions.get("create"));
         Assert.assertFalse(permissions.get("start"));
         Assert.assertFalse(permissions.get("stop"));
-        Assert.assertTrue(permissions.get("read"));
+        assertTrue(permissions.get("read"));
 
         response = get("/organizations/jenkins/pipelines/folder1/");
 
@@ -585,7 +601,7 @@ public class PipelineApiTest extends BaseTest {
         Assert.assertFalse(permissions.get("create"));
         Assert.assertFalse(permissions.get("start"));
         Assert.assertFalse(permissions.get("stop"));
-        Assert.assertTrue(permissions.get("read"));
+        assertTrue(permissions.get("read"));
     }
 
     @Test
@@ -600,7 +616,7 @@ public class PipelineApiTest extends BaseTest {
 
         Project p = folder.createProject(FreeStyleProject.class, "test1");
         String token = getJwtToken(j.jenkins, "alice", "alice");
-        Assert.assertNotNull(token);
+        assertNotNull(token);
         Map response = new RequestBuilder(baseUrl)
             .get("/organizations/jenkins/pipelines/folder1/pipelines/test1")
             .jwtToken(token)
@@ -609,10 +625,10 @@ public class PipelineApiTest extends BaseTest {
         validatePipeline(p, response);
 
         Map<String,Boolean> permissions = (Map<String, Boolean>) response.get("permissions");
-        Assert.assertTrue(permissions.get("create"));
-        Assert.assertTrue(permissions.get("start"));
-        Assert.assertTrue(permissions.get("stop"));
-        Assert.assertTrue(permissions.get("read"));
+        assertTrue(permissions.get("create"));
+        assertTrue(permissions.get("start"));
+        assertTrue(permissions.get("stop"));
+        assertTrue(permissions.get("read"));
     }
 
     @Test
@@ -624,22 +640,22 @@ public class PipelineApiTest extends BaseTest {
         Map resp = get("/organizations/jenkins/pipelines/pp/");
 
         List<Map<String,Object>> parameters = (List<Map<String, Object>>) resp.get("parameters");
-        Assert.assertEquals(1, parameters.size());
-        Assert.assertEquals("version", parameters.get(0).get("name"));
-        Assert.assertEquals("StringParameterDefinition", parameters.get(0).get("type"));
-        Assert.assertEquals("version number", parameters.get(0).get("description"));
-        Assert.assertEquals("1.0", ((Map)parameters.get(0).get("defaultParameterValue")).get("value"));
+        assertEquals(1, parameters.size());
+        assertEquals("version", parameters.get(0).get("name"));
+        assertEquals("StringParameterDefinition", parameters.get(0).get("type"));
+        assertEquals("version number", parameters.get(0).get("description"));
+        assertEquals("1.0", ((Map)parameters.get(0).get("defaultParameterValue")).get("value"));
         validatePipeline(p, resp);
 
         resp = post("/organizations/jenkins/pipelines/pp/runs/",
                 ImmutableMap.of("parameters",
                         ImmutableList.of(ImmutableMap.of("name", "version", "value", "2.0"))
                 ), 200);
-        Assert.assertEquals("pp", resp.get("pipeline"));
+        assertEquals("pp", resp.get("pipeline"));
         Thread.sleep(1000);
         resp = get("/organizations/jenkins/pipelines/pp/runs/1/");
-        Assert.assertEquals("SUCCESS", resp.get("result"));
-        Assert.assertEquals("FINISHED", resp.get("state"));
+        assertEquals("SUCCESS", resp.get("result"));
+        assertEquals("FINISHED", resp.get("state"));
     }
 
     @Test public void mavenModulesNoteListed() throws Exception {
@@ -650,8 +666,8 @@ public class PipelineApiTest extends BaseTest {
         j.buildAndAssertSuccess(m);
 
         List responses = get("/organizations/jenkins/pipelines/", List.class);
-        Assert.assertEquals(1, responses.size());
-        Assert.assertEquals("p", ((Map) responses.get(0)).get("name"));
+        assertEquals(1, responses.size());
+        assertEquals("p", ((Map) responses.get(0)).get("name"));
 
     }
 }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -82,7 +82,26 @@ public class PipelineApiTest extends BaseTest {
 
         String link = response.getHeaders().get("Link").get(0);
 
-        assertEquals("</jenkins/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/?start=0&limit=100>; rel=\"next\"", link);
+        assertEquals("</jenkins/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/?start=100&limit=100>; rel=\"next\"", link);
+
+        response = Unirest.get(getBaseUrl("/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject&filter1=no-folders&start=0&limit=26"))
+                .header("Accept-Encoding","")
+                .header("Authorization", "Bearer "+jwtToken)
+                .asString();
+
+        link = response.getHeaders().get("Link").get(0);
+
+        assertEquals("</jenkins/blue/rest/search/?q=type:pipeline;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject&filter1=no-folders&start=26&limit=26>; rel=\"next\"", link);
+
+
+        response = Unirest.get(getBaseUrl("/organizations/jenkins/pipelines/folder1/pipelines/?start=10&limit=10&foo=bar"))
+                .header("Accept-Encoding","")
+                .header("Authorization", "Bearer "+jwtToken)
+                .asString();
+
+        link = response.getHeaders().get("Link").get(0);
+
+        assertEquals("</jenkins/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/?foo=bar&start=20&limit=10>; rel=\"next\"", link);
     }
 
     @Test

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
@@ -54,7 +54,7 @@ public @interface PagedResponse {
                     }
                     Object[] page = Iterators.toArray(resp.iterator(start, limit), Object.class);
                         String separator = (req.getQueryString() != null) ? "&" : "?";
-                        rsp.setHeader("Link", "<" + req.getRequestURIWithQueryString() + separator + "start=" + (start + limit) + "&limit="+limit + ">; rel=\"next\"");
+                        rsp.setHeader("Link", "<" + req.getRequestURIWithQueryString() + separator + "start=" + start + "&limit="+limit + ">; rel=\"next\"");
 
                     Export.doJson(req, rsp, page);
                 }


### PR DESCRIPTION
# Description

See [JENKINS-41372](https://issues.jenkins-ci.org/browse/JENKINS-41372).

GET http://localhost:8080/jenkins/blue/rest/organizations/jenkins/pipelines/?start=0

should print Link header start parameter to be 0.

```
Link:</jenkins/blue/rest/organizations/jenkins/pipelines/?start=0&limit=100>; rel="next"
```

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
