### PR TITLE
[JENKINS-43419-Remove_extensionPoint_size_test_for_dashboard] Remove …

### DIFF
--- a/blueocean/src/test/java/io/jenkins/blueocean/config/JenkinsJSExtensionsTest.java
+++ b/blueocean/src/test/java/io/jenkins/blueocean/config/JenkinsJSExtensionsTest.java
@@ -55,11 +55,9 @@ public class JenkinsJSExtensionsTest extends BaseTest {
             Assert.assertNotNull(extensionPoints);
 
             if ("blueocean-dashboard".equals(pluginId)) {
-                Assert.assertEquals(7, extensionPoints.size());
                 Assert.assertEquals("AdminNavLink", extensionPoints.getJSONObject(0).get("component"));
                 Assert.assertEquals("jenkins.logo.top", extensionPoints.getJSONObject(0).get("extensionPoint"));
             } else if ("blueocean-personalization".equals(pluginId)) {
-                Assert.assertEquals(5, extensionPoints.size());
                 Assert.assertEquals("redux/FavoritesStore", extensionPoints.getJSONObject(0).get("component"));
                 Assert.assertEquals("jenkins.main.stores", extensionPoints.getJSONObject(0).get("extensionPoint"));
                 Assert.assertEquals("components/DashboardCards", extensionPoints.getJSONObject(1).get("component"));


### PR DESCRIPTION
…all asserts on size, since size does not matter :)

# Description

See [JENKINS-43419](https://issues.jenkins-ci.org/browse/JENKINS-43419).

Requested in https://github.com/jenkinsci/blueocean-plugin/pull/839. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

