### PR TITLE
[FIX JENKINS-42920] Switch to using query params for branch filtering

### DIFF
--- a/blueocean-dashboard/src/main/js/PipelineRoutes.jsx
+++ b/blueocean-dashboard/src/main/js/PipelineRoutes.jsx
@@ -120,7 +120,7 @@ export default (
 
         <Route path="organizations/:organization" component={PipelinePage}>
             <Route path=":pipeline/branches" component={MultiBranch} />
-            <Route path=":pipeline/activity(/:branch)" component={Activity} />
+            <Route path=":pipeline/activity" component={Activity} />
             <Route path=":pipeline/pr" component={PullRequests} />
 
             <Route path=":pipeline/detail/:branch/:runId" component={RunDetails} onLeave={onLeaveCheckBackground}>

--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -44,23 +44,26 @@ EmptyState.propTypes = {
 };
 @observer
 export class Activity extends Component {
-
     componentWillMount() {
         if (this.context.params) {
             const organization = this.context.params.organization;
             const pipeline = this.context.params.pipeline;
-            const branch = this.context.location.query.branch;
+            const branch = this._branchFromProps(this.props);
             this.pager = this.context.activityService.activityPager(organization, pipeline, branch);
         }
     }
     
     componentWillReceiveProps(newProps) {
-        if (this.props.params && this.props.location.query.branch !== newProps.location.query.branch) {
+        if (this.props.params && this._branchFromProps(this.props) !== this._branchFromProps(newProps)) {
             const organization = newProps.params.organization;
             const pipeline = newProps.params.pipeline;
-            const branch = newProps.location.query.branch;
+            const branch = this._branchFromProps(newProps);
             this.pager = this.context.activityService.activityPager(organization, pipeline, branch);
         }
+    }
+    
+    _branchFromProps(props) {
+        return ((props.location || {}).query || {}).branch;
     }
     
     navigateToBranch(branch) {
@@ -80,8 +83,8 @@ export class Activity extends Component {
         if (!pipeline) {
             return null;
         }
-        const { branch } = this.context.location.query;
-        console.log('aa', branch);
+        const branch = this._branchFromProps(this.props);
+        
         const isMultiBranchPipeline = capable(pipeline, MULTIBRANCH_PIPELINE);
 
         // Only show the Run button for non multi-branch pipelines.

--- a/blueocean-dashboard/src/main/js/components/Activity.jsx
+++ b/blueocean-dashboard/src/main/js/components/Activity.jsx
@@ -49,16 +49,16 @@ export class Activity extends Component {
         if (this.context.params) {
             const organization = this.context.params.organization;
             const pipeline = this.context.params.pipeline;
-            const branch = this.context.params.branch;
+            const branch = this.context.location.query.branch;
             this.pager = this.context.activityService.activityPager(organization, pipeline, branch);
         }
     }
     
     componentWillReceiveProps(newProps) {
-        if (this.props.params && this.props.params.branch !== newProps.params.branch) {
+        if (this.props.params && this.props.location.query.branch !== newProps.location.query.branch) {
             const organization = newProps.params.organization;
             const pipeline = newProps.params.pipeline;
-            const branch = newProps.params.branch;
+            const branch = newProps.location.query.branch;
             this.pager = this.context.activityService.activityPager(organization, pipeline, branch);
         }
     }
@@ -69,7 +69,7 @@ export class Activity extends Component {
         const baseUrl = buildPipelineUrl(organization, pipeline);
         let activitiesURL = `${baseUrl}/activity`;
         if (branch) {
-            activitiesURL += '/' + encodeURIComponent(branch);
+            activitiesURL += '?branch=' + encodeURIComponent(branch);
         }
         this.context.router.push(activitiesURL);
     }
@@ -80,7 +80,8 @@ export class Activity extends Component {
         if (!pipeline) {
             return null;
         }
-        const { branch } = this.context.params;
+        const { branch } = this.context.location.query;
+        console.log('aa', branch);
         const isMultiBranchPipeline = capable(pipeline, MULTIBRANCH_PIPELINE);
 
         // Only show the Run button for non multi-branch pipelines.
@@ -192,6 +193,7 @@ Activity.propTypes = {
     locale: string,
     t: func,
     params: object,
+    location: object.isRequired,
 };
 
 export default Activity;

--- a/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
@@ -92,7 +92,7 @@ class RunDetailsHeader extends Component {
             </h1>
         );
 
-        const branchUrl = `${buildPipelineUrl(run.organization, pipeline.fullName)}/activity/${run.pipeline}`;
+        const branchUrl = `${buildPipelineUrl(run.organization, pipeline.fullName)}/activity?branch=${run.pipeline}`;
         const labelClassName = run.pullRequest ? 'pullRequest' : '';
 
         const branchSourceDetails = (


### PR DESCRIPTION
# Description

Switchs branch filtering to use query params. Has side effect of ativity tab button staying selected. @michaelneale is there any other places that redirect to a filtered branch that you know of?

See [JENKINS-42920](https://issues.jenkins-ci.org/browse/JENKINS-42920).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

