### PR TITLE
JENKINS-40084 PipelineRunImpl.replay assumes the task is still in the…

### DIFF
--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -33,7 +33,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
-import io.jenkins.blueocean.service.embedded.rest.QueueContainerImpl;
+import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import org.jenkinsci.plugins.pubsub.EventProps;
 import org.jenkinsci.plugins.pubsub.Events;
 import org.jenkinsci.plugins.pubsub.JobChannelMessage;
@@ -89,12 +89,12 @@ public class BlueMessageEnricher extends MessageEnricher {
                 final long queueId = Long.parseLong(message.get("job_run_queueId"));
                 Queue.Item queueItem = jenkins.model.Jenkins.getInstance().getQueue().getItem(queueId);
                 hudson.model.Job job = (hudson.model.Job) jobChannelItem;
-                BlueQueueItem blueQueueItem = QueueContainerImpl.getQueuedItem(queueItem, job);
+                BlueQueueItem blueQueueItem = QueueUtil.getQueuedItem(queueItem, job);
                 if (blueQueueItem != null) {
                     LOGGER.info("Expected: " + blueQueueItem.getExpectedBuildNumber());
                     jobChannelMessage.set(BlueEventProps.blueocean_queue_item_expected_build_number, Integer.toString(blueQueueItem.getExpectedBuildNumber()));
                 } else {
-                    Run run = QueueContainerImpl.getRun(job, queueId);
+                    Run run = QueueUtil.getRun(job, queueId);
                     if (run == null) {
                         return;
                     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
@@ -8,7 +8,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BlueQueueContainer;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
-import io.jenkins.blueocean.service.embedded.rest.QueueContainerImpl;
+import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import jenkins.model.Jenkins;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class MultiBranchPipelineQueueContainer extends BlueQueueContainer {
             if(item != null && item.task instanceof Job){
                 Job job = ((Job) item.task);
                 if(job.getParent() != null && job.getParent().getFullName().equals(multiBranchPipeline.mbp.getFullName())) {
-                    return QueueContainerImpl.getQueuedItem(item, job);
+                    return QueueUtil.getQueuedItem(item, job);
                 }
             }
         }catch (NumberFormatException e){
@@ -58,7 +58,7 @@ public class MultiBranchPipelineQueueContainer extends BlueQueueContainer {
         List<BlueQueueItem> queueItems = Lists.newArrayList();
         for(Object o: multiBranchPipeline.mbp.getItems()) {
             if(o instanceof Job) {
-                queueItems.addAll(QueueContainerImpl.getQueuedItems((Job)o));
+                queueItems.addAll(QueueUtil.getQueuedItems((Job)o));
             }
         }
         return queueItems.iterator();

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -102,10 +102,10 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
 
         BlueQueueItem queueItem = QueueUtil.getQueuedItem(item, run.getParent());
         WorkflowRun replayedRun = QueueUtil.getRun(run.getParent(), item.getId());
-        if (replayedRun != null) { // If the item has left the queue and is running
-            return new PipelineRunImpl(replayedRun, getLink());
-        } else if (queueItem != null) { // If the item is still queued
+        if (queueItem != null) { // If the item is still queued
             return queueItem.toRun();
+        } else if (replayedRun != null) { // If the item has left the queue and is running
+                return new PipelineRunImpl(replayedRun, getLink());
         } else { // For some reason could not be added to the queue
             throw new ServiceException.UnexpectedErrorException("Run was not added to queue.");
         }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -105,7 +105,7 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
         if (queueItem != null) { // If the item is still queued
             return queueItem.toRun();
         } else if (replayedRun != null) { // If the item has left the queue and is running
-                return new PipelineRunImpl(replayedRun, getLink());
+                return new PipelineRunImpl(replayedRun, parent);
         } else { // For some reason could not be added to the queue
             throw new ServiceException.UnexpectedErrorException("Run was not added to queue.");
         }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -22,7 +22,7 @@ import io.jenkins.blueocean.rest.model.Container;
 import io.jenkins.blueocean.rest.model.Containers;
 import io.jenkins.blueocean.service.embedded.rest.AbstractRunImpl;
 import io.jenkins.blueocean.service.embedded.rest.ChangeSetResource;
-import io.jenkins.blueocean.service.embedded.rest.QueueContainerImpl;
+import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import io.jenkins.blueocean.service.embedded.rest.StoppableRun;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction;
@@ -100,12 +100,14 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
 
         Queue.Item item = replayAction.run2(replayAction.getOriginalScript(), replayAction.getOriginalLoadedScripts());
 
-        BlueQueueItem queueItem = QueueContainerImpl.getQueuedItem(item, run.getParent());
-
-        if(queueItem == null) {
-            throw new ServiceException.UnexpectedErrorException("Run was not added to queue.");
-        } else {
+        BlueQueueItem queueItem = QueueUtil.getQueuedItem(item, run.getParent());
+        WorkflowRun replayedRun = QueueUtil.getRun(run.getParent(), item.getId());
+        if (replayedRun != null) { // If the item has left the queue and is running
+            return new PipelineRunImpl(replayedRun, getLink());
+        } else if (queueItem != null) { // If the item is still queued
             return queueItem.toRun();
+        } else { // For some reason could not be added to the queue
+            throw new ServiceException.UnexpectedErrorException("Run was not added to queue.");
         }
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -34,7 +34,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     protected final T run;
     protected final BlueOrganization org;
 
-    private final Link parent;
+    protected final Link parent;
     public AbstractRunImpl(T run, Link parent) {
         this.run = run;
         this.parent = parent;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueContainerImpl.java
@@ -1,22 +1,11 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import hudson.model.BuildableItem;
 import hudson.model.Job;
-import hudson.model.Queue;
-import hudson.model.Run;
-import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.hal.Link;
-import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueQueueContainer;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
-import jenkins.model.Jenkins;
 
-import javax.annotation.Nullable;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * @author Ivan Meredith
@@ -32,7 +21,7 @@ public class QueueContainerImpl extends BlueQueueContainer {
 
     @Override
     public BlueQueueItem get(String name) {
-        for (BlueQueueItem blueQueueItem : getQueuedItems(job)) {
+        for (BlueQueueItem blueQueueItem : QueueUtil.getQueuedItems(job)) {
             if(name.equals(blueQueueItem.getId())){
                 return blueQueueItem;
             }
@@ -43,55 +32,7 @@ public class QueueContainerImpl extends BlueQueueContainer {
 
     @Override
     public Iterator<BlueQueueItem> iterator() {
-        return getQueuedItems(job).iterator();
-    }
-
-    /**
-     * This function gets gets a list of all queued items if the job is a buildable item.
-     *
-     * Note the estimated build number calculation is a guess - job types need not return
-     * sequential build numbers.
-     *
-     * @return List of items newest first
-     */
-    public static List<BlueQueueItem> getQueuedItems(Job job) {
-        Link pipelineLink = LinkResolver.resolveLink(job);
-        if(job instanceof BuildableItem) {
-            BuildableItem task = (BuildableItem)job;
-            List<Queue.Item> items = Jenkins.getInstance().getQueue().getItems(task);
-            List<BlueQueueItem> items2 = Lists.newArrayList();
-            for (int i = 0; i < items.size(); i++) {
-                Link self = pipelineLink.rel("queue").rel(Long.toString(items.get(i).getId()));
-                items2.add(0, new QueueItemImpl(
-                    items.get(i),
-                    job.getName(),
-                    (items.size() == 1 ? job.getNextBuildNumber() : job.getNextBuildNumber() + i), self, pipelineLink));
-            }
-
-            return items2;
-        } else {
-            throw new ServiceException.UnexpectedErrorException("This pipeline is not buildable and therefore does not have a queue.");
-        }
-    }
-
-    public static BlueQueueItem getQueuedItem(final Queue.Item item, Job job) {
-
-        for(BlueQueueItem qi:QueueContainerImpl.getQueuedItems(job)){
-            if(qi.getId().equalsIgnoreCase(Long.toString(item.getId()))){
-                return qi;
-            }
-        }
-        return null;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static Run getRun(Job job, final long queueId) {
-        return Iterables.find((Iterable<Run>) job.getBuilds(), new Predicate<Run>() {
-            @Override
-            public boolean apply(@Nullable Run input) {
-                return input != null && input.getQueueId() == queueId;
-            }
-        }, null);
+        return QueueUtil.getQueuedItems(job).iterator();
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
@@ -1,0 +1,78 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import hudson.model.BuildableItem;
+import hudson.model.Job;
+import hudson.model.Run;
+import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.hal.LinkResolver;
+import io.jenkins.blueocean.rest.model.BlueQueueItem;
+import jenkins.model.Jenkins;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class QueueUtil {
+
+    public static BlueQueueItem getQueuedItem(final hudson.model.Queue.Item item, Job job) {
+
+        for(BlueQueueItem qi: getQueuedItems(job)){
+            if(qi.getId().equalsIgnoreCase(Long.toString(item.getId()))){
+                return qi;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find a corresponding run for the queueId
+     * @param job to search
+     * @param queueId of the item
+     * @param <T> type of run
+     * @return the run or null
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public static <T extends Run> T getRun(@Nonnull Job job, final long queueId) {
+        return Iterables.find((Iterable<T>) job.getBuilds(), new Predicate<Run>() {
+            @Override
+            public boolean apply(@Nullable Run input) {
+                return input != null && input.getQueueId() == queueId;
+            }
+        }, null);
+    }
+
+    /**
+     * This function gets gets a list of all queued items if the job is a buildable item.
+     *
+     * Note the estimated build number calculation is a guess - job types need not return
+     * sequential build numbers.
+     *
+     * @return List of items newest first
+     */
+    public static List<BlueQueueItem> getQueuedItems(Job job) {
+        Link pipelineLink = LinkResolver.resolveLink(job);
+        if(job instanceof BuildableItem) {
+            BuildableItem task = (BuildableItem)job;
+            List<hudson.model.Queue.Item> items = Jenkins.getInstance().getQueue().getItems(task);
+            List<BlueQueueItem> items2 = Lists.newArrayList();
+            for (int i = 0; i < items.size(); i++) {
+                Link self = pipelineLink.rel("queue").rel(Long.toString(items.get(i).getId()));
+                items2.add(0, new QueueItemImpl(
+                    items.get(i),
+                    job.getName(),
+                    (items.size() == 1 ? job.getNextBuildNumber() : job.getNextBuildNumber() + i), self, pipelineLink));
+            }
+
+            return items2;
+        } else {
+            throw new ServiceException.UnexpectedErrorException("This pipeline is not buildable and therefore does not have a queue.");
+        }
+    }
+
+    private QueueUtil() {}
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
@@ -70,7 +70,7 @@ public class RunContainerImpl extends BlueRunContainer {
                 throw new NotFoundException(String.format("Run %s not found in organization %s and pipeline %s",
                     name, pipeline.getOrganization(), job.getName()));
             }
-            for (BlueQueueItem item : QueueContainerImpl.getQueuedItems(job)) {
+            for (BlueQueueItem item : QueueUtil.getQueuedItems(job)) {
                 if (item.getExpectedBuildNumber() == number) {
                     return item.toRun();
                 }
@@ -98,7 +98,7 @@ public class RunContainerImpl extends BlueRunContainer {
     }
 
     private Iterator<BlueRun> getRuns(Iterable<BlueRun> runs) {
-        return Iterables.concat(Iterables.transform(QueueContainerImpl.getQueuedItems(job), new Function<BlueQueueItem, BlueRun>() {
+        return Iterables.concat(Iterables.transform(QueueUtil.getQueuedItems(job), new Function<BlueQueueItem, BlueRun>() {
             @Override
             public BlueRun apply(BlueQueueItem input) {
                 return input.toRun();


### PR DESCRIPTION
… queue

# Description

Tries to find the item in the queue, if does not exist tries to find the run that is executing else throws an exception.

That should cover most of the cases. Better now that `replay` expects a run to be returned.

See [JENKINS-40084](https://issues.jenkins-ci.org/browse/JENKINS-40084).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

