### PR TITLE
[JENKINS-44270] - BlueOcean organization root ItemGroup not taken into account for Links and fullName on the API

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -114,12 +114,12 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
 
     @Override
     public String getFullName() {
-        return mbp.getFullName();
+        return AbstractPipelineImpl.getFullName(org, mbp);
     }
 
     @Override
     public String getFullDisplayName() {
-        return AbstractPipelineImpl.getFullDisplayName(mbp, null);
+        return AbstractPipelineImpl.getFullDisplayName(org, mbp);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -3,6 +3,7 @@ package io.jenkins.blueocean.service.embedded.rest;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.Util;
 import hudson.model.AbstractItem;
 import hudson.model.Item;
@@ -134,57 +135,63 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     @Override
     public String getFullName(){
-        return job.getFullName();
+        return getFullName(org, job);
     }
 
     @Override
     public String getFullDisplayName() {
-        return getFullDisplayName(job.getParent(), Util.rawEncode(job.getDisplayName()));
+        return getFullDisplayName(org, job);
     }
 
     /**
-     * Returns full display name. Each display name is separated by '/' and each display name is url encoded. If the
-     * item is inside an org, it will be looked up.
-     * 
-     * @param parent parent folder
-     * @param displayName URL encoded display name. Caller must pass urlencoded name
-     *
-     * @return full display name
-     */
-    public static String getFullDisplayName(@Nonnull ItemGroup parent, @Nullable String displayName){
-        return getFullDisplayName(OrganizationFactory.getInstance().getContainingOrg(parent), parent, displayName);
-    }
-
-    /**
-     * Returns full display name. Each display name is separated by '/' and each display name is url encoded.
+     * Returns full display name relative to the <code>BlueOrganization</code> base. Each display name is separated by
+     * '/' and each display name is url encoded
      *
      * @param org the organization the item belongs to
-     * @param parent parent folder
-     * @param displayName URL encoded display name. Caller must pass urlencoded name
+     * @param item to return the full display name of
      *
      * @return full display name
      */
-    public static String getFullDisplayName(@Nullable BlueOrganization org, @Nonnull ItemGroup parent, @Nullable String displayName) {
-        //Stop if we are on an org and reached the top
+    public static String getFullDisplayName(@Nullable BlueOrganization org, @Nonnull Item item) {
+        ItemGroup<?> group = getBaseGroup(org);
+        String[] displayNames = Functions.getRelativeDisplayNameFrom(item, group).split(" » ");
+
+        StringBuilder encondedDisplayName=new StringBuilder();
+        for(int i=0;i<displayNames.length;i++) {
+            if(i!=0) {
+                encondedDisplayName.append(String.format("/%s", Util.rawEncode(displayNames[i])));
+            }else {
+                encondedDisplayName.append(String.format("%s", Util.rawEncode(displayNames[i])));
+            }
+        }
+        
+        return encondedDisplayName.toString();
+    }
+
+    /**
+     * Returns full name relative to the <code>BlueOrganization</code> base. Each name is separated by '/'
+     * 
+     * @param org the organization the item belongs to
+     * @param item to return the full name of
+     * @return
+     */
+    public static String getFullName(@Nullable BlueOrganization org, @Nonnull Item item) {
+        ItemGroup<?> group = getBaseGroup(org);
+        return Functions.getRelativeNameFrom(item, group);
+    }
+
+    /**
+     * Tries to obtain the base group for a <code>BlueOrganization</code>
+     * 
+     * @param org to get the base group of
+     * @return the base group
+     */
+    public static ItemGroup<?> getBaseGroup(BlueOrganization org) {
+        ItemGroup<?> group = null;
         if (org != null && org instanceof AbstractOrganization) {
-            ItemGroup group = ((AbstractOrganization) org).getGroup();
-            if (group == parent) {
-                return displayName;
-            }
+            group = ((AbstractOrganization) org).getGroup();
         }
-
-        String name = parent.getDisplayName();
-        if (name.length() == 0)
-            return displayName;
-
-        if (name.length() > 0 && parent instanceof AbstractItem) {
-            if (displayName == null) {
-                return getFullDisplayName(((AbstractItem) parent).getParent(), String.format("%s", Util.rawEncode(name)));
-            } else {
-                return getFullDisplayName(((AbstractItem) parent).getParent(), String.format("%s/%s", Util.rawEncode(name), displayName));
-            }
-        }
-        return displayName;
+        return group;
     }
 
     @Override
@@ -192,6 +199,12 @@ public class AbstractPipelineImpl extends BluePipeline {
         return org.getLink().rel("pipelines").rel(getRecursivePathFromFullName(this));
     }
 
+    /**
+     * Calculates the recursive path for the <code>BluePipeline</code>. The path is relative to the org base
+     * 
+     * @param pipeline to get the recursive path from
+     * @return the recursive path
+     */
     public static String getRecursivePathFromFullName(BluePipeline pipeline){
         StringBuilder pipelinePath = new StringBuilder();
         String[] names = pipeline.getFullName().split("/");

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -63,12 +63,20 @@ public class PipelineFolderImpl extends BluePipelineFolder {
 
     @Override
     public String getFullName() {
-        return folder.getFullName();
+        if (folder instanceof Item) {
+            return AbstractPipelineImpl.getFullName(org, (Item) folder);
+        } else {
+            return null;
+        }
     }
 
     @Override
     public String getFullDisplayName() {
-        return AbstractPipelineImpl.getFullDisplayName(folder, null);
+        if (folder instanceof Item) {
+            return AbstractPipelineImpl.getFullDisplayName(org, (Item) folder);
+        } else {
+            return folder.getDisplayName();
+        }
     }
 
     @Override

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -44,6 +44,7 @@ import jenkins.model.Jenkins;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
@@ -728,15 +729,23 @@ public class PipelineApiTest extends BaseTest {
      * see the elements under that folder.
      */
     @Test
+    @Issue({ "JENKINS-44176", "JENKINS-44270" })
     public void testOrganizationFolder() throws IOException, ExecutionException, InterruptedException {
 
-        FreeStyleProject jobOutSideOrg = j.createFreeStyleProject("pipelineOutsideOrg");
+        FreeStyleProject jobOutSideOrg = j.createFreeStyleProject("pipelineOutsideOrgName");
+        jobOutSideOrg.setDisplayName("pipelineOutsideOrg Display Name");
 
-        MockFolder orgFolder = j.createFolder("TestOrgFolder");
-        MockFolder folderOnOrg = orgFolder.createProject(MockFolder.class, "folderOnOrg");
+        MockFolder orgFolder = j.createFolder("TestOrgFolderName");
+        orgFolder.setDisplayName("TestOrgFolderName Display Name");
 
-        FreeStyleProject jobOnRootOrg = orgFolder.createProject(FreeStyleProject.class, "jobOnRootOrg");
-        FreeStyleProject jobOnFolder = folderOnOrg.createProject(FreeStyleProject.class, "jobOnFolder");
+        MockFolder folderOnOrg = orgFolder.createProject(MockFolder.class, "folderOnOrgName");
+        folderOnOrg.setDisplayName("folderOnOrg Display Name");
+
+        FreeStyleProject jobOnRootOrg = orgFolder.createProject(FreeStyleProject.class, "jobOnRootOrgName");
+        jobOnRootOrg.setDisplayName("jobOnRootOrg Display Name");
+
+        FreeStyleProject jobOnFolder = folderOnOrg.createProject(FreeStyleProject.class, "jobOnFolderName");
+        jobOnFolder.setDisplayName("jobOnFolder Display Name");
 
         List<Map> pipelines = get("/search/?q=type:pipeline;organization:TestOrg;excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject", List.class);
 
@@ -744,24 +753,38 @@ public class PipelineApiTest extends BaseTest {
         Assert.assertEquals(3, pipelines.size());
 
         //The full name should not contain the organization folder name
+        Map links;
         for (Map map : pipelines) {
             Assert.assertEquals("TestOrg", map.get("organization"));
-
-            if (map.get("name").equals("folderOnOrg")) {
-                map.get("fullDisplayName").equals("folderOnOrg");
-            } else if (map.get("name").equals("jobOnRootOrg")) {
-                map.get("fullDisplayName").equals("jobOnFolder");
-            } else if (map.get("name").equals("jobOnFolder")) {
-                map.get("fullDisplayName").equals("folderOnOrg/jobOnFolder");
+            if (map.get("name").equals("folderOnOrgName")) {
+                map.get("fullDisplayName").equals("folderOnOrg%20Display%20Name");
+                map.get("fullName").equals("folderOnOrgName");
+                checkLinks((Map) map.get("_links"), "/blue/rest/organizations/TestOrg/pipelines/folderOnOrgName/");
+            } else if (map.get("name").equals("jobOnRootOrgName")) {
+                map.get("fullDisplayName").equals("jobOnRootOrg%20Display%20Name");
+                map.get("fullName").equals("jobOnRootOrgName");
+                checkLinks((Map) map.get("_links"), "/blue/rest/organizations/TestOrg/pipelines/jobOnRootOrgName/");
+            } else if (map.get("name").equals("jobOnFolderName")) {
+                map.get("fullDisplayName").equals("folderOnOrg%20Display%20Name/jobOnFolder%20Display%20Name");
+                map.get("fullName").equals("folderOnOrgName/jobOnFolderName");
+                checkLinks((Map) map.get("_links"), "/blue/rest/organizations/TestOrg/pipelines/folderOnOrgName/pipelines/jobOnFolderName/");
             } else {
                 Assert.fail("Item " + map.get("name") + " shouldn't be present");
             }
         }
     }
 
+    private void checkLinks(Map links, String startWith) {
+        for (Object link : links.values()) {
+            Map linkMap = (Map) link;
+            String href = ((String) linkMap.get("href"));
+            Assert.assertTrue("Link should start with " + startWith + " but was " + href, href.startsWith(startWith));
+        }
+    }
+
     @TestExtension(value = "testOrganizationFolder")
     public static class TestOrganizationFactoryImpl extends OrganizationFactoryImpl {
-        private OrganizationImpl instance = new OrganizationImpl("TestOrg", Jenkins.getInstance().getItem("/TestOrgFolder", Jenkins.getInstance(), MockFolder.class));
+        private OrganizationImpl instance = new OrganizationImpl("TestOrg", Jenkins.getInstance().getItem("/TestOrgFolderName", Jenkins.getInstance(), MockFolder.class));
 
         @Override
         public OrganizationImpl get(String name) {


### PR DESCRIPTION
# Description

See [JENKINS-44270](https://issues.jenkins-ci.org/browse/JENKINS-44270).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

