### PR TITLE
Support docker-from-docker more easily

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,7 +1,10 @@
 # This image is based off the latest Jenkins LTS
-FROM jenkins:alpine
+FROM jenkinsci/jenkins:lts-alpine
 
 USER root
+
+# Add the docker binary so running Docker commands from the master works nicely
+RUN apk -U add docker
 
 RUN install-plugins.sh antisamy-markup-formatter matrix-auth pipeline-model-definition blueocean:$BLUEOCEAN_VERSION
 


### PR DESCRIPTION
This makes it easy to demo and use the container for Dockery workloads, which makes the Pipeline Editor muy bueno.

For example, with this commit: `docker run -p 8080:8080 -v /var/run/docker.sock:/var/run/docker.sock jenkinsci/blueocean`

Will allow the user to get started right away with Jenkinsfiles such as:

```groovy
   pipeline {
      agent { docker { image 'maven:3-alpine' }
      stages {
         stage('Build') {
            steps {
               sh 'mvn'
            }
         }
      }
   }
```