### PR TITLE
@jenkins-cd/js-builder@0.0.57 on dependants

### DIFF
--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.57-tf-beta-1",
-      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
+      "version": "0.0.57",
+      "from": "@jenkins-cd/js-builder@0.0.57",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {
@@ -296,9 +296,9 @@
           "dev": true
         },
         "babylon": {
-          "version": "6.17.0",
+          "version": "6.17.1",
           "from": "babylon@^6.15.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
           "dev": true
         },
         "js-tokens": {
@@ -378,9 +378,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -546,9 +546,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -682,9 +682,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@>=6.15.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -746,9 +746,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -810,9 +810,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -986,9 +986,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -1050,9 +1050,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -1114,9 +1114,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -1178,9 +1178,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -1262,9 +1262,9 @@
           "dev": true,
           "dependencies": {
             "babylon": {
-              "version": "6.17.0",
+              "version": "6.17.1",
               "from": "babylon@^6.15.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
               "dev": true
             }
           }
@@ -1749,7 +1749,7 @@
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "from": "buffer-shims@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "dev": true
     },
@@ -1839,7 +1839,7 @@
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.0 <0.4.0",
+      "from": "circular-json@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
@@ -2338,9 +2338,9 @@
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.15",
+          "version": "0.10.16",
           "from": "es5-ext@>=0.10.14 <0.11.0",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
           "dev": true
         },
         "es6-iterator": {
@@ -2370,9 +2370,9 @@
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.15",
+          "version": "0.10.16",
           "from": "es5-ext@~0.10.14",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
           "dev": true
         },
         "es6-iterator": {
@@ -2408,9 +2408,9 @@
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.15",
+          "version": "0.10.16",
           "from": "es5-ext@^0.10.14",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
           "dev": true
         },
         "es6-iterator": {
@@ -2559,9 +2559,9 @@
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.15",
+          "version": "0.10.16",
           "from": "es5-ext@~0.10.14",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.16.tgz",
           "dev": true
         }
       }
@@ -2610,7 +2610,7 @@
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@3.0.0",
+      "from": "extend@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
@@ -2941,7 +2941,7 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@3.9.1",
+      "from": "gulp@>=3.9.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dev": true,
       "dependencies": {
@@ -3511,9 +3511,9 @@
       "dev": true
     },
     "jsonparse": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "dev": true
     },
     "jsonpointer": {
@@ -5470,7 +5470,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0",
+      "from": "xtend@>=4.0.1 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "dev": true
     },

--- a/blueocean-config/npm-shrinkwrap.json
+++ b/blueocean-config/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.56",
-      "from": "@jenkins-cd/js-builder@0.0.56",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.56.tgz",
+      "version": "0.0.57-tf-beta-1",
+      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-modules": {
@@ -40,9 +40,9 @@
       }
     },
     "ajv": {
-      "version": "4.11.7",
+      "version": "4.11.8",
       "from": "ajv@>=4.7.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "dev": true,
       "dependencies": {
         "json-stable-stringify": {
@@ -308,9 +308,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -334,9 +334,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -398,9 +398,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -424,9 +424,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -450,9 +450,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -476,9 +476,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -502,9 +502,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -566,9 +566,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -598,9 +598,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -618,9 +618,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -638,9 +638,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -702,9 +702,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -766,9 +766,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -830,9 +830,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -850,9 +850,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -876,9 +876,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -896,9 +896,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -922,9 +922,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -942,9 +942,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1006,9 +1006,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1070,9 +1070,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1134,9 +1134,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1198,9 +1198,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1218,9 +1218,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1282,9 +1282,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1308,9 +1308,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1328,9 +1328,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1354,9 +1354,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1374,9 +1374,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1394,9 +1394,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1414,9 +1414,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1446,9 +1446,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.10.4",
+          "version": "0.10.5",
           "from": "regenerator-runtime@^0.10.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
       }
@@ -1590,32 +1590,6 @@
           "from": "combine-source-map@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
           "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "dev": true,
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@~1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.2.9",
-              "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "dev": true
-            },
-            "string_decoder": {
-              "version": "1.0.0",
-              "from": "string_decoder@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-              "dev": true
-            }
-          }
         },
         "convert-source-map": {
           "version": "1.1.3",
@@ -1775,7 +1749,7 @@
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <1.1.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "dev": true
     },
@@ -1865,7 +1839,7 @@
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.1 <0.4.0",
+      "from": "circular-json@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
@@ -1985,21 +1959,21 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.4.10",
-      "from": "concat-stream@>=1.4.5 <1.5.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.6.0 <1.7.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "dev": true,
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "readable-stream": {
+          "version": "2.2.9",
+          "from": "readable-stream@>=2.2.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "dev": true
         },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+        "string_decoder": {
+          "version": "1.0.0",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
           "dev": true
         }
       }
@@ -2527,9 +2501,9 @@
       "dev": true
     },
     "espree": {
-      "version": "3.4.2",
+      "version": "3.4.3",
       "from": "espree@>=3.1.6 <4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
@@ -2636,7 +2610,7 @@
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <4.0.0",
+      "from": "extend@3.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
@@ -2967,7 +2941,7 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@>=3.9.0 <4.0.0",
+      "from": "gulp@3.9.1",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dev": true,
       "dependencies": {
@@ -3048,9 +3022,9 @@
       "dev": true
     },
     "gulp-runner": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "gulp-runner@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.1.tgz",
       "dev": true
     },
     "gulp-util": {
@@ -3194,9 +3168,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.2.7",
+      "version": "3.3.0",
       "from": "ignore@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz",
       "dev": true
     },
     "imurmurhash": {
@@ -3472,9 +3446,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.3",
+      "version": "3.8.4",
       "from": "js-yaml@>=3.5.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
@@ -3993,9 +3967,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.23",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
           "dev": true
         }
       }
@@ -4832,9 +4806,9 @@
       }
     },
     "static-module": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "static-module@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.2.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
@@ -4902,9 +4876,9 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {
@@ -5496,7 +5470,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <4.1.0",
+      "from": "xtend@>=4.0.0 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "dev": true
     },

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
+    "@jenkins-cd/js-builder": "0.0.57",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -14,7 +14,7 @@
     "rollbar-browser": "1.9.2"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.56",
+    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
     "babel-eslint": "6.1.2",
     "eslint-plugin-react": "4.3.0",
     "gulp": "3.9.1"

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -19,9 +19,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.57-tf-beta-1",
-      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
+      "version": "0.0.57",
+      "from": "@jenkins-cd/js-builder@0.0.57",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
@@ -5055,9 +5055,9 @@
       "dev": true
     },
     "jsonparse": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "dev": true
     },
     "jsonpointer": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -19,9 +19,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.56",
-      "from": "@jenkins-cd/js-builder@0.0.56",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.56.tgz",
+      "version": "0.0.57-tf-beta-1",
+      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
@@ -1552,7 +1552,7 @@
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <1.1.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "dev": true
     },
@@ -1662,7 +1662,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.0 <2.0.0",
+      "from": "chalk@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "cheerio": {
@@ -1693,7 +1693,7 @@
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.1 <0.4.0",
+      "from": "circular-json@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
@@ -4414,7 +4414,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ini": {
@@ -5695,9 +5695,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.23",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
           "dev": true
         }
       }
@@ -5715,7 +5715,7 @@
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "minimatch@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
@@ -5740,7 +5740,7 @@
     },
     "mobx-utils": {
       "version": "1.1.2",
-      "from": "mobx-utils@1.1.2",
+      "from": "mobx-utils@latest",
       "resolved": "https://registry.npmjs.org/mobx-utils/-/mobx-utils-1.1.2.tgz"
     },
     "mocha": {
@@ -6782,7 +6782,7 @@
     },
     "react-autocomplete": {
       "version": "1.4.0",
-      "from": "react-autocomplete@1.4.0",
+      "from": "react-autocomplete@latest",
       "resolved": "https://registry.npmjs.org/react-autocomplete/-/react-autocomplete-1.4.0.tgz"
     },
     "react-dom": {
@@ -7329,7 +7329,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.6 <0.6.0",
+          "from": "source-map@>=0.5.3 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "dev": true
         }
@@ -7699,7 +7699,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -7891,7 +7891,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
+      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "dev": true
     },
@@ -8413,7 +8413,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <5.0.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
+    "@jenkins-cd/js-builder": "0.0.57",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.56",
+    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.57-tf-beta-1",
-      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
+      "version": "0.0.57",
+      "from": "@jenkins-cd/js-builder@0.0.57",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
@@ -4914,9 +4914,9 @@
       "dev": true
     },
     "jsonparse": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "dev": true
     },
     "jsonpointer": {

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.56",
-      "from": "@jenkins-cd/js-builder@0.0.56",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.56.tgz",
+      "version": "0.0.57-tf-beta-1",
+      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
@@ -4048,9 +4048,9 @@
       "dev": true
     },
     "gulp-runner": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "gulp-runner@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.1.tgz",
       "dev": true
     },
     "gulp-util": {
@@ -4636,9 +4636,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "2.6.0",
+      "version": "2.6.1",
       "from": "jasmine-core@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz",
       "dev": true
     },
     "jasmine-reporters": {
@@ -5582,9 +5582,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.23",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
           "dev": true
         }
       }
@@ -7318,30 +7318,24 @@
       }
     },
     "static-module": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "static-module@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.2.tgz",
       "dev": true,
       "dependencies": {
         "concat-stream": {
-          "version": "1.4.10",
-          "from": "concat-stream@>=1.4.5 <1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "version": "1.6.0",
+          "from": "concat-stream@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "dev": true,
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.14",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "version": "2.2.9",
+              "from": "readable-stream@>=2.2.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
               "dev": true
             }
           }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "dev": true
         },
         "object-keys": {
           "version": "0.4.0",
@@ -7359,6 +7353,26 @@
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.27-1 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.0",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
           "dev": true
         },
         "through2": {
@@ -7414,9 +7428,9 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
+    "@jenkins-cd/js-builder": "0.0.57",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.56",
+    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.56",
-      "from": "@jenkins-cd/js-builder@0.0.56",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.56.tgz",
+      "version": "0.0.57-tf-beta-1",
+      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
@@ -2458,9 +2458,9 @@
       "dev": true
     },
     "gulp-runner": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "gulp-runner@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.1.tgz",
       "dev": true
     },
     "gulp-util": {
@@ -2943,9 +2943,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "2.6.0",
+      "version": "2.6.1",
       "from": "jasmine-core@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz",
       "dev": true
     },
     "jasmine-reporters": {
@@ -3732,9 +3732,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.23",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
           "dev": true
         }
       }
@@ -4196,9 +4196,9 @@
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
-      "version": "0.11.9",
+      "version": "0.11.10",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "dev": true
     },
     "process-nextick-args": {
@@ -4783,30 +4783,24 @@
       }
     },
     "static-module": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "static-module@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.2.tgz",
       "dev": true,
       "dependencies": {
         "concat-stream": {
-          "version": "1.4.10",
-          "from": "concat-stream@>=1.4.5 <1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "version": "1.6.0",
+          "from": "concat-stream@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "dev": true,
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.14",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "version": "2.2.9",
+              "from": "readable-stream@>=2.2.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
               "dev": true
             }
           }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "dev": true
         },
         "object-keys": {
           "version": "0.4.0",
@@ -4824,6 +4818,26 @@
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.27-1 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.0",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
           "dev": true
         },
         "through2": {
@@ -4867,9 +4881,9 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.57-tf-beta-1",
-      "from": "@jenkins-cd/js-builder@0.0.57-tf-beta-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57-tf-beta-1.tgz",
+      "version": "0.0.57",
+      "from": "@jenkins-cd/js-builder@0.0.57",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.57.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
@@ -3195,9 +3195,9 @@
       "dev": true
     },
     "jsonparse": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "dev": true
     },
     "jsonpointer": {

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.56",
+    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
+    "@jenkins-cd/js-builder": "0.0.57",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
+    "@jenkins-cd/js-builder": "0.0.57",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "@jenkins-cd/logging": "0.0.6",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.56",
+    "@jenkins-cd/js-builder": "0.0.57-tf-beta-1",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/js-test": "1.2.3",
     "@jenkins-cd/logging": "0.0.6",


### PR DESCRIPTION
Related to [JENKINS-39657](https://issues.jenkins-ci.org/browse/JENKINS-39657).

Depends on https://github.com/jenkinsci/js-builder/pull/16.

Basically ... a `js-builder` that generates metadata that can be used by https://github.com/tfennelly/jenkins-js-modules-chrome-ext for runtime analysis of bundles.