### PR TITLE
JENKINS-42417 Skipped tests should not use "unstable" coloring

### DIFF
--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -44,11 +44,12 @@ export default class TestCaseResultRow extends Component {
         case 'FAILED':
             statusIndicator = StatusIndicator.validResultValues.failure;
             break;
-        case 'SKIPPED':
-            statusIndicator = StatusIndicator.validResultValues.not_built;
-            break;
         case 'FIXED':
             statusIndicator = StatusIndicator.validResultValues.success;
+            break;
+        case 'SKIPPED':
+        case 'UNKNOWN':
+            statusIndicator = StatusIndicator.validResultValues.not_built;
             break;
         default:
         }

--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -44,7 +44,7 @@ export default class TestCaseResultRow extends Component {
         case 'FAILED':
             statusIndicator = StatusIndicator.validResultValues.failure;
             break;
-        case 'FIXED':
+        case 'PASSED':
             statusIndicator = StatusIndicator.validResultValues.success;
             break;
         case 'SKIPPED':

--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -48,10 +48,10 @@ export default class TestCaseResultRow extends Component {
             statusIndicator = StatusIndicator.validResultValues.success;
             break;
         case 'SKIPPED':
-        case 'UNKNOWN':
             statusIndicator = StatusIndicator.validResultValues.not_built;
             break;
         default:
+            statusIndicator = StatusIndicator.validResultValues.unknown;
         }
 
         const onExpand = () => {

--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -41,15 +41,13 @@ export default class TestCaseResultRow extends Component {
         const showTestCase = (t.errorStackTrace || t.errorDetails || this.stdout || this.stderr);
         let statusIndicator = null;
         switch (t.status) {
-        case 'REGRESSION':
         case 'FAILED':
             statusIndicator = StatusIndicator.validResultValues.failure;
             break;
         case 'SKIPPED':
-            statusIndicator = StatusIndicator.validResultValues.unstable;
+            statusIndicator = StatusIndicator.validResultValues.not_built;
             break;
         case 'FIXED':
-        case 'PASSED':
             statusIndicator = StatusIndicator.validResultValues.success;
             break;
         default:


### PR DESCRIPTION
# Description

![skipped](https://cloud.githubusercontent.com/assets/50156/25321504/76f3b3a6-28f2-11e7-9a7c-30b54fbefe48.png)

## Testing
To test have some skipped tests in the pipeline and ensure they have the not built indicator rather than the yellow "unstable".

See [JENKINS-42417](https://issues.jenkins-ci.org/browse/JENKINS-42417).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

