### PR TITLE
Fix dialog form text color for first time run

### DIFF
--- a/blueocean-dashboard/src/main/less/forms/index.less
+++ b/blueocean-dashboard/src/main/less/forms/index.less
@@ -74,6 +74,7 @@
             margin: 24px 32px 16px 32px;
         }
 
+        color: #4A4A4A;
         min-width: 450px;
 
         * > .FormElement {


### PR DESCRIPTION
Currently, if project has no builds, the Dialog class inherits text
color from class:

    .empty-state .empty-state-container .empty-state-content

Which is white now. And it happens for dialog form to have white
text on white background.

This change ensures that the Dialog always has readable text color
for the white background.

Before: http://i.imgur.com/lciqAyK.png
After: http://i.imgur.com/ZLvhclUl.png
