### PR TITLE
fix content jumping when vertical scrollbar appears/disappears

### DIFF
--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -1,3 +1,8 @@
+html {
+    width: 100vw;
+    overflow-x: hidden;
+}
+
 #modal-snap-background {
     position: fixed;
     top: 0;

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -1,6 +1,5 @@
 html {
-    width: 100vw;
-    overflow-x: hidden;
+    overflow-y: scroll;
 }
 
 #modal-snap-background {


### PR DESCRIPTION
# Description
Made the html tag have a 100vw width that will ignore the appearance or disappearance of the vertical scrollbar on systems that have a mouse attached, this bug did not manifest when only a touchpad was present.

A possible problem with this fix would appear if we need to ever horizontal scroll the html tag. If we ever need to do that, an alternate fix to this bug is to make the vertical scrollbar always appear on systems that have a mouse connected but this fix is preferred because the the vertical scrollbar won't appear if it is not needed.

No tests are necessary because the fix consists of only css changes

See [JENKINS-44048](https://issues.jenkins-ci.org/browse/JENKINS-44048).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

