### PR TITLE
Adding some classNames to ExtensionRenderer

### DIFF
--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/spec/ExtensionRenderer-spec.js
+++ b/js-extensions/spec/ExtensionRenderer-spec.js
@@ -77,7 +77,7 @@ describe('ExtensionRenderer', function () {
         assert.isTrue(result.is('ExtensionRenderer'), 'should be ExtensionRenderer');
         assert.equal(result.length, 1, 'length');
         assert.equal(result.children().length, 0, 'children.length');
-        assert.equal(result.html(), '<div></div>', 'html');
+        assert.equal(result.html(), '<div class="ExtensionPoint foo-bar-baz"></div>', 'html');
         // Fixme: ^^^^ figure out how to test the rendered element name other than html() string comparison
     });
 
@@ -85,22 +85,27 @@ describe('ExtensionRenderer', function () {
         const result = mount(React.createElement(ExtensionRenderer, {extensionPoint: 'foo.bar.baz'}, 'Default text node'));
         assert.isTrue(result.is('ExtensionRenderer'), 'should be ExtensionRenderer');
         assert.equal(result.length, 1, 'length');
-        assert.equal(result.html(), '<div>Default text node</div>', 'html output');
+        assert.equal(result.html(), '<div class="ExtensionPoint foo-bar-baz">Default text node</div>', 'html output');
     });
 
     it('should change the wrapping element', function () {
         const result = mount(React.createElement(ExtensionRenderer, {extensionPoint: 'ep1', wrappingElement: 'section'}));
-        assert.equal(result.html(), '<section><div><h1>Extension is a H1</h1></div></section>', 'html output');
+        assert.equal(result.html(), '<section class="ExtensionPoint ep1"><div><h1>Extension is a H1</h1></div></section>', 'html output');
     });
 
     it('should render the extension', function () {
         const result = mount(React.createElement(ExtensionRenderer, {extensionPoint: 'ep1'}));
-        assert.equal(result.html(), '<div><div><h1>Extension is a H1</h1></div></div>', 'html output');
+        assert.equal(result.html(), '<div class="ExtensionPoint ep1"><div><h1>Extension is a H1</h1></div></div>', 'html output');
+    });
+
+    it('should render a custom class name', function () {
+        const result = mount(React.createElement(ExtensionRenderer, {extensionPoint: 'ep1', className: 'super-dooper'}));
+        assert.equal(result.html(), '<div class="ExtensionPoint ep1 super-dooper"><div><h1>Extension is a H1</h1></div></div>', 'html output');
     });
 
     it('should should not show default children when extension is present', function () {
         const result = mount(React.createElement(ExtensionRenderer, {extensionPoint: 'ep1'}, 'Default text node'));
-        assert.equal(result.html(), '<div><div><h1>Extension is a H1</h1></div></div>', 'html output');
+        assert.equal(result.html(), '<div class="ExtensionPoint ep1"><div><h1>Extension is a H1</h1></div></div>', 'html output');
     });
 
 

--- a/js-extensions/src/ExtensionRenderer.jsx
+++ b/js-extensions/src/ExtensionRenderer.jsx
@@ -82,7 +82,22 @@ export default class ExtensionRenderer extends React.Component {
             newChildren = this.props.children;
         }
 
-        return React.createElement(this.props.wrappingElement, null, newChildren);
+        const {
+            className,
+            extensionPoint
+        } = this.props;
+
+        const classNames = ['ExtensionPoint', extensionPoint.replace(/\.+/g,'-')];
+        
+        if (className) {
+            classNames.push(className);
+        }
+
+        const newProps = {
+            className: classNames.join(' ')
+        };
+
+        return React.createElement(this.props.wrappingElement, newProps, newChildren);
     }
 
     /**

--- a/js-extensions/src/ExtensionRenderer.jsx
+++ b/js-extensions/src/ExtensionRenderer.jsx
@@ -84,7 +84,8 @@ export default class ExtensionRenderer extends React.Component {
 
         const {
             className,
-            extensionPoint
+            extensionPoint,
+            wrappingElement
         } = this.props;
 
         const classNames = ['ExtensionPoint', extensionPoint.replace(/\.+/g,'-')];
@@ -97,7 +98,7 @@ export default class ExtensionRenderer extends React.Component {
             className: classNames.join(' ')
         };
 
-        return React.createElement(this.props.wrappingElement, newProps, newChildren);
+        return React.createElement(wrappingElement, newProps, newChildren);
     }
 
     /**


### PR DESCRIPTION
Something I need in order to do the table migration nicely; add some classNames to ExtensionRenderer and the ability to specify additional classes from client code.

# Description

See [JENKINS-41833](https://issues.jenkins-ci.org/browse/JENKINS-41833).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

