### PR TITLE
Automatically republish if a new LTS is available

### DIFF
--- a/docker/official/build.sh
+++ b/docker/official/build.sh
@@ -5,9 +5,18 @@ cd $HERE
 
 BLUEOCEAN_VERSION=$(git for-each-ref --sort=-taggerdate refs/tags/blueocean-parent-\*  | grep -v 'beta' | head -1 |awk '{print $3 }' | sed 's/refs\/tags\/blueocean-parent-//')
 
+# Check we have the latest LTS for blue ocean to build on and get its image ID
+docker pull jenkinsci/jenkins:lts-alpine
+LTS_IMAGE_ID=$(docker images jenkinsci/jenkins:lts-alpine | sed -n 2p | awk '{ print $3 }')
+
+# Make an explicit version tag for both blue and LTS, like 1.0.1-3321321
+# We need this so if the LTS image changes OR blue ocean, we rebuild and published
+# A new LTS means there may be security fixes
+FULL_VERSION="$BLUEOCEAN_VERSION-$LTS_IMAGE_ID"
+
 # Check if the image already exists
-if docker pull jenkinsci/blueocean:$BLUEOCEAN_VERSION; then
-  echo "Image jenkinsci/blueocean:$BLUEOCEAN_VERSION already exists in Docker Hub"
+if docker pull jenkinsci/blueocean:$FULL_VERSION; then
+  echo "Image jenkinsci/blueocean:$FULL_VERSION already exists in Docker Hub"
   exit 0
 fi
 
@@ -18,5 +27,10 @@ docker build --rm --no-cache --pull \
 # Consider this build is the latest
 docker tag "jenkinsci/blueocean:$BLUEOCEAN_VERSION" jenkinsci/blueocean:latest
 
+# Tag this build with the full version tag
+docker tag "jenkinsci/blueocean:$BLUEOCEAN_VERSION" "jenkinsci/blueocean:$FULL_VERSION"
+
+# push it real good
 docker push "jenkinsci/blueocean:$BLUEOCEAN_VERSION"
+docker push "jenkinsci/blueocean:$FULL_VERSION"
 docker push jenkinsci/blueocean:latest


### PR DESCRIPTION
# Description

This tags the image additionally with the LTS id. Thus in theory, if a new LTS is published before a new blue ocean, it will then publish a the same blue ocean but with the new LTS. 

I don't have the environment to test this in, so up to @rtyler to approve or reject this. 

