### PR TITLE
Fix typo: BadRequestExpception => BadRequestException

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JsonConverter.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JsonConverter.java
@@ -34,7 +34,7 @@ public class JsonConverter{
         } catch (JsonParseException e){
             String msg = "Json parsing failure: "+e.getMessage();
             LOGGER.error(msg, e);
-            throw new ServiceException.BadRequestExpception("Json parsing failure: "+e.getMessage());
+            throw new ServiceException.BadRequestException("Json parsing failure: "+e.getMessage());
         } catch (JsonMappingException e){
             String msg = String.format("Failed to map Json to java type : %s. %s ", type, e.getMessage());
             LOGGER.error(msg, e);

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
@@ -108,44 +108,21 @@ public class ServiceException extends RuntimeException implements HttpResponse {
         }
     }
 
-    /**
-     * @deprecated use #BadRequestException
-     */
-    @Deprecated
-    public static class BadRequestExpception extends ServiceException{
+    public static class BadRequestException extends ServiceException {
 
-        public BadRequestExpception(String message) {
+        public BadRequestException(String message) {
             super(BAD_REQUEST, message);
         }
 
-        public BadRequestExpception(String message, Throwable throwable ) {
+        public BadRequestException(String message, Throwable throwable ) {
             super(BAD_REQUEST, message, throwable);
         }
 
-        public BadRequestExpception(ErrorMessage errorMessage) {
+        public BadRequestException(ErrorMessage errorMessage) {
             super(BAD_REQUEST, errorMessage, null);
         }
-        public BadRequestExpception(ErrorMessage errorMessage, Throwable throwable ) {
-            super(BAD_REQUEST, errorMessage, throwable);
-        }
-    }
-
-    // inheriting the deprecated one in case people are doing like `catch(BadRequestException)` so that it sill works
-    public static class BadRequestException extends BadRequestExpception {
-
-        public BadRequestException(String message) {
-            super(message);
-        }
-
-        public BadRequestException(String message, Throwable throwable ) {
-            super(message, throwable);
-        }
-
-        public BadRequestException(ErrorMessage errorMessage) {
-            super(errorMessage);
-        }
         public BadRequestException(ErrorMessage errorMessage, Throwable throwable ) {
-            super(errorMessage, throwable);
+            super(BAD_REQUEST, errorMessage, throwable);
         }
     }
 

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/ServiceException.java
@@ -108,6 +108,10 @@ public class ServiceException extends RuntimeException implements HttpResponse {
         }
     }
 
+    /**
+     * @deprecated use #BadRequestException
+     */
+    @Deprecated
     public static class BadRequestExpception extends ServiceException{
 
         public BadRequestExpception(String message) {
@@ -123,6 +127,25 @@ public class ServiceException extends RuntimeException implements HttpResponse {
         }
         public BadRequestExpception(ErrorMessage errorMessage, Throwable throwable ) {
             super(BAD_REQUEST, errorMessage, throwable);
+        }
+    }
+
+    // inheriting the deprecated one in case people are doing like `catch(BadRequestException)` so that it sill works
+    public static class BadRequestException extends BadRequestExpception {
+
+        public BadRequestException(String message) {
+            super(message);
+        }
+
+        public BadRequestException(String message, Throwable throwable ) {
+            super(message, throwable);
+        }
+
+        public BadRequestException(ErrorMessage errorMessage) {
+            super(errorMessage);
+        }
+        public BadRequestException(ErrorMessage errorMessage, Throwable throwable ) {
+            super(errorMessage, throwable);
         }
     }
 

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -111,7 +111,7 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequest {
                     //add the properties otherwise simply use it
                     Domain domain = CredentialsUtils.findDomain(credentialId, authenticatedUser);
                     if(domain == null){ //this should not happen since validateCredentialId found the credential
-                        throw new ServiceException.BadRequestExpception(
+                        throw new ServiceException.BadRequestException(
                                 new ErrorMessage(400, "Failed to create pipeline")
                                         .add(new ErrorMessage.Error("scm.credentialId",
                                                 ErrorMessage.Error.ErrorCodes.INVALID.toString(),
@@ -322,7 +322,7 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequest {
         if (credentialId != null && !credentialId.trim().isEmpty()) {
             StandardUsernamePasswordCredentials credentials = CredentialsUtils.findCredential(credentialId, StandardUsernamePasswordCredentials.class, new BlueOceanDomainRequirement());
             if (credentials == null) {
-                throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to create Github pipeline")
+                throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to create Github pipeline")
                         .add(new ErrorMessage.Error("scmConfig.credentialId",
                                 ErrorMessage.Error.ErrorCodes.NOT_FOUND.toString(),
                                 "No Credentials instance found for credentialId: "+credentialId)));

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -125,7 +125,7 @@ public class GithubScm extends Scm {
         final StandardUsernamePasswordCredentials credential = CredentialsUtils.findCredential(credentialId, StandardUsernamePasswordCredentials.class, new BlueOceanDomainRequirement());
 
         if(credential == null){
-            throw new ServiceException.BadRequestExpception(String.format("Credential id: %s not found for user %s", credentialId, authenticatedUser.getId()));
+            throw new ServiceException.BadRequestException(String.format("Credential id: %s not found for user %s", credentialId, authenticatedUser.getId()));
         }
 
         String accessToken = credential.getPassword().getPlainText();
@@ -192,7 +192,7 @@ public class GithubScm extends Scm {
             credentialId = request.getHeader(X_CREDENTIAL_ID);
         }
         if(credentialId == null){
-            throw new ServiceException.BadRequestExpception("Missing credential id. It must be provided either as HTTP header: " + X_CREDENTIAL_ID+" or as query parameter 'credentialId'");
+            throw new ServiceException.BadRequestException("Missing credential id. It must be provided either as HTTP header: " + X_CREDENTIAL_ID+" or as query parameter 'credentialId'");
         }
         return credentialId;
     }
@@ -200,7 +200,7 @@ public class GithubScm extends Scm {
     static class RateLimitHandlerImpl extends RateLimitHandler{
         @Override
         public void onError(IOException e, HttpURLConnection httpURLConnection) throws IOException {
-            throw new ServiceException.BadRequestExpception("API rate limit reached."+e.getMessage(), e);
+            throw new ServiceException.BadRequestException("API rate limit reached."+e.getMessage(), e);
         }
     }
 
@@ -208,7 +208,7 @@ public class GithubScm extends Scm {
     public HttpResponse validateAndCreate(@JsonBody JSONObject request) {
         String accessToken = (String) request.get("accessToken");
         if(accessToken == null){
-            throw new ServiceException.BadRequestExpception("accessToken is required");
+            throw new ServiceException.BadRequestException("accessToken is required");
         }
         try {
             User authenticatedUser =  getAuthenticatedUser();
@@ -270,7 +270,7 @@ public class GithubScm extends Scm {
             throw new ServiceException.NotFoundException("Not Found");
         }
         if(status != 200) {
-            throw new ServiceException.BadRequestExpception(String.format("Github Api returned error: %s. Error message: %s.", connection.getResponseCode(), connection.getResponseMessage()));
+            throw new ServiceException.BadRequestException(String.format("Github Api returned error: %s. Error message: %s.", connection.getResponseCode(), connection.getResponseMessage()));
         }
 
         return connection;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
@@ -63,7 +63,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
         }
 
         if(!errors.isEmpty()){
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                     new ErrorMessage(400, "Failed to load scm file").addAll(errors));
         }
 
@@ -71,12 +71,12 @@ public class GithubScmContentProvider extends ScmContentProvider {
 
         //if no repo param, then see if its there in given Item.
         if(repo == null && scmParamsFromItem.repo == null){
-            throw new ServiceException.BadRequestExpception("github repo could not be determine from pipeline: "+item.getFullName());
+            throw new ServiceException.BadRequestException("github repo could not be determine from pipeline: "+item.getFullName());
         }
 
         // If both, repo param and repo in pipeline scm configuration present, they better match
         if(repo != null && scmParamsFromItem.repo != null && !repo.equals(scmParamsFromItem.repo)){
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                     String.format("repo parameter %s doesn't match with repo in pipeline %s github configuration repo: %s ",
                             repo, item.getFullName(), scmParamsFromItem.repo));
         }
@@ -127,7 +127,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
 
         GithubScmSaveFileRequest request = staplerRequest.bindJSON(GithubScmSaveFileRequest.class, body);
         if(request == null){
-            throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to bind request"));
+            throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to bind request"));
         }
 
         ScmContentProvider scmContentProvider = ScmContentProvider.resolve(item);
@@ -135,7 +135,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
         if(scmContentProvider != null){
             return saveContent(request, item);
         }
-        throw new ServiceException.BadRequestExpception("No save scm content provider found for pipeline: " + item.getFullName());
+        throw new ServiceException.BadRequestException("No save scm content provider found for pipeline: " + item.getFullName());
     }
 
     @SuppressWarnings("unchecked")
@@ -172,7 +172,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
             if (credentials instanceof StandardUsernamePasswordCredentials) {
                 accessToken = ((StandardUsernamePasswordCredentials) credentials).getPassword().getPlainText();
             } else {
-                throw new ServiceException.BadRequestExpception("accessToken not found in pipeline: " + item.getFullName());
+                throw new ServiceException.BadRequestException("accessToken not found in pipeline: " + item.getFullName());
             }
         }
         return githubRequest.save(apiUrl, owner, repo, accessToken);
@@ -258,15 +258,15 @@ public class GithubScmContentProvider extends ScmContentProvider {
                 if (credentials instanceof StandardUsernamePasswordCredentials) {
                     accessToken = ((StandardUsernamePasswordCredentials) credentials).getPassword().getPlainText();
                 } else {
-                    throw new ServiceException.BadRequestExpception("accessToken not found in pipeline: " + item.getFullName());
+                    throw new ServiceException.BadRequestException("accessToken not found in pipeline: " + item.getFullName());
                 }
             }
             if(owner == null){
-                throw new ServiceException.BadRequestExpception(
+                throw new ServiceException.BadRequestException(
                         String.format("Pipeline %s is not configured with github source correctly, no github user/org found", item.getFullName()));
             }
             if(accessToken == null){
-                throw new ServiceException.BadRequestExpception(
+                throw new ServiceException.BadRequestException(
                         String.format("Pipeline %s is not configured with github source correctly, no credentials with github accessToken found", item.getFullName()));
             }
             this.owner = owner;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmSaveFileRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmSaveFileRequest.java
@@ -35,7 +35,7 @@ public class GithubScmSaveFileRequest{
         if(this.content == null){
             errors.add(new ErrorMessage.Error("content",
                     ErrorMessage.Error.ErrorCodes.MISSING.toString(), "content is required parameter"));
-            throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to save file to scm").addAll(errors));
+            throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to save file to scm").addAll(errors));
         }else {
             errors.addAll(content.validate());
         }
@@ -57,11 +57,11 @@ public class GithubScmSaveFileRequest{
                     ErrorMessage.Error.ErrorCodes.MISSING.toString(), "No scm repo found with pipeline %s, please provide content.repo parameter"));
         }
         if(errors.size() > 0) {
-            throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to save content").addAll(errors));
+            throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to save content").addAll(errors));
         }
 
         if(!errors.isEmpty()){
-            throw new ServiceException.BadRequestExpception(new ErrorMessage(400, "Failed to save file to scm").addAll(errors));
+            throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to save file to scm").addAll(errors));
         }
 
         try {
@@ -187,7 +187,7 @@ public class GithubScmSaveFileRequest{
                             .withAuthorization("token " + accessToken)
                             .to(GHContent.class);
                     if (!StringUtils.isBlank(sha) && !sha.equals(ghContent.getSha())) {
-                        throw new ServiceException.BadRequestExpception(String.format("sha in request: %s is different from sha of file %s in branch %s",
+                        throw new ServiceException.BadRequestException(String.format("sha in request: %s is different from sha of file %s in branch %s",
                                 sha, content.getPath(), content.getBranch()));
                     }
                     return ghContent.getSha();

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/HttpRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/HttpRequest.java
@@ -88,7 +88,7 @@ class HttpRequest {
                 throw new ServiceException.NotFoundException("Not Found: "+getErrorResponse(connection));
             }
             if(status > 399) {
-                throw new ServiceException.BadRequestExpception(String.format("%s %s returned error: %s. Error message: %s.", method, url ,status, getErrorResponse(connection)));
+                throw new ServiceException.BadRequestException(String.format("%s %s returned error: %s. Error message: %s.", method, url ,status, getErrorResponse(connection)));
             }
             if(!method.equals("HEAD")) {
                 r = new InputStreamReader(wrapStream(connection.getInputStream(), connection.getContentEncoding()), "UTF-8");

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtAuthenticationServiceImpl.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtAuthenticationServiceImpl.java
@@ -41,7 +41,7 @@ public class JwtAuthenticationServiceImpl extends JwtAuthenticationService {
         }
         if(expiryTimeInMins != null){
             if(expiryTimeInMins > maxExpiryTime) {
-                throw new ServiceException.BadRequestExpception(
+                throw new ServiceException.BadRequestException(
                     String.format("expiryTimeInMins %s can't be greated than %s", expiryTimeInMins, maxExpiryTime));
             }
             expiryTime = expiryTimeInMins * 60;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -82,11 +82,11 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     @Override
     public BlueFavorite favorite(@JsonBody BlueFavoriteAction favoriteAction) {
         if (favoriteAction == null) {
-            throw new ServiceException.BadRequestExpception("Must provide pipeline name");
+            throw new ServiceException.BadRequestException("Must provide pipeline name");
         }
         Job job = PrimaryBranch.resolve(mbp);
         if (job == null) {
-            throw new ServiceException.BadRequestExpception("no default branch to favorite");
+            throw new ServiceException.BadRequestException("no default branch to favorite");
         }
         FavoriteUtil.toggle(favoriteAction, job);
         return new FavoriteImpl(new BranchImpl(job, getLink().rel("branches")), getLink().rel("favorite"));

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineQueueContainer.java
@@ -43,7 +43,7 @@ public class MultiBranchPipelineQueueContainer extends BlueQueueContainer {
                 }
             }
         }catch (NumberFormatException e){
-            throw new ServiceException.BadRequestExpception("Invalid queue id: "+name+". Must be a number.",e);
+            throw new ServiceException.BadRequestException("Invalid queue id: "+name+". Must be a number.",e);
         }
         return null;
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -113,7 +113,7 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
     public BlueRun replay() {
         ReplayAction replayAction = run.getAction(ReplayAction.class);
         if(!isReplayable(replayAction)) {
-            throw new ServiceException.BadRequestExpception("This run does not support replay");
+            throw new ServiceException.BadRequestException("This run does not support replay");
         }
 
         Queue.Item item = replayAction.run2(replayAction.getOriginalScript(), replayAction.getOriginalLoadedScripts());

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -167,24 +167,24 @@ public class PipelineStepImpl extends BluePipelineStep {
         }
         String id = body.getString(ID_ELEMENT);
         if(id == null){
-            throw new ServiceException.BadRequestExpception("id is required");
+            throw new ServiceException.BadRequestException("id is required");
         }
 
         if(body.get(PARAMETERS_ELEMENT) == null && body.get(ABORT_ELEMENT) == null){
-            throw new ServiceException.BadRequestExpception("parameters is required");
+            throw new ServiceException.BadRequestException("parameters is required");
         }
 
         WorkflowRun run = node.getRun();
         InputAction inputAction = run.getAction(InputAction.class);
         if (inputAction == null) {
-            throw new ServiceException.BadRequestExpception("Error processing Input Submit request. This Run instance does not" +
+            throw new ServiceException.BadRequestException("Error processing Input Submit request. This Run instance does not" +
                     " have an InputAction.");
         }
 
         try {
             InputStepExecution execution = inputAction.getExecution(id);
             if (execution == null) {
-                throw new ServiceException.BadRequestExpception(
+                throw new ServiceException.BadRequestException(
                         String.format("Error processing Input Submit request. This Run instance does not" +
                         " have an Input with an id of '%s'.", id));
             }
@@ -211,11 +211,11 @@ public class PipelineStepImpl extends BluePipelineStep {
     //TODO: InputStepException.preSubmissionCheck() is private, remove it after its made public
     private void preSubmissionCheck(InputStepExecution execution){
         if (execution.isSettled()) {
-            throw new ServiceException.BadRequestExpception("This input has been already given");
+            throw new ServiceException.BadRequestException("This input has been already given");
         }
 
         if(!canSubmit(execution.getInput())){
-            throw new ServiceException.BadRequestExpception("You need to be "+ execution.getInput().getSubmitter() +" to submit this");
+            throw new ServiceException.BadRequestException("You need to be "+ execution.getInput().getSubmitter() +" to submit this");
         }
     }
 
@@ -228,7 +228,7 @@ public class PipelineStepImpl extends BluePipelineStep {
             String name = (String) p.get(NAME_ELEMENT);
 
             if(name == null){
-                throw new ServiceException.BadRequestExpception("name is required parameter element");
+                throw new ServiceException.BadRequestException("name is required parameter element");
             }
 
             ParameterDefinition d=null;
@@ -237,7 +237,7 @@ public class PipelineStepImpl extends BluePipelineStep {
                     d = def;
             }
             if (d == null)
-                throw new ServiceException.BadRequestExpception("No such parameter definition: " + name);
+                throw new ServiceException.BadRequestException("No such parameter definition: " + name);
 
             ParameterValue v = d.createValue(request, p);
             if (v == null) {

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/ScmResourceImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/ScmResourceImpl.java
@@ -43,7 +43,7 @@ public class ScmResourceImpl extends BluePipelineScm {
         if(scmContentProvider != null){
             return scmContentProvider.saveContent(staplerRequest, item);
         }
-        throw new ServiceException.BadRequestExpception("No scm content provider found for pipeline: " + item.getFullName());
+        throw new ServiceException.BadRequestException("No scm content provider found for pipeline: " + item.getFullName());
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/credential/CredentialSearch.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/credential/CredentialSearch.java
@@ -38,7 +38,7 @@ CredentialSearch extends OmniSearch<CredentialApi.Credential> {
             if (domain != null) {
                 CredentialApi.CredentialDomain d = api.getDomains().get(domain);
                 if (d == null) {
-                    throw new ServiceException.BadRequestExpception("Credential domain " + domain + " not found");
+                    throw new ServiceException.BadRequestException("Credential domain " + domain + " not found");
                 }
                 for (CredentialApi.Credential c : d.getCredentials()) {
                     credentials.add(c);
@@ -57,12 +57,12 @@ CredentialSearch extends OmniSearch<CredentialApi.Credential> {
     private BlueOrganization getOrganization(Query q){
         String org = q.param("organization");
         if(org == null){
-            throw new ServiceException.BadRequestExpception("Credentials search query parameter 'organization' is required");
+            throw new ServiceException.BadRequestException("Credentials search query parameter 'organization' is required");
         }
 
         BlueOrganization organization = OrganizationFactory.getInstance().get(org);
         if(organization == null){
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                     String.format("Organization %s not found. Query parameter 'organization' value: %s is invalid. ", org,org));
         }
         return organization;

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/credential/CredentialsUtils.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/credential/CredentialsUtils.java
@@ -181,7 +181,7 @@ public class CredentialsUtils {
                     domainName+" to store credentials by BlueOcean", domainSpecifications)
             );
             if (!result) {
-                throw new ServiceException.BadRequestExpception("Failed to create credential domain: " + domainName);
+                throw new ServiceException.BadRequestException("Failed to create credential domain: " + domainName);
             }
             domain = store.getDomainByName(domainName);
             if (domain == null) {

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
@@ -93,14 +93,14 @@ public abstract class AbstractMultiBranchCreateRequest extends AbstractPipelineC
         if(StringUtils.isNotBlank(scmConfig.getCredentialId())) {
             Domain domain = CredentialsUtils.findDomain(scmConfig.getCredentialId(), authenticatedUser);
             if(domain == null){
-                throw new ServiceException.BadRequestExpception(
+                throw new ServiceException.BadRequestException(
                     new ErrorMessage(400, "Failed to create pipeline")
                         .add(new Error(ERROR_FIELD_SCM_CREDENTIAL_ID,
                             Error.ErrorCodes.INVALID.toString(),
                             "No domain in user credentials found for credentialId: "+ scmConfig.getCredentialId())));
             }
             if (StringUtils.isEmpty(scmConfig.getUri())) {
-                throw new ServiceException.BadRequestExpception("uri not specified");
+                throw new ServiceException.BadRequestException("uri not specified");
             }
             if(domain.test(new BlueOceanDomainRequirement())) { //this is blueocean specific domain
                 project.addProperty(
@@ -151,7 +151,7 @@ public abstract class AbstractMultiBranchCreateRequest extends AbstractPipelineC
     private static ServiceException fail(List<Error> errors) {
         ErrorMessage errorMessage = new ErrorMessage(400, "Failed to create pipeline");
         errorMessage.addAll(errors);
-        return new ServiceException.BadRequestExpception(errorMessage);
+        return new ServiceException.BadRequestException(errorMessage);
     }
 
     private static ServiceException fail(Error... errors) {

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractPipelineCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractPipelineCreateRequest.java
@@ -30,7 +30,7 @@ public abstract class AbstractPipelineCreateRequest extends BluePipelineCreateRe
         setName(name);
         Collection<BlueOrganization> organizations = OrganizationFactory.getInstance().list();
         if(organizations.isEmpty()){
-            throw new ServiceException.BadRequestExpception(new ErrorMessage(400,
+            throw new ServiceException.BadRequestException(new ErrorMessage(400,
                     "Pipeline creation failed. Failed to find organization"));
         }else {
             setOrganization(organizations.iterator().next().getName());
@@ -48,7 +48,7 @@ public abstract class AbstractPipelineCreateRequest extends BluePipelineCreateRe
         }
         TopLevelItemDescriptor descriptor = Items.all().findByName(descriptorName);
         if(descriptor == null || !(descriptorClass.isAssignableFrom(descriptor.getClass()))){
-            throw new ServiceException.BadRequestExpception(String.format("Failed to create pipeline: %s, descriptor %s is not found", name, descriptorName));
+            throw new ServiceException.BadRequestException(String.format("Failed to create pipeline: %s, descriptor %s is not found", name, descriptorName));
         }
 
         ModifiableTopLevelItemGroup p = getParent();
@@ -67,7 +67,7 @@ public abstract class AbstractPipelineCreateRequest extends BluePipelineCreateRe
         String organization = getOrganization();
         ModifiableTopLevelItemGroup parent =  OrganizationFactory.getItemGroup(getOrganization());
         if(parent == null){
-            throw new ServiceException.BadRequestExpception("Invalid Jenkins organization. " + organization);
+            throw new ServiceException.BadRequestException("Invalid Jenkins organization. " + organization);
         }
 
         return parent;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -121,7 +121,7 @@ public class AbstractPipelineImpl extends BluePipeline {
     @Override
     public BlueFavorite favorite(@JsonBody BlueFavoriteAction favoriteAction) {
         if(favoriteAction == null) {
-            throw new ServiceException.BadRequestExpception("Must provide pipeline name");
+            throw new ServiceException.BadRequestException("Must provide pipeline name");
         }
         FavoriteUtil.toggle(favoriteAction, job);
         return FavoriteUtil.getFavorite(job, new Reachable() {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -220,7 +220,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
                     timeOutInSecs = DEFAULT_BLOCKING_STOP_TIMEOUT_IN_SECS;
                 }
                 if(timeOutInSecs < 0){
-                    throw new ServiceException.BadRequestExpception("timeOutInSecs must be >= 0");
+                    throw new ServiceException.BadRequestException("timeOutInSecs must be >= 0");
                 }
 
                 long timeOutInMillis = timeOutInSecs*1000;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueTestResultContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueTestResultContainerImpl.java
@@ -5,7 +5,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import hudson.model.Run;
-import io.jenkins.blueocean.commons.ServiceException.BadRequestExpception;
+import io.jenkins.blueocean.commons.ServiceException.BadRequestException;
 import io.jenkins.blueocean.commons.ServiceException.NotFoundException;
 import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
 import io.jenkins.blueocean.rest.factory.BlueTestResultFactory.Result;
@@ -70,7 +70,7 @@ public class BlueTestResultContainerImpl extends BlueTestResultContainer {
             } else if (!isEmpty(state)) {
                 results = filterByState(resolved.results, state);
             } else {
-                throw new BadRequestExpception("must provide either 'status' or 'state' params");
+                throw new BadRequestException("must provide either 'status' or 'state' params");
             }
         } else {
             results = resolved.results.iterator();
@@ -83,14 +83,14 @@ public class BlueTestResultContainerImpl extends BlueTestResultContainer {
         String[] statusAtoms = StringUtils.split(status, ',');
         Predicate<BlueTestResult> predicate = Predicates.alwaysFalse();
         if (statusAtoms == null || statusAtoms.length == 0) {
-            throw new BadRequestExpception("status not provided");
+            throw new BadRequestException("status not provided");
         }
         for (String statusString : statusAtoms) {
             Status queryStatus;
             try {
                 queryStatus = Status.valueOf(statusString.toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new BadRequestExpception("bad status " + status, e);
+                throw new BadRequestException("bad status " + status, e);
             }
             predicate = Predicates.or(predicate, new StatusPredicate(queryStatus));
         }
@@ -102,7 +102,7 @@ public class BlueTestResultContainerImpl extends BlueTestResultContainer {
         String[] stateAtoms = StringUtils.split(state, ',');
         Predicate<BlueTestResult> predicate = Predicates.alwaysFalse();
         if (stateAtoms == null || stateAtoms.length == 0) {
-            throw new BadRequestExpception("state not provided");
+            throw new BadRequestException("state not provided");
         }
 
         for (String stateString : stateAtoms) {
@@ -110,7 +110,7 @@ public class BlueTestResultContainerImpl extends BlueTestResultContainer {
             try {
                 queryState = State.valueOf(stateString.toUpperCase());
             } catch (IllegalArgumentException e) {
-                throw new BadRequestExpception("bad state " + state, e);
+                throw new BadRequestException("bad state " + state, e);
             }
             predicate = Predicates.or(predicate, new StatePredicate(queryState));
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineSearch.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineSearch.java
@@ -74,7 +74,7 @@ public class PipelineSearch extends OmniSearch<BluePipeline>{
                         logger.error(e.getMessage(), e1);
                     }
                     //ignored, give other OmniSearch implementations chance, they might handle it
-                    //throw new ServiceException.BadRequestExpception(String.format("%s parameter has invalid value: %s", EXCLUDED_FROM_FLATTENING_PARAM, s1), e);
+                    //throw new ServiceException.BadRequestException(String.format("%s parameter has invalid value: %s", EXCLUDED_FROM_FLATTENING_PARAM, s1), e);
                 }
                 if(c!=null){
                     excludeList.add(c);
@@ -140,7 +140,7 @@ public class PipelineSearch extends OmniSearch<BluePipeline>{
         if (org==null)  return Jenkins.getInstance();
         ItemGroup group = OrganizationFactory.getItemGroup(org);
         if (group==null) {
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                 String.format("Organization %s not found. Query parameter %s value: %s is invalid. ", org,ORGANIZATION_PARAM,org));
         }
         return group;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
@@ -158,7 +158,7 @@ public class RunContainerImpl extends BlueRunContainer {
         try {
             JSONObject body = JSONObject.fromObject(IOUtils.toString(request.getReader()));
             if (body.get("parameters") == null && pp.getParameterDefinitions().size() > 0) {
-                throw new ServiceException.BadRequestExpception("This is parameterized job, requires parameters");
+                throw new ServiceException.BadRequestException("This is parameterized job, requires parameters");
             }
             if (body.get("parameters") != null) {
                 JSONArray pds = JSONArray.fromObject(body.get("parameters"));
@@ -166,18 +166,18 @@ public class RunContainerImpl extends BlueRunContainer {
                     JSONObject p = (JSONObject) o;
                     String name = (String) p.get("name");
                     if (name == null) {
-                        throw new ServiceException.BadRequestExpception("parameters.name is required element");
+                        throw new ServiceException.BadRequestException("parameters.name is required element");
                     }
                     ParameterDefinition pd = pp.getParameterDefinition(name);
                     if (pd == null) {
-                        throw new ServiceException.BadRequestExpception("No such parameter definition: " + name);
+                        throw new ServiceException.BadRequestException("No such parameter definition: " + name);
                     }
                     ParameterValue parameterValue = pd.createValue(request, p);
                     if (parameterValue != null) {
                         values.add(parameterValue);
                         pdsInRequest.add(pd);
                     } else {
-                        throw new ServiceException.BadRequestExpception("Invalid value. Cannot retrieve the parameter value: " + name);
+                        throw new ServiceException.BadRequestException("Invalid value. Cannot retrieve the parameter value: " + name);
                     }
                 }
 
@@ -187,7 +187,7 @@ public class RunContainerImpl extends BlueRunContainer {
                         if(!pdsInRequest.contains(pd)){
                             ParameterValue v = pd.getDefaultParameterValue();
                             if(v == null || v.getValue() == null){
-                                throw new ServiceException.BadRequestExpception("Missing parameter: "+pd.getName());
+                                throw new ServiceException.BadRequestException("Missing parameter: "+pd.getName());
                             }
                             values.add(v);
                         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunSearch.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunSearch.java
@@ -54,7 +54,7 @@ public class RunSearch extends OmniSearch<BlueRun> {
             if (p instanceof Job) {
                 return Pageables.wrap(findRuns((Job)p));
             }else{
-                throw new ServiceException.BadRequestExpception(String.format("Pipeline %s not found", pipeline));
+                throw new ServiceException.BadRequestException(String.format("Pipeline %s not found", pipeline));
             }
         }else if(latestOnly){
             return Pageables.empty();

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Query.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Query.java
@@ -46,7 +46,7 @@ public class Query {
     public <T> T param(String key, Class<T> type, boolean required){
         String value = params.get(key);
         if(value == null && required){
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                 String.format("%s is required parameter to execute query for type %s", key, type));
         }else if (value == null && Boolean.class.isAssignableFrom(type)){
             return (T) Boolean.FALSE;
@@ -77,7 +77,7 @@ public class Query {
         //If there is no type, we don't know what resource to look for
         //TODO: what would be default type?
         if (type == null) {
-            throw new ServiceException.BadRequestExpception("type is required parameter for query param q");
+            throw new ServiceException.BadRequestException("type is required parameter for query param q");
         }
         return new Query(type, params);
     }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Utils.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
                     String.format("Unknown type %s", type));
             }
         }catch (NumberFormatException e){
-            throw new ServiceException.BadRequestExpception(
+            throw new ServiceException.BadRequestException(
                 String.format("Value %s can't be converted to type: %s", value, type));
         }
     }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipeline.java
@@ -1,13 +1,17 @@
 package io.jenkins.blueocean.rest.model;
 
+import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.annotation.Capability;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.json.JsonBody;
 import org.kohsuke.stapler.verb.PUT;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineContainer.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineContainer.java
@@ -37,7 +37,7 @@ public abstract class BluePipelineContainer extends Container<BluePipeline>{
         }
 
         if(!err.getErrors().isEmpty()){
-            throw new ServiceException.BadRequestExpception(err);
+            throw new ServiceException.BadRequestException(err);
         }
 
         BluePipelineCreateRequest request = staplerRequest.bindJSON(BluePipelineCreateRequest.class, body);


### PR DESCRIPTION
Better late than never? :-)

I've done the change in a way that normally anyone using `BadRequestExpception` already, even catching it shouldn't see a difference (since I made it a subclass).

I have built the whole `blueocean-plugin` locally, and if this also builds in CI I guess this would already show the change is actually backward compatible.

# Description

The `ServiceException.BadRequestExpception` class was renamed  `ServiceException.BadRequestException` (typo removed).

Not filing a JIRA for a non-user facing change, but if you generally do, just tell me and I'll happily follow the current process.

# Submitter checklist
- ~~[ ] Link to JIRA ticket in description, if appropriate.~~
- ~~[ ] Change is code complete and matches issue description~~
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- ~~[ ] Ran Acceptance Test Harness against PR changes.~~

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

