### PR TITLE
Hotfix/savingorgs

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -179,8 +179,10 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequestIm
                         }
                     });
                 }else {
+                    gitHubSCMNavigator.setPattern(".*");
                     organizationFolder.scheduleBuild(new Cause.UserIdCause());
                 }
+                organizationFolder.save();
                 return githubOrganizationFolder;
             }
         } catch (Exception e){

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -148,6 +148,13 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequestIm
                         }
                     }
 
+                    // Add any existing discovered repos
+                    for (MultiBranchProject<?,?> p : organizationFolder.getItems()) {
+                        if (!repos.contains(p.getName())) {
+                            repos.add(p.getName());
+                        }
+                    }
+
                     if (credentialId == null) {
                         credentialId = gitHubSCMNavigator.getScanCredentialsId();
                     }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineUpdateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineUpdateRequest.java
@@ -55,6 +55,7 @@ public class GithubPipelineUpdateRequest extends BluePipelineUpdateRequest {
                 folder.scheduleBuild(new Cause.UserIdCause());
             }
         }
+        item.save();
         return pipeline;
     }
 


### PR DESCRIPTION
URGENT fix for saving github orgs correctly. as it is now, they are not persisted so a restart loses the pattern in the github org folder. 
"pattern" is the pattern field in the classic config screen for the github org folder (click on config, and look for the pattern field, which determines what repos make pipelines in this organisation).

No ticket as hard to describe and I am too tired. 

To test this:: 

```
Create a single repo, check pattern in multibranch folder config that it has that single repo
Restart, check it is still in folder pattern
Add a repo, check folder pattern has new one and previous one
Restart, check both in pattern still
Switch to discover, check pattern is ".*"
restart, check pattern is still ".*"
Switch back to single, check that the one you picked is in the pattern, along with previous ones
Restart, check pattern is the same as before you retsarted

Remove whole org folder 
Add as auto discover, check pattern
restart, check pattern
```
If this sniffs ok, we need to cherry pick it to the release branch urgently. 