### PR TITLE
Make aggregator work with new plugins extensing blueocean

### DIFF
--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -35,6 +35,17 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-jwt</artifactId>
         </dependency>
+
+        <!--
+            Junit plugin loads structs 1.2 during mvn hpi:run for plugins depending on blueocean aggregator.
+            We tell mvn hpi:run to load later version of structs.
+
+            TODO: remove when junit plugin dependency is removed
+        -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
@@ -45,11 +56,6 @@
         </dependency>
 
         <!-- Test plugins -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>
             <artifactId>unirest-java</artifactId>

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -95,12 +95,6 @@
           <artifactId>blueocean-pipeline-editor</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-
-
         <!-- Test deps -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -95,6 +95,11 @@
           <artifactId>blueocean-pipeline-editor</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+        </dependency>
+
 
         <!-- Test deps -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,12 @@
             <version>1.20</version>
         </dependency>
 
+        <!-- Needed to make other plugins work with `mvn hpi:run` by simply depending on blueocean aggregator -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.6</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -444,13 +444,6 @@
             <version>1.20</version>
         </dependency>
 
-        <!-- Needed to make other plugins work with `mvn hpi:run` by simply depending on blueocean aggregator -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.6</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.mashape.unirest</groupId>


### PR DESCRIPTION
New plugins that define dependency on blueocean aggregator fail to start
duing `mvn hpi:run` with errors:

```
WARNING: Failed to load
org.jenkinsci.plugins.workflow.steps.scm.GenericSCMStep$DescriptorImpl
java.lang.NoClassDefFoundError:
org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable
  at java.lang.Class.getDeclaredMethods0(Native Method)
```
Reason it fails is due to order in which dependencies are resolved by
mvn hpi:run where it resolves structs 1.2 during loading scm-api which
depends on junit and it depends on structs 1.2. But structs 1.2 doesn't
have UninstantiatedDescribable.

I have this github project to demonstrate that it works: https://github.com/vivek/sample-blueocean-extension/blob/master/pom.xml#L70-L76

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
