### PR TITLE
Fix cause on run details

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
@@ -152,7 +152,7 @@ class RunDetailsHeader extends Component {
             </div>
         );
 
-        const causeMessage = (run && run.causes.length > 0 && run.causes[0].shortDescription) || null;
+        const causeMessage = (run && run.causes.length > 0 && run.causes[run.causes.length - 1].shortDescription) || null;
         const cause = (<div className="causes">{causeMessage}</div>);
 
         return (


### PR DESCRIPTION
# Description

Fixes bug where the incorrect cause for a replayed run would be shown.

In `RunMessage.jsx` we do this:
`const cause = run.causes[run.causes.length-1].shortDescription;`

You can see the bug here:
![run](https://cloud.githubusercontent.com/assets/50156/26288194/f899a76a-3ecf-11e7-9e75-27ee41409b47.gif)


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

