### PR TITLE
JENKINS-44258 Replayed runs have same changeset as original

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
@@ -11,17 +11,31 @@ export default class RunMessageCell extends Component {
         const run = this.props.run;
         const t = this.props.t;
         let message;
-        if (run && run.description) {
+
+        // Note that the order that this is evaluated is important for providing a relevant message to the user
+
+        // 1. If the user has set a message then we always show it
+        const showUserDefinedMessage = run && run.description;
+
+        // 2. Show commit messages if available
+        //    however if a run has > 1 cause then the cause is likely more important than the change set (e.g. replay)
+        const showCommitMessage = run && run.changeSet && (run.changeSet && run.changeSet.length > 0) && (run.causes && run.causes.length <= 1);
+
+        // 3. Lastly if there are any causes, display the last cause available
+        const showCauses = run && (run.causes && run.causes.length > 0);
+
+        if (showUserDefinedMessage) {
             message = (<span className="RunMessageCell" title={run.description}><span className="RunMessageCellInner">{run.description}</span></span>);
-        } else if (run && run.changeSet && run.changeSet.length > 0) {
+        } else if (showCommitMessage) {
             const commitMsg = run.changeSet[run.changeSet.length - 1].msg;
             if (run.changeSet.length > 1) {
                 return (<span className="RunMessageCell" title={commitMsg}><span className="RunMessageCellInner">{commitMsg}</span> <Lozenge title={t('lozenge.commit', {0: run.changeSet.length})}/></span>);
             } else {
                 return (<span className="RunMessageCell" title={commitMsg}><span className="RunMessageCellInner">{commitMsg}</span></span>);
             }
-        } else if (run && run.causes.length > 0) {
-            const cause = run.causes[0].shortDescription;
+        } else if (showCauses) {
+            // Last cause is always more significant than the first
+            const cause = run.causes[run.causes.length-1].shortDescription;
             return (<span className="RunMessageCell" title={cause}><span className="RunMessageCellInner">{cause}</span></span>)
         } else {
             message = (<span className="RunMessageCell"><span className="RunMessageCellInner">–</span></span>);

--- a/blueocean-dashboard/src/test/js/run-message-cell-spec.js
+++ b/blueocean-dashboard/src/test/js/run-message-cell-spec.js
@@ -20,7 +20,8 @@ describe('RunMessageCell', () => {
                 'msg': 'Oops',
             }, {
                 'msg': 'fix bug',
-            }]
+            }],
+            causes: [],
         };
         const cell = render(<RunMessageCell run={run} t={t} />);
         expect(cell.text()).to.equal('fix bug lozenge.commit');
@@ -30,10 +31,25 @@ describe('RunMessageCell', () => {
         const run =  {
             'changeSet':[{
                 'msg': 'Oops',
-            }]
+            }],
+            causes: [],
         };
         const cell = render(<RunMessageCell run={run} t={t} />);
         expect(cell.text()).to.equal('Oops');
+    });
+
+    it('displays cause because more than 1 cause is more important', () => {
+            const run = {
+                'changeSet':[{
+                    'msg': 'Oops',
+                }],
+                causes: [
+                    { shortDescription: 'Cake is delicious' },
+                    { shortDescription: 'Have some cake' },
+                ]
+            };
+            const cell = render(<RunMessageCell run={run} t={t} />);
+            expect(cell.text()).to.equal('Have some cake');
     });
 
     it('displays cause', () => {
@@ -44,7 +60,7 @@ describe('RunMessageCell', () => {
             ]
         };
         const cell = render(<RunMessageCell run={run} t={t} />);
-        expect(cell.text()).to.equal('Cake is delicious');
+        expect(cell.text()).to.equal('Have some cake');
     });
 
     it('displays nothing', () => {

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -10,7 +11,6 @@ import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.factory.BlueRunFactory;
-import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.impl.pipeline.BranchImpl.Branch;
 import io.jenkins.blueocean.rest.impl.pipeline.BranchImpl.PullRequest;
 import io.jenkins.blueocean.rest.model.BlueChangeSetEntry;
@@ -27,6 +27,7 @@ import io.jenkins.blueocean.service.embedded.rest.StoppableRun;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMRevisionAction;
 import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction;
+import org.jenkinsci.plugins.workflow.cps.replay.ReplayCause;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
@@ -49,7 +50,7 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW
 @Capability(JENKINS_WORKFLOW_RUN)
 public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
     private static final Logger logger = LoggerFactory.getLogger(PipelineRunImpl.class);
-    public PipelineRunImpl(WorkflowRun run, Link parent) {
+    public PipelineRunImpl(WorkflowRun run, Reachable parent) {
         super(run, parent);
     }
 
@@ -70,17 +71,28 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
 
     @Override
     public Container<BlueChangeSetEntry> getChangeSet() {
-        Map<String, BlueChangeSetEntry> m = new LinkedHashMap<>();
-        int cnt = 0;
-        for (ChangeLogSet<? extends Entry> cs : run.getChangeSets()) {
-            for (ChangeLogSet.Entry e : cs) {
-                cnt++;
-                String id = e.getCommitId();
-                if (id == null) id = String.valueOf(cnt);
-                m.put(id, new ChangeSetResource(e, this));
+        // If this run is a replay then return the changesets from the original run
+        ReplayCause replayCause = run.getCause(ReplayCause.class);
+        if (replayCause != null) {
+            Run run = replayCause.getRun();
+            if (run == null) {
+                return Containers.fromResourceMap(getLink(), ImmutableMap.<String, BlueChangeSetEntry>of());
+            } else {
+                return AbstractRunImpl.getBlueRun(run, parent).getChangeSet();
             }
+        } else {
+            Map<String, BlueChangeSetEntry> m = new LinkedHashMap<>();
+            int cnt = 0;
+            for (ChangeLogSet<? extends Entry> cs : run.getChangeSets()) {
+                for (ChangeLogSet.Entry e : cs) {
+                    cnt++;
+                    String id = e.getCommitId();
+                    if (id == null) id = String.valueOf(cnt);
+                    m.put(id, new ChangeSetResource(e, this));
+                }
+            }
+            return Containers.fromResourceMap(getLink(), m);
         }
-        return Containers.fromResourceMap(getLink(),m);
     }
 
     @Override
@@ -189,7 +201,7 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
         @Override
         public BlueRun getRun(Run run, Reachable parent) {
             if(run instanceof WorkflowRun) {
-                return new PipelineRunImpl((WorkflowRun) run, parent.getLink());
+                return new PipelineRunImpl((WorkflowRun) run, parent);
             }
             return null;
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -39,25 +39,13 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     protected final T run;
     protected final BlueOrganization org;
 
-    protected final Link parent;
-    public AbstractRunImpl(T run, Link parent) {
+    protected final Reachable parent;
+    public AbstractRunImpl(T run, Reachable parent) {
         this.run = run;
         this.parent = parent;
         this.org = OrganizationFactory.getInstance().getContainingOrg(run);
     }
 
-    //TODO: It serializes jenkins Run model children, enable this code after fixing it
-//    /**
-//     * Allow properties reachable through {@link Run} to be exposed upon request (via the tree parameter).
-//     */
-//    @Exported
-//    public T getRun() {
-//        return run;
-//    }
-
-    /**
-     * Subtype should return
-     */
     public Container<BlueChangeSetEntry> getChangeSet() {
         return null;
     }
@@ -206,7 +194,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
                 return blueRun;
             }
         }
-        return new AbstractRunImpl<>(r, parent.getLink());
+        return new AbstractRunImpl<>(r, parent);
     }
 
     @Override
@@ -273,7 +261,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
         if(parent == null){
             return org.getLink().rel(String.format("pipelines/%s/runs/%s", run.getParent().getName(), getId()));
         }
-        return parent.rel("runs/"+getId());
+        return parent.getLink().rel("runs/"+getId());
     }
 
     private boolean isCompletedOrAborted(){
@@ -283,7 +271,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
 
     @Override
     public Links getLinks() {
-        return super.getLinks().add("parent", parent);
+        return super.getLinks().add("parent", parent.getLink());
     }
 
     public static class BlueCauseImpl extends BlueCause {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
@@ -7,7 +7,6 @@ import hudson.scm.ChangeLogSet;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.factory.BlueRunFactory;
-import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueChangeSetEntry;
 import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.Container;
@@ -26,7 +25,7 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_FREE_STY
  */
 @Capability(JENKINS_FREE_STYLE_BUILD)
 public class FreeStyleRunImpl extends AbstractRunImpl<FreeStyleBuild> {
-    public FreeStyleRunImpl(FreeStyleBuild run, Link parent) {
+    public FreeStyleRunImpl(FreeStyleBuild run, Reachable parent) {
         super(run, parent);
     }
 
@@ -60,7 +59,7 @@ public class FreeStyleRunImpl extends AbstractRunImpl<FreeStyleBuild> {
         @Override
         public BlueRun getRun(Run run, Reachable parent) {
             if (run instanceof FreeStyleBuild) {
-                return new FreeStyleRunImpl((FreeStyleBuild)run, parent.getLink());
+                return new FreeStyleRunImpl((FreeStyleBuild)run, parent);
             }
             return null;
         }


### PR DESCRIPTION
This change is fairly nuanced but results in a more relevant experience for users.

Included in this change:
* When we detect the replay cause on the current run we lookup the original run and return its changesets.
* It turns out the first cause in the array is the least significant - replayed runs never had the correct cause displayed and is now fixed.
* If there are two or more causes on the run then the last cause in the array is more important to the user than the changeset message when viewing Activity or Branches tabs.

# Testing
- Create a pipeline and run it so that it contains a few changesets
-  Message column on Activity should be the changeset
- Replay the run
- Message column on Activity should be "Replayed #?" where ? is the run number of the original run

# Description

See [JENKINS-44258](https://issues.jenkins-ci.org/browse/JENKINS-44258).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

