### PR TITLE
Fixes single repo optimized path by checking presense of Jenkinsfile

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganizationFolder.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganizationFolder.java
@@ -9,11 +9,19 @@ import jenkins.branch.OrganizationFolder;
 import jenkins.scm.api.SCMNavigator;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Vivek Pandey
  */
 public class GithubOrganizationFolder  extends OrganizationFolderPipelineImpl {
+    //Map of repo properties.
+    private final Map<String, BlueRepositoryProperty> repos = new HashMap<>();
+
     public GithubOrganizationFolder(OrganizationFolder folder, Link parent) {
         super(folder, parent);
     }
@@ -34,6 +42,22 @@ public class GithubOrganizationFolder  extends OrganizationFolderPipelineImpl {
         return super.isScanAllRepos();
     }
 
+    //TODO: Pull it up in to BlueOrganizationFolder, once we are happy with this abstraction
+
+    /**
+     * Client can expect it to return empty map or null. In certain cases, such as when organization folder scan is
+     * triggered with only one repo,
+     * @return
+     */
+    @Exported(name = "repos")
+    public Map<String, BlueRepositoryProperty> repos(){
+        return repos;
+    }
+
+    void addRepo(String repo, BlueRepositoryProperty prop){
+        repos.put(repo, prop);
+    }
+
     @Extension(ordinal = -8)
     public static class OrganizationFolderFactoryImpl extends OrganizationFolderFactory {
         @Override
@@ -41,5 +65,18 @@ public class GithubOrganizationFolder  extends OrganizationFolderPipelineImpl {
             SCMNavigator navigator = Iterables.getFirst(folder.getNavigators(), null);
             return GitHubSCMNavigator.class.isInstance(navigator) ? new GithubOrganizationFolder(folder, parent.getLink()) : null;
         }
+    }
+
+    //TODO: Once we are happy with this abstraction, move it up in to blueocean-rest
+    @ExportedBean(defaultVisibility = 9999)
+    public abstract static class BlueRepositoryProperty{
+
+        /**
+         *
+         * Tells if this repo meets scan criteria. For example, if a repo has Jenkinsfile in root, it
+         * meets the indexing criteria
+         */
+        @Exported(name = "meetsScanCriteria")
+        public abstract boolean meetsIndexingCriteria();
     }
 }


### PR DESCRIPTION
# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

@kzantow  I think I have implemented the workaround discussed with Stephen. PTAL. 

Now create pipeline returns 'repos' element, UI should check the response for this element and if for that single repo the flag is false, then immediately launch editor.

below 'test1' is a GitHub repo:

```
"repos" : {
      "test1" : {
         "meetsScanCriteria" : true      
      }
   }
```

TODOs:

[ ] Fix it for update
[ ] If agreed on this approach expose 'repos' element in BlueOrganizationFolder.

cc: @cliffmeyers 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given