### PR TITLE
[FIX JENKINS-43896] Non-transpiled dependency broke IE 11

### DIFF
--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -48,9 +48,9 @@
       "resolved": "https://registry.npmjs.org/@jenkins-cd/logging/-/logging-0.0.6.tgz"
     },
     "@jenkins-cd/preferences": {
-      "version": "0.0.3",
-      "from": "@jenkins-cd/preferences@0.0.3",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/preferences/-/preferences-0.0.3.tgz"
+      "version": "0.0.4",
+      "from": "@jenkins-cd/preferences@0.0.4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/preferences/-/preferences-0.0.4.tgz"
     },
     "@jenkins-cd/react-material-icons": {
       "version": "1.0.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -43,7 +43,7 @@
     "@jenkins-cd/design-language": "0.0.127",
     "@jenkins-cd/js-extensions": "0.0.35",
     "@jenkins-cd/js-modules": "0.0.8",
-    "@jenkins-cd/preferences": "0.0.3",
+    "@jenkins-cd/preferences": "0.0.4",
     "@jenkins-cd/react-material-icons": "1.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "es6-promise": "4.0.5",


### PR DESCRIPTION
# Description

`@jenkins-cd/preferences` was not transpiled, breaking IE 11

See [JENKINS-43896](https://issues.jenkins-ci.org/browse/JENKINS-43896).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

