### PR TITLE
JENKINS-43600 Artifacts cannot be accessed when pipeline is paused fo…

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -3,7 +3,7 @@ import { FileSize, Table } from '@jenkins-cd/design-language';
 import { Icon } from '@jenkins-cd/react-material-icons';
 import { observer } from 'mobx-react';
 import mobxUtils from 'mobx-utils';
-import { UrlConfig, logging } from '@jenkins-cd/blueocean-core-js';
+import { logging, UrlConfig } from '@jenkins-cd/blueocean-core-js';
 
 const logger = logging.logger('io.jenkins.blueocean.dashboard.artifacts');
 const { func, object, string } = PropTypes;
@@ -65,10 +65,11 @@ export default class RunDetailsArtifacts extends Component {
     }
 
     _fetchArtifacts(props) {
-        const { result } = props;
-        if (result && result.state === 'FINISHED') {
-            this.artifacts = this.context.activityService.fetchArtifacts(result._links.self.href);
+        const result = props.result;
+        if (!result) {
+            return;
         }
+        this.artifacts = this.context.activityService.fetchArtifacts(result._links.self.href);
     }
 
     render() {


### PR DESCRIPTION
Artifacts cannot be accessed when pipeline is paused for input or executing

# Description

See [JENKINS-43600](https://issues.jenkins-ci.org/browse/JENKINS-43600).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

PTAL @imeredith 