### PR TITLE
[FIX JENKINS-42602] Fix NPM dance, module sharing

### DIFF
--- a/blueocean-core-js/.mvn_exec_node
+++ b/blueocean-core-js/.mvn_exec_node
@@ -1,0 +1,1 @@
+Simple marker file to tell maven to execute node build profiles.

--- a/blueocean-core-js/gulpfile.js
+++ b/blueocean-core-js/gulpfile.js
@@ -1,5 +1,7 @@
 "use strict";
 
+process.env.SKIP_BLUE_IMPORTS = 'YES';
+
 /*
  Build file for Jenkins Blue Ocean Commons JavaScript.
  */
@@ -133,3 +135,25 @@ gulp.task("validate", () => {
         }
     }
 });
+
+
+var builder = require('@jenkins-cd/js-builder');
+
+builder.src([
+    'src/js',
+    'less']);
+
+//
+// Create the main bundle.
+//
+builder.bundle('src/js/index.js', 'blueocean-core-js.js')
+    .inDir('target/classes/io/jenkins/blueocean')
+    .less('src/less/core.less')
+    .import('react@any', {
+        aliases: ['react/lib/React'] // in case a module requires react through the back door
+    })
+    .import('react-dom@any')
+    .import("react-router@any")
+    .export("@jenkins-cd/js-extensions")
+    .export("@jenkins-cd/logging")
+    .export('mobx')

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.109-SNAPSHOT",
+  "version": "0.0.112-SNAPSHOT",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -13,10 +13,296 @@
       "resolved": "https://registry.npmjs.org/@jenkins-cd/eslint-config-jenkins/-/eslint-config-jenkins-0.0.2.tgz",
       "dev": true
     },
+    "@jenkins-cd/js-builder": {
+      "version": "0.0.60-SNAPSHOT-4",
+      "from": "@jenkins-cd/js-builder@0.0.60-SNAPSHOT-4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.60-SNAPSHOT-4.tgz",
+      "dev": true,
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "from": "asn1@0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "from": "assert-plus@>=0.1.5 <0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "from": "base64-js@0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "dev": true
+        },
+        "boom": {
+          "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@>=1.1.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "dev": true
+        },
+        "browserify": {
+          "version": "12.0.2",
+          "from": "browserify@>=12.0.1 <13.0.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-12.0.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.15 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dev": true
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "from": "buffer@>=3.4.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "combined-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "convert-source-map": {
+          "version": "0.4.1",
+          "from": "convert-source-map@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.4 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dev": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "from": "graceful-fs@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "gulp-eslint": {
+          "version": "2.1.0",
+          "from": "gulp-eslint@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-2.1.0.tgz",
+          "dev": true
+        },
+        "gulp-less": {
+          "version": "1.3.9",
+          "from": "gulp-less@>=1.3.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-1.3.9.tgz",
+          "dev": true,
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.34",
+              "from": "readable-stream@~1.0.17",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "dev": true
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dev": true
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "from": "hawk@1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "from": "hoek@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        },
+        "less": {
+          "version": "1.7.5",
+          "from": "less@>=1.7.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/less/-/less-1.7.5.tgz",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "from": "mime-types@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "dev": true
+        },
+        "qs": {
+          "version": "1.0.2",
+          "from": "qs@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "2.40.0",
+          "from": "request@>=2.40.0 <2.41.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@0.1.x",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dev": true
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "3.3.4",
+          "from": "underscore.string@3.3.4",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "dev": true
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dev": true
+        }
+      }
+    },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.35",
-      "from": "@jenkins-cd/js-extensions@0.0.35",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+      "version": "0.0.36-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.36-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -245,6 +531,12 @@
       "version": "2.2.1",
       "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "dev": true
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "from": "ansicolors@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "dev": true
     },
     "anymatch": {
@@ -1070,9 +1362,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "base62@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz"
     },
     "base64-arraybuffer": {
       "version": "0.1.2",
@@ -1203,6 +1495,12 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true
     },
+    "brfs": {
+      "version": "1.4.3",
+      "from": "brfs@>=1.4.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
+      "dev": true
+    },
     "browser-pack": {
       "version": "6.0.2",
       "from": "browser-pack@>=6.0.1 <7.0.0",
@@ -1228,6 +1526,74 @@
       "from": "browser-stdout@1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "dev": true
+    },
+    "browser-unpack": {
+      "version": "1.2.0",
+      "from": "browser-unpack@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-unpack/-/browser-unpack-1.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "from": "acorn@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "dev": true
+        },
+        "browser-pack": {
+          "version": "5.0.1",
+          "from": "browser-pack@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "dev": true
+        },
+        "combine-source-map": {
+          "version": "0.6.1",
+          "from": "combine-source-map@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.1.3",
+          "from": "convert-source-map@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "dev": true
+        },
+        "inline-source-map": {
+          "version": "0.5.0",
+          "from": "inline-source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        },
+        "lodash.memoize": {
+          "version": "3.0.4",
+          "from": "lodash.memoize@>=3.0.3 <3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@^1.1.1",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "dev": true
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dev": true
+        }
+      }
     },
     "browserify": {
       "version": "13.1.0",
@@ -1261,6 +1627,38 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
       "dev": true
     },
+    "browserify-transform-tools": {
+      "version": "1.7.0",
+      "from": "browserify-transform-tools@>=1.4.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "5.0.3",
+          "from": "acorn@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+          "dev": true
+        },
+        "falafel": {
+          "version": "2.1.0",
+          "from": "falafel@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "browserify-tree": {
+      "version": "0.0.6",
+      "from": "browserify-tree@0.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-tree/-/browserify-tree-0.0.6.tgz",
+      "dev": true
+    },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@>=0.1.2 <0.2.0",
@@ -1277,6 +1675,12 @@
       "version": "4.9.1",
       "from": "buffer@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "dev": true
+    },
+    "buffer-equal": {
+      "version": "0.0.1",
+      "from": "buffer-equal@0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -1370,6 +1774,12 @@
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000618.tgz",
       "dev": true
     },
+    "cardinal": {
+      "version": "1.0.0",
+      "from": "cardinal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "dev": true
+    },
     "case-sensitive-paths-webpack-plugin": {
       "version": "1.1.4",
       "from": "case-sensitive-paths-webpack-plugin@>=1.1.2 <2.0.0",
@@ -1453,10 +1863,72 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "dev": true
     },
+    "clean-css": {
+      "version": "2.2.23",
+      "from": "clean-css@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.2.0",
+          "from": "commander@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "from": "cli@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@^1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@^7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@^3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dev": true
+        }
+      }
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "from": "cli-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "cli-usage": {
+      "version": "0.1.4",
+      "from": "cli-usage@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
       "dev": true
     },
     "cli-width": {
@@ -1739,6 +2211,12 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
       "dev": true
     },
+    "css": {
+      "version": "1.0.8",
+      "from": "css@>=1.0.8 <1.1.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+      "dev": true
+    },
     "css-color-names": {
       "version": "0.0.4",
       "from": "css-color-names@0.0.4",
@@ -1749,6 +2227,12 @@
       "version": "0.25.0",
       "from": "css-loader@0.25.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
+      "dev": true
+    },
+    "css-parse": {
+      "version": "1.0.4",
+      "from": "css-parse@1.0.4",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
       "dev": true
     },
     "css-select": {
@@ -1770,6 +2254,12 @@
           "dev": true
         }
       }
+    },
+    "css-stringify": {
+      "version": "1.0.5",
+      "from": "css-stringify@1.0.5",
+      "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+      "dev": true
     },
     "css-what": {
       "version": "2.1.0",
@@ -1814,6 +2304,13 @@
       "from": "cssstyle@>=0.2.29 <0.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "dev": true
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "from": "ctype@0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "dev": true,
+      "optional": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -2039,6 +2536,26 @@
       "from": "duplexer2@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "dev": true
+    },
+    "duplexify": {
+      "version": "3.5.0",
+      "from": "duplexify@>=3.5.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0",
+          "from": "end-of-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+          "dev": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "dev": true
+        }
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2471,6 +2988,12 @@
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz",
       "dev": true
     },
+    "exit": {
+      "version": "0.1.2",
+      "from": "exit@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "dev": true
+    },
     "exit-hook": {
       "version": "1.1.1",
       "from": "exit-hook@>=1.0.0 <2.0.0",
@@ -2602,6 +3125,26 @@
       "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "dev": true
+    },
+    "falafel": {
+      "version": "1.2.0",
+      "from": "falafel@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        }
+      }
     },
     "fancy-log": {
       "version": "1.3.0",
@@ -2778,6 +3321,12 @@
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "dev": true
+    },
+    "fork-stream": {
+      "version": "0.0.4",
+      "from": "fork-stream@>=0.0.4 <0.0.5",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
       "dev": true
     },
     "form-data": {
@@ -3866,6 +4415,12 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "from": "growly@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "dev": true
+    },
     "gulp": {
       "version": "3.9.1",
       "from": "gulp@3.9.1",
@@ -4064,16 +4619,46 @@
         }
       }
     },
+    "gulp-if": {
+      "version": "2.0.2",
+      "from": "gulp-if@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "dev": true
+    },
+    "gulp-jasmine": {
+      "version": "2.4.2",
+      "from": "gulp-jasmine@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-jasmine/-/gulp-jasmine-2.4.2.tgz",
+      "dev": true
+    },
+    "gulp-jshint": {
+      "version": "2.0.4",
+      "from": "gulp-jshint@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.4.tgz",
+      "dev": true
+    },
     "gulp-less": {
       "version": "3.1.0",
       "from": "gulp-less@3.1.0",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.1.0.tgz",
       "dev": true
     },
+    "gulp-match": {
+      "version": "1.0.3",
+      "from": "gulp-match@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "dev": true
+    },
     "gulp-rename": {
       "version": "1.2.2",
       "from": "gulp-rename@1.2.2",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "dev": true
+    },
+    "gulp-runner": {
+      "version": "1.0.1",
+      "from": "gulp-runner@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-runner/-/gulp-runner-1.0.1.tgz",
       "dev": true
     },
     "gulp-sourcemaps": {
@@ -4121,6 +4706,50 @@
       "from": "gulplog@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "dev": true
+    },
+    "handlebars": {
+      "version": "3.0.3",
+      "from": "handlebars@>=3.0.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@^0.1.40",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "har-validator": {
       "version": "2.0.6",
@@ -4712,6 +5341,50 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "dev": true
     },
+    "jasmine": {
+      "version": "2.6.0",
+      "from": "jasmine@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@^1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@^7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@^3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dev": true
+        }
+      }
+    },
+    "jasmine-core": {
+      "version": "2.6.2",
+      "from": "jasmine-core@>=2.6.0 <2.7.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
+      "dev": true
+    },
+    "jasmine-reporters": {
+      "version": "2.2.1",
+      "from": "jasmine-reporters@>=2.0.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.2.1.tgz",
+      "dev": true
+    },
+    "jasmine-terminal-reporter": {
+      "version": "1.0.3",
+      "from": "jasmine-terminal-reporter@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-terminal-reporter/-/jasmine-terminal-reporter-1.0.3.tgz",
+      "dev": true
+    },
     "jju": {
       "version": "1.3.0",
       "from": "jju@>=1.1.0 <2.0.0",
@@ -4785,6 +5458,26 @@
       "from": "jsesc@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "dev": true
+    },
+    "jshint": {
+      "version": "2.9.4",
+      "from": "jshint@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "dev": true
+        }
+      }
     },
     "json-loader": {
       "version": "0.5.4",
@@ -5081,10 +5774,28 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
       "dev": true
     },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "dev": true
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "from": "lodash._baseassign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "dev": true
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "dev": true
     },
     "lodash._basecopy": {
@@ -5099,6 +5810,12 @@
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "dev": true
     },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "dev": true
+    },
     "lodash._basetostring": {
       "version": "3.0.1",
       "from": "lodash._basetostring@>=3.0.0 <4.0.0",
@@ -5109,6 +5826,12 @@
       "version": "3.0.0",
       "from": "lodash._basevalues@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "dev": true
     },
     "lodash._createcompounder": {
@@ -5215,10 +5938,22 @@
       "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
       "dev": true
     },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "from": "lodash.bind@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "3.0.1",
       "from": "lodash.camelcase@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "dev": true
     },
     "lodash.create": {
@@ -5256,6 +5991,12 @@
       "version": "3.2.0",
       "from": "lodash.escape@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "from": "lodash.foreach@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "dev": true
     },
     "lodash.indexof": {
@@ -5316,6 +6057,12 @@
       "version": "4.1.2",
       "from": "lodash.memoize@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "from": "lodash.merge@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "dev": true
     },
     "lodash.once": {
@@ -5472,6 +6219,18 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "dev": true
     },
+    "marked": {
+      "version": "0.3.6",
+      "from": "marked@>=0.3.6 <0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "dev": true
+    },
+    "marked-terminal": {
+      "version": "1.7.0",
+      "from": "marked-terminal@>=1.6.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
+      "dev": true
+    },
     "math-expression-evaluator": {
       "version": "1.2.15",
       "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
@@ -5510,6 +6269,12 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "dev": true
     },
+    "merge-stream": {
+      "version": "1.0.1",
+      "from": "merge-stream@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "from": "methods@>=1.1.2 <1.2.0",
@@ -5539,6 +6304,26 @@
       "from": "mime-types@>=2.1.7 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
       "dev": true
+    },
+    "minifyify": {
+      "version": "7.3.5",
+      "from": "minifyify@>=7.1.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.3.5.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "from": "lodash.defaults@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
+        }
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -5629,6 +6414,12 @@
       "from": "ms@0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
+    "multimatch": {
+      "version": "2.1.0",
+      "from": "multimatch@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "dev": true
+    },
     "multipipe": {
       "version": "0.1.2",
       "from": "multipipe@>=0.1.2 <0.2.0",
@@ -5680,10 +6471,22 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true
     },
+    "ncp": {
+      "version": "2.0.0",
+      "from": "ncp@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "from": "negotiator@0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "dev": true
+    },
+    "node-emoji": {
+      "version": "1.5.1",
+      "from": "node-emoji@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
       "dev": true
     },
     "node-fetch": {
@@ -5691,11 +6494,43 @@
       "from": "node-fetch@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
+    "node-http-server": {
+      "version": "3.0.5",
+      "from": "node-http-server@>=3.0.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/node-http-server/-/node-http-server-3.0.5.tgz",
+      "dev": true
+    },
     "node-libs-browser": {
       "version": "0.7.0",
       "from": "node-libs-browser@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
       "dev": true
+    },
+    "node-notifier": {
+      "version": "4.6.1",
+      "from": "node-notifier@>=4.5.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@^1.1.1",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.1.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "dev": true
+        }
+      }
     },
     "node-uuid": {
       "version": "1.4.7",
@@ -5772,6 +6607,12 @@
       "version": "0.0.3",
       "from": "object-component@0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "from": "object-inspect@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
       "dev": true
     },
     "object-is": {
@@ -6440,6 +7281,20 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "dev": true
     },
+    "quote-stream": {
+      "version": "1.0.2",
+      "from": "quote-stream@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        }
+      }
+    },
     "randomatic": {
       "version": "1.1.6",
       "from": "randomatic@>=1.1.3 <2.0.0",
@@ -6457,6 +7312,26 @@
       "from": "raw-body@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "dev": true
+    },
+    "rcfinder": {
+      "version": "0.1.9",
+      "from": "rcfinder@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.9.tgz",
+      "dev": true
+    },
+    "rcloader": {
+      "version": "0.2.2",
+      "from": "rcloader@>=0.2.2 <0.3.0",
+      "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.2.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash.isobject": {
+          "version": "3.0.2",
+          "from": "lodash.isobject@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+          "dev": true
+        }
+      }
     },
     "react": {
       "version": "15.3.2",
@@ -6523,6 +7398,44 @@
       "version": "1.0.0",
       "from": "react-stubber@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
+      "dev": true
+    },
+    "react-tools": {
+      "version": "0.13.3",
+      "from": "react-tools@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "base62": {
+          "version": "0.1.1",
+          "from": "base62@0.1.1",
+          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+          "dev": true
+        },
+        "jstransform": {
+          "version": "10.1.0",
+          "from": "jstransform@>=10.1.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+          "dev": true
+        }
+      }
+    },
+    "reactify": {
+      "version": "1.1.1",
+      "from": "reactify@1.1.1",
+      "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
       "dev": true
     },
     "read-only-stream": {
@@ -6595,6 +7508,20 @@
       "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "dev": true
+    },
+    "redeyed": {
+      "version": "1.0.1",
+      "from": "redeyed@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "3.0.0",
+          "from": "esprima@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "reduce-css-calc": {
       "version": "1.3.0",
@@ -6886,6 +7813,12 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
       "dev": true
     },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "from": "shallow-copy@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "dev": true
+    },
     "shallowequal": {
       "version": "0.2.2",
       "from": "shallowequal@>=0.2.0 <0.3.0",
@@ -6925,6 +7858,12 @@
           "dev": true
         }
       }
+    },
+    "shellwords": {
+      "version": "0.1.0",
+      "from": "shellwords@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+      "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
@@ -7180,6 +8119,161 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
       "dev": true
     },
+    "static-eval": {
+      "version": "0.2.4",
+      "from": "static-eval@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
+      "dev": true,
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "from": "escodegen@>=0.0.24 <0.1.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "dev": true
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "from": "estraverse@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "dev": true
+        }
+      }
+    },
+    "static-module": {
+      "version": "1.3.2",
+      "from": "static-module@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.0",
+          "from": "concat-stream@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.2.9",
+              "from": "readable-stream@>=2.2.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "dev": true
+            }
+          }
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "dev": true
+            }
+          }
+        },
+        "escodegen": {
+          "version": "1.3.3",
+          "from": "escodegen@>=1.3.2 <1.4.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+          "dev": true
+        },
+        "esprima": {
+          "version": "1.1.1",
+          "from": "esprima@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.5.1",
+          "from": "estraverse@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+          "dev": true
+        },
+        "esutils": {
+          "version": "1.0.0",
+          "from": "esutils@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "from": "object-keys@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "dev": true
+        },
+        "quote-stream": {
+          "version": "0.0.0",
+          "from": "quote-stream@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.27-1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "dev": true,
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "dev": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.33 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "from": "xtend@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "dev": true
+        }
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "from": "statuses@>=1.3.1 <2.0.0",
@@ -7216,6 +8310,12 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz",
       "dev": true
     },
+    "stream-shift": {
+      "version": "1.0.0",
+      "from": "stream-shift@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "dev": true
+    },
     "stream-splicer": {
       "version": "2.0.0",
       "from": "stream-splicer@>=2.0.0 <3.0.0",
@@ -7237,6 +8337,12 @@
       "version": "1.0.2",
       "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "dev": true
+    },
+    "string.prototype.codepointat": {
+      "version": "0.2.0",
+      "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "dev": true
     },
     "string.prototype.padend": {
@@ -7365,6 +8471,12 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "dev": true
     },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "from": "ternary-stream@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
@@ -7446,6 +8558,82 @@
       "from": "tr46@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "dev": true
+    },
+    "transform": {
+      "version": "1.1.2",
+      "from": "transform@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/transform/-/transform-1.1.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "ms": {
+          "version": "0.6.2",
+          "from": "ms@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "dev": true
+        },
+        "promise": {
+          "version": "3.2.0",
+          "from": "promise@>=3.2.0 <3.3.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-3.2.0.tgz",
+          "dev": true
+        },
+        "resolve": {
+          "version": "0.5.1",
+          "from": "resolve@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.5.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "transform-filter": {
+      "version": "0.1.1",
+      "from": "transform-filter@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
+      "dev": true
+    },
+    "transformers": {
+      "version": "2.1.0",
+      "from": "transformers@>=2.1.0 <2.2.0",
+      "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "is-promise": {
+          "version": "1.0.1",
+          "from": "is-promise@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@~0.3.5",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "dev": true
+        },
+        "promise": {
+          "version": "2.0.0",
+          "from": "promise@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@~0.1.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.2.5",
+          "from": "uglify-js@>=2.2.5 <2.3.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@~0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "dev": true
+        }
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -7765,6 +8953,44 @@
         }
       }
     },
+    "vinyl-source-stream": {
+      "version": "1.1.0",
+      "from": "vinyl-source-stream@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dev": true
+        }
+      }
+    },
     "vinyl-sourcemaps-apply": {
       "version": "0.2.1",
       "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -7965,10 +9191,30 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.17",
+      "from": "xml2js@>=0.4.9 <0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "dev": true,
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "from": "xmlbuilder@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "dev": true
+        }
+      }
+    },
     "xmlbuilder": {
       "version": "8.2.2",
       "from": "xmlbuilder@8.2.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "from": "xmldom@>=0.1.22 <0.2.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "dev": true
     },
     "xmlhttprequest-ssl": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -9,9 +9,11 @@
     "storybook:port": "npm run start-storybook -- -p ",
     "flow": "flow",
     "gulp": "gulp",
-    "bundle:watch": "gulp watch",
+    "bundle:watch": "gulp bundle:watch",
     "test": "gulp test",
-    "prepublish": "gulp"
+    "prepublish": "gulp",
+    "mvnbuild": "gulp bundle",
+    "mvntest": "echo 0"
   },
   "author": "Cliff Meyers <cmeyers@cloudbees.com> (https://www.cloudbees.com/)",
   "contributors": [
@@ -30,7 +32,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.128",
-    "@jenkins-cd/js-extensions": "0.0.35",
+    "@jenkins-cd/js-extensions": "0.0.36-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/react-material-icons": "1.0.0",
@@ -55,6 +57,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
+    "@jenkins-cd/js-builder": "0.0.60-SNAPSHOT-4",
     "@kadira/storybook": "2.20.1",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
@@ -89,6 +92,7 @@
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",
     "react-dom": "15.3.2",
+    "reactify": "1.1.1",
     "run-sequence": "1.2.2",
     "sinon": "1.17.6",
     "watchify": "3.7.0"

--- a/blueocean-core-js/pom.xml
+++ b/blueocean-core-js/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>blueocean-parent</artifactId>
+		<groupId>io.jenkins.blueocean</groupId>
+        <version>1.1.0-beta-5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>blueocean-core-js</artifactId>
+	<packaging>hpi</packaging>
+
+	<name>Blue Ocean Core JS</name>
+
+	<url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Core+JS</url>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>.</directory>
+				<includes>
+					<include>package.json</include>
+					<include>dist/**/*</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>io.jenkins.blueocean</groupId>
+				<artifactId>blueocean-maven-plugin</artifactId>
+				<version>0.0.1</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>process-node-dependencies</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>InjectedTest.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+
+			<!-- Disable InjectedTest -->
+			<plugin>
+				<groupId>org.jenkins-ci.tools</groupId>
+				<artifactId>maven-hpi-plugin</artifactId>
+				<configuration>
+					<disabledTestInjection>true</disabledTestInjection>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.jenkins.blueocean</groupId>
+			<artifactId>jenkins-design-language</artifactId>
+			<version>0.0.124-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/blueocean-core-js/src/js/index.js
+++ b/blueocean-core-js/src/js/index.js
@@ -93,6 +93,8 @@ sseService.registerHandler(defaultSSEhandler.handleEvents);
 
 import { enableMocksForI18n, disableMocksForI18n } from './i18n/i18n';
 
+export { execute as i18nBundleStartup } from './i18n/bundle-startup';
+
 export const DEBUG = {
     enableMocksForI18n,
     disableMocksForI18n,

--- a/blueocean-core-js/src/main/resources/index.jelly
+++ b/blueocean-core-js/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+  Blue Ocean Core JS Plugin. This plugin is a part of the Blue Ocean Plugin set.
+</div>

--- a/blueocean-core-js/src/main/resources/jenkins-js-extension.json
+++ b/blueocean-core-js/src/main/resources/jenkins-js-extension.json
@@ -1,0 +1,7 @@
+{
+    "hpiPluginId": "blueocean-core-js",
+    "i18nBundles": [
+        "jenkins.plugins.blueocean.web.Messages"
+    ],
+    "extensions": []
+}

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -5,7 +5,24 @@
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.113",
       "from": "@jenkins-cd/blueocean-core-js@0.0.113",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz"
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz",
+      "dependencies": {
+        "@jenkins-cd/js-extensions": {
+          "version": "0.0.35",
+          "from": "@jenkins-cd/js-extensions@0.0.35",
+          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+        },
+        "react-router": {
+          "version": "2.3.0",
+          "from": "react-router@2.3.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz"
+        },
+        "warning": {
+          "version": "2.1.0",
+          "from": "warning@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        }
+      }
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -19,15 +36,21 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.59",
-      "from": "@jenkins-cd/js-builder@0.0.59",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.59.tgz",
+      "version": "0.0.60-SNAPSHOT-4",
+      "from": "@jenkins-cd/js-builder@0.0.60-SNAPSHOT-4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.60-SNAPSHOT-4.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
+          "version": "7.1.2",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         },
         "underscore.string": {
@@ -39,9 +62,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.35",
-      "from": "@jenkins-cd/js-extensions@0.0.35",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+      "version": "0.0.36-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.36-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -1188,9 +1211,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "base62@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz"
     },
     "base64-js": {
       "version": "0.0.8",
@@ -1732,9 +1755,15 @@
       "dev": true,
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.1.1 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "version": "7.1.2",
+          "from": "glob@^7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@^3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         }
       }
@@ -1971,15 +2000,15 @@
       }
     },
     "create-hash": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "dev": true
     },
     "create-hmac": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "dev": true
     },
     "create-react-class": {
@@ -4222,6 +4251,12 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "dev": true
     },
+    "hash-base": {
+      "version": "2.0.2",
+      "from": "hash-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "dev": true
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
@@ -4247,7 +4282,14 @@
     "history": {
       "version": "2.1.2",
       "from": "history@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
+      "dependencies": {
+        "warning": {
+          "version": "2.1.0",
+          "from": "warning@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        }
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4748,17 +4790,23 @@
       "dev": true,
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.6 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "version": "7.1.2",
+          "from": "glob@^7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@^3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         }
       }
     },
     "jasmine-core": {
-      "version": "2.6.1",
+      "version": "2.6.2",
       "from": "jasmine-core@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
       "dev": true
     },
     "jasmine-reporters": {
@@ -5695,9 +5743,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.23",
+          "version": "2.8.27",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "dev": true
         }
       }
@@ -6294,9 +6342,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.9",
+      "version": "3.0.12",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "dev": true
     },
     "pbkdf2-compat": {
@@ -6830,9 +6878,9 @@
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz"
     },
     "react-router": {
-      "version": "2.3.0",
-      "from": "react-router@2.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz"
+      "version": "2.8.1",
+      "from": "react-router@2.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz"
     },
     "react-simple-di": {
       "version": "1.2.0",
@@ -6844,6 +6892,44 @@
       "version": "1.0.0",
       "from": "react-stubber@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
+      "dev": true
+    },
+    "react-tools": {
+      "version": "0.13.3",
+      "from": "react-tools@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "base62": {
+          "version": "0.1.1",
+          "from": "base62@0.1.1",
+          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+          "dev": true
+        },
+        "jstransform": {
+          "version": "10.1.0",
+          "from": "jstransform@>=10.1.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+          "dev": true
+        }
+      }
+    },
+    "reactify": {
+      "version": "1.1.1",
+      "from": "reactify@1.1.1",
+      "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
       "dev": true
     },
     "read-only-stream": {
@@ -7107,9 +7193,9 @@
       }
     },
     "ripemd160": {
-      "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+      "version": "2.0.1",
+      "from": "ripemd160@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "dev": true
     },
     "run-async": {
@@ -8226,9 +8312,9 @@
       "dev": true
     },
     "warning": {
-      "version": "2.1.0",
-      "from": "warning@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "warning@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
     },
     "watchpack": {
       "version": "0.2.9",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.59",
+    "@jenkins-cd/js-builder": "0.0.60-SNAPSHOT-4",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",
@@ -35,13 +35,14 @@
     "mocha": "3.1.0",
     "nock": "8.0.0",
     "react-addons-test-utils": "15.3.2",
+    "reactify": "1.1.1",
     "redux-mock-store": "1.2.1",
     "skin-deep": "0.16.0"
   },
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.113",
     "@jenkins-cd/design-language": "0.0.128",
-    "@jenkins-cd/js-extensions": "0.0.35",
+    "@jenkins-cd/js-extensions": "0.0.36-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.8",
     "@jenkins-cd/preferences": "0.0.4",
     "@jenkins-cd/react-material-icons": "1.0.0",
@@ -63,19 +64,21 @@
     "react-i18next": "1.10.1",
     "react-redux": "4.4.5",
     "react-remarkable": "1.1.1",
-    "react-router": "2.3.0",
+    "react-router": "2.8.1",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
     "reselect": "2.5.4"
   },
   "jenkinscd": {
-    "import": [
-      "immutable",
-      "keymirror",
-      "react-redux",
-      "react-router",
-      "redux-thunk",
+    "export": [
       "reselect"
+    ],
+    "import": [
+      "immutable@any",
+      "keymirror@any",
+      "react-redux@any",
+      "react-router@any",
+      "redux-thunk@any"
     ]
   }
 }

--- a/blueocean-dashboard/src/test/js/_init-tests-spec.js
+++ b/blueocean-dashboard/src/test/js/_init-tests-spec.js
@@ -15,6 +15,9 @@
  */
 
 import { store, classMetadataStore } from '@jenkins-cd/js-extensions';
+import { DEBUG } from '@jenkins-cd/blueocean-core-js';
+
+DEBUG.enableMocksForI18n();
 
 store.init({
     extensionData: [

--- a/blueocean-maven-plugin/pom.xml
+++ b/blueocean-maven-plugin/pom.xml
@@ -1,0 +1,136 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.jenkins.blueocean</groupId>
+	<artifactId>blueocean-maven-plugin</artifactId>
+	<version>0.0.1</version> <!-- need a non-snapshot version -->
+	<packaging>maven-plugin</packaging>
+
+	<name>Blue Ocean Maven Plugin</name>
+
+	<url>http://jenkins.io</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.2</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.tools</groupId>
+			<artifactId>maven-hpi-plugin</artifactId>
+			<version>1.122</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.0.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-vfs2</artifactId>
+			<version>2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.main</groupId>
+			<artifactId>jenkins-core</artifactId>
+			<version>2.7.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<goalPrefix>blueocean</goalPrefix>
+					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mojo-descriptor</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>help-goal</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>run-its</id>
+			<build>
+
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-invoker-plugin</artifactId>
+						<version>1.7</version>
+						<configuration>
+							<debug>true</debug>
+							<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+							<pomIncludes>
+								<pomInclude>*/pom.xml</pomInclude>
+							</pomIncludes>
+							<postBuildHookScript>verify</postBuildHookScript>
+							<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+							<settingsFile>src/it/settings.xml</settingsFile>
+							<goals>
+								<goal>clean</goal>
+								<goal>test-compile</goal>
+							</goals>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<goals>
+									<goal>install</goal>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/blueocean-maven-plugin/src/it/simple-it/pom.xml
+++ b/blueocean-maven-plugin/src/it/simple-it/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.jenkins.blueocean.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>touch</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>touch</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/blueocean-maven-plugin/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
+++ b/blueocean-maven-plugin/src/main/java/io/jenkins/blueocean/maven/plugin/ProcessUpstreamDependenciesMojo.java
@@ -1,0 +1,179 @@
+package io.jenkins.blueocean.maven.plugin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.jenkinsci.maven.plugins.hpi.AbstractJenkinsMojo;
+import org.jenkinsci.maven.plugins.hpi.MavenArtifact;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Goal which copies upstream blueocean javascript locally
+ */
+@Mojo(name = "process-node-dependencies", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+public class ProcessUpstreamDependenciesMojo extends AbstractJenkinsMojo {
+	/**
+	 * Location of the file.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", property = "baseDir", required = true)
+	private File baseDir;
+
+	/**
+	 * Location of the node_modules
+	 */
+	@Parameter(defaultValue = "${project.basedir}/node_modules", property = "nodeModulesDir", required = false)
+	private File nodeModulesDirectory;
+	
+    /**
+     * The maven project.
+     */
+    @Component
+    protected MavenProject project;
+    
+    @Component
+    protected DependencyGraphBuilder graphBuilder;
+    
+	public void execute() throws MojoExecutionException {
+		List<MavenArtifact> artifacts = new ArrayList<>();
+		try {
+			collectBlueoceanDependencies(graphBuilder.buildDependencyGraph(project, null), artifacts);
+			
+			File pluginsDir = nodeModulesDirectory; // new File(nodeModulesDirectory, "blueocean-plugins");
+			
+			if (!pluginsDir.exists()) {
+				pluginsDir.mkdirs();
+			}
+	
+			for (MavenArtifact artifact : artifacts) {
+				List<Contents> jarEntries = findJarEntries(new FileInputStream(artifact.getFile()), "package.json");
+				
+				System.out.println("Using artifact: " + artifact.getArtifactId());
+				
+				JSONObject packageJson = JSONObject.fromObject(new String(jarEntries.get(0).data));
+				
+				String name = packageJson.getString("name");
+				String[] subdirs = name.split("/");
+				
+				File outDir = nodeModulesDirectory;
+				for (int i = 0; i < subdirs.length; i++) {
+					outDir = new File(outDir, subdirs[i]);
+				}
+				
+				File artifactFile = artifact.getFile();
+				long artifactLastModified = artifactFile.lastModified();
+				
+				if (!outDir.exists()) {
+					outDir.mkdirs();
+				}
+
+				try (ZipInputStream jar = new ZipInputStream(new FileInputStream(artifact.getFile()))) {
+					ZipEntry entry;
+					while ((entry = jar.getNextEntry()) != null) {
+						if (entry.isDirectory()) {
+							continue;
+						}
+						File outFile = new File(outDir, entry.getName());
+						if (!outFile.exists() || outFile.lastModified() < artifactLastModified) {
+							System.out.println("Copying module: " + outFile.getAbsolutePath());
+							File parentFile = outFile.getParentFile();
+							if (!parentFile.exists()) {
+								parentFile.mkdirs();
+							}
+							try (FileOutputStream out = new FileOutputStream(outFile)) {
+								int read = 0;
+								byte[] buf = new byte[4096];
+								while((read = jar.read(buf)) >= 0) {
+									out.write(buf, 0, read);
+								}
+							}
+						}
+					}
+				}
+			}
+		} catch (DependencyGraphBuilderException | IOException e) {
+			throw new RuntimeException(e);
+		}
+		
+		System.out.println("Done installing blueocean dependencies for " + project.getArtifactId());
+	}
+	
+	private class Contents {
+		public Contents(String fileName, byte[] data) {
+			super();
+			this.fileName = fileName;
+			this.data = data;
+		}
+		String fileName;
+		byte[] data;
+	}
+	
+	private List<Contents> findJarEntries(InputStream jarFile, String pathGlob) throws IOException {
+		List<Contents> out = new ArrayList<>();
+		Pattern matcher = Pattern.compile(
+			("\\Q" + pathGlob.replace("**", "\\E\\Q").replace("*", "\\E[^/]*\\Q").replace("\\E\\Q", "\\E.*\\Q") + "\\E").replace("\\Q\\E", "")
+		);
+		try (ZipInputStream jar = new ZipInputStream(jarFile)) {
+			ZipEntry entry;
+			while ((entry = jar.getNextEntry()) != null) {
+				if (matcher.matcher(entry.getName()).matches()) {
+					ByteArrayOutputStream bo = new ByteArrayOutputStream((int)entry.getSize());
+					int read = 0;
+					byte[] buf = new byte[4096];
+					while((read = jar.read(buf)) >= 0) {
+						bo.write(buf, 0, read);
+					}
+					out.add(new Contents(entry.getName(), bo.toByteArray()));
+				}
+			}
+		}
+		return out;
+	}
+	
+	private void collectBlueoceanDependencies(DependencyNode node, List<MavenArtifact> results) throws FileNotFoundException, IOException {
+		MavenArtifact artifact = wrap(node.getArtifact());
+		try {
+			List<Contents> jarEntries = findJarEntries(new FileInputStream(artifact.getFile()), "package.json");
+			if (jarEntries.size() > 0) {
+				results.add(artifact);
+			}
+		} catch(Exception e) {
+			System.out.println("Unable to find artifact: " + artifact);
+
+			MavenArtifact hpi = artifact.getHpi();
+			try {
+				if (hpi != null) {
+					List<Contents> jarEntries = findJarEntries(new FileInputStream(hpi.getFile()), "WEB-INF/lib/"+artifact.getArtifactId()+".jar");
+					if (jarEntries.size() > 0) {
+						results.add(hpi);
+					}
+				}
+			} catch(Exception e2) {
+				System.out.println("Unable to find hpi artifact for: " + hpi);
+			}
+		}
+		
+		for (DependencyNode child : node.getChildren()) {
+			collectBlueoceanDependencies(child, results);
+		}
+	}
+}

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -5,7 +5,24 @@
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.113",
       "from": "@jenkins-cd/blueocean-core-js@0.0.113",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz"
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz",
+      "dependencies": {
+        "@jenkins-cd/js-extensions": {
+          "version": "0.0.35",
+          "from": "@jenkins-cd/js-extensions@0.0.35",
+          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+        },
+        "react-router": {
+          "version": "2.3.0",
+          "from": "react-router@2.3.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz"
+        },
+        "warning": {
+          "version": "2.1.0",
+          "from": "warning@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        }
+      }
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -19,15 +36,15 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.59",
-      "from": "@jenkins-cd/js-builder@0.0.59",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.59.tgz",
+      "version": "0.0.60-SNAPSHOT-4",
+      "from": "@jenkins-cd/js-builder@0.0.60-SNAPSHOT-4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.60-SNAPSHOT-4.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.35",
-      "from": "@jenkins-cd/js-extensions@0.0.35",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+      "version": "0.0.36-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.36-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -1162,9 +1179,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "base62@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz"
     },
     "Base64": {
       "version": "0.2.1",
@@ -1915,15 +1932,15 @@
       }
     },
     "create-hash": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "dev": true
     },
     "create-hmac": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "dev": true
     },
     "cryptiles": {
@@ -4116,6 +4133,12 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "dev": true
     },
+    "hash-base": {
+      "version": "2.0.2",
+      "from": "hash-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "dev": true
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
@@ -4135,6 +4158,23 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "history": {
+      "version": "2.1.2",
+      "from": "history@>=2.1.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
+      "dependencies": {
+        "query-string": {
+          "version": "3.0.3",
+          "from": "query-string@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz"
+        },
+        "warning": {
+          "version": "2.1.0",
+          "from": "warning@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
         }
       }
     },
@@ -4629,9 +4669,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "2.6.1",
+      "version": "2.6.2",
       "from": "jasmine-core@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
       "dev": true
     },
     "jasmine-reporters": {
@@ -5575,9 +5615,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.23",
+          "version": "2.8.27",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "dev": true
         }
       }
@@ -6169,9 +6209,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.9",
+      "version": "3.0.12",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "dev": true
     },
     "pbkdf2-compat": {
@@ -6692,26 +6732,9 @@
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz"
     },
     "react-router": {
-      "version": "2.3.0",
-      "from": "react-router@2.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz",
-      "dependencies": {
-        "history": {
-          "version": "2.1.2",
-          "from": "history@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz"
-        },
-        "query-string": {
-          "version": "3.0.3",
-          "from": "query-string@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz"
-        },
-        "warning": {
-          "version": "2.1.0",
-          "from": "warning@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
-        }
-      }
+      "version": "2.8.1",
+      "from": "react-router@2.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz"
     },
     "react-simple-di": {
       "version": "1.2.0",
@@ -6723,6 +6746,44 @@
       "version": "1.0.0",
       "from": "react-stubber@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/react-stubber/-/react-stubber-1.0.0.tgz",
+      "dev": true
+    },
+    "react-tools": {
+      "version": "0.13.3",
+      "from": "react-tools@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "base62": {
+          "version": "0.1.1",
+          "from": "base62@0.1.1",
+          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+          "dev": true
+        },
+        "jstransform": {
+          "version": "10.1.0",
+          "from": "jstransform@>=10.1.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+          "dev": true
+        }
+      }
+    },
+    "reactify": {
+      "version": "1.1.1",
+      "from": "reactify@1.1.1",
+      "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
       "dev": true
     },
     "read-only-stream": {
@@ -6992,9 +7053,9 @@
       "dev": true
     },
     "ripemd160": {
-      "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+      "version": "2.0.1",
+      "from": "ripemd160@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "dev": true
     },
     "run-async": {
@@ -7363,9 +7424,9 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "dev": true
         },
         "through2": {
@@ -7433,9 +7494,9 @@
           "dev": true
         },
         "string_decoder": {
-          "version": "1.0.0",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "version": "1.0.1",
+          "from": "string_decoder@~1.0.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "dev": true
         }
       }
@@ -8141,6 +8202,11 @@
       "from": "vm-browserify@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "dev": true
+    },
+    "warning": {
+      "version": "3.0.0",
+      "from": "warning@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
     },
     "watchpack": {
       "version": "0.2.9",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "@jenkins-cd/js-builder": "0.0.59",
+    "@jenkins-cd/js-builder": "0.0.60-SNAPSHOT-4",
     "@kadira/storybook": "2.20.1",
     "babel": "6.5.2",
     "babel-core": "6.17.0",
@@ -32,12 +32,13 @@
     "gulp-mocha": "3.0.1",
     "mocha": "3.1.0",
     "nock": "8.0.0",
-    "react-addons-test-utils": "15.3.2"
+    "react-addons-test-utils": "15.3.2",
+    "reactify": "1.1.1"
   },
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.113",
     "@jenkins-cd/design-language": "0.0.128",
-    "@jenkins-cd/js-extensions": "0.0.35",
+    "@jenkins-cd/js-extensions": "0.0.36-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.8",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",
@@ -48,19 +49,19 @@
     "react-dom": "15.3.2",
     "react-i18next": "1.10.1",
     "react-redux": "4.4.5",
-    "react-router": "2.3.0",
+    "react-router": "2.8.1",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
     "reselect": "2.5.4"
   },
   "jenkinscd": {
     "import": [
-      "immutable",
-      "keymirror",
-      "react-redux",
-      "react-router",
-      "redux-thunk",
-      "reselect"
+      "immutable@any",
+      "keymirror@any",
+      "react-redux@any",
+      "react-router@any",
+      "redux-thunk@any",
+      "reselect@any"
     ]
   }
 }

--- a/blueocean-web/gulpfile.js
+++ b/blueocean-web/gulpfile.js
@@ -48,15 +48,20 @@ builder.bundle('src/main/js/blueocean.js')
     .inDir('target/classes/io/jenkins/blueocean')
     .less('src/main/less/blueocean.less')
     .onStartup('./src/main/js/init')
-    .export("@jenkins-cd/blueocean-core-js")
-    .export('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup') // remove once JENKINS-39646 fixes back-door bundle module leakage
-    .export("@jenkins-cd/design-language")
-    .export("@jenkins-cd/js-extensions")
-    .export('react')
-    .export('react-dom')
     .export('redux')
-    .export('mobx')
     .export('mobx-react')
+    .export("immutable")
+	.export("keymirror")
+    .export("react-redux")
+    .export("redux-thunk")
+    .import('react@any', {
+        aliases: ['react/lib/React'] // in case a module requires react through the back door
+    })
+    .import('react-dom@any')
+    .import('mobx@any')
+    .import("@jenkins-cd/js-extensions@any")
+    .import("@jenkins-cd/blueocean-core-js@any")
+    .import('@jenkins-cd/design-language@any')
     .generateNoImportsBundle();
 
 //

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -5,7 +5,24 @@
     "@jenkins-cd/blueocean-core-js": {
       "version": "0.0.113",
       "from": "@jenkins-cd/blueocean-core-js@0.0.113",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz"
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.113.tgz",
+      "dependencies": {
+        "@jenkins-cd/js-extensions": {
+          "version": "0.0.35",
+          "from": "@jenkins-cd/js-extensions@0.0.35",
+          "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+        },
+        "react-router": {
+          "version": "2.3.0",
+          "from": "react-router@2.3.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz"
+        },
+        "warning": {
+          "version": "2.1.0",
+          "from": "warning@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        }
+      }
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -19,15 +36,15 @@
       "dev": true
     },
     "@jenkins-cd/js-builder": {
-      "version": "0.0.59",
-      "from": "@jenkins-cd/js-builder@0.0.59",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.59.tgz",
+      "version": "0.0.60-SNAPSHOT-4",
+      "from": "@jenkins-cd/js-builder@0.0.60-SNAPSHOT-4",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-builder/-/js-builder-0.0.60-SNAPSHOT-4.tgz",
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.35",
-      "from": "@jenkins-cd/js-extensions@0.0.35",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.35.tgz"
+      "version": "0.0.36-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.36-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.8",
@@ -869,9 +886,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "base62@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz"
     },
     "base64-js": {
       "version": "0.0.8",
@@ -1452,15 +1469,15 @@
       }
     },
     "create-hash": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "dev": true
     },
     "create-hmac": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "dev": true
     },
     "cryptiles": {
@@ -2520,6 +2537,12 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "dev": true
     },
+    "hash-base": {
+      "version": "2.0.2",
+      "from": "hash-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "dev": true
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
@@ -2936,9 +2959,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "2.6.1",
+      "version": "2.6.2",
       "from": "jasmine-core@>=2.6.0 <2.7.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
       "dev": true
     },
     "jasmine-reporters": {
@@ -3725,9 +3748,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.23",
+          "version": "2.8.27",
           "from": "uglify-js@>=2.6.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.23.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
           "dev": true
         }
       }
@@ -4131,9 +4154,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.9",
+      "version": "3.0.12",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "dev": true
     },
     "pem-jwk": {
@@ -4243,6 +4266,11 @@
       "dev": true,
       "optional": true
     },
+    "query-string": {
+      "version": "3.0.3",
+      "from": "query-string@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz"
+    },
     "querystring": {
       "version": "0.2.0",
       "from": "querystring@0.2.0",
@@ -4330,16 +4358,61 @@
       "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.1.tgz"
     },
     "react-router": {
-      "version": "2.3.0",
-      "from": "react-router@2.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.3.0.tgz",
+      "version": "2.8.1",
+      "from": "react-router@2.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz",
       "dependencies": {
-        "warning": {
-          "version": "2.1.0",
-          "from": "warning@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        "history": {
+          "version": "2.1.2",
+          "from": "history@>=2.1.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
+          "dependencies": {
+            "warning": {
+              "version": "2.1.0",
+              "from": "warning@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+            }
+          }
         }
       }
+    },
+    "react-tools": {
+      "version": "0.13.3",
+      "from": "react-tools@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "base62": {
+          "version": "0.1.1",
+          "from": "base62@0.1.1",
+          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+          "dev": true
+        },
+        "jstransform": {
+          "version": "10.1.0",
+          "from": "jstransform@>=10.1.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+          "dev": true
+        }
+      }
+    },
+    "reactify": {
+      "version": "1.1.1",
+      "from": "reactify@1.1.1",
+      "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
+      "dev": true
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -4557,9 +4630,9 @@
       "dev": true
     },
     "ripemd160": {
-      "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+      "version": "2.0.1",
+      "from": "ripemd160@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "dev": true
     },
     "run-async": {
@@ -4828,9 +4901,9 @@
           }
         },
         "string_decoder": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "dev": true
         },
         "through2": {
@@ -4886,9 +4959,9 @@
           "dev": true
         },
         "string_decoder": {
-          "version": "1.0.0",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+          "version": "1.0.1",
+          "from": "string_decoder@~1.0.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "dev": true
         }
       }
@@ -5468,6 +5541,11 @@
       "from": "vm-browserify@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "dev": true
+    },
+    "warning": {
+      "version": "3.0.0",
+      "from": "warning@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
     },
     "whatwg-fetch": {
       "version": "2.0.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -13,7 +13,7 @@
     "mvntest": "gulp test lint"
   },
   "devDependencies": {
-    "@jenkins-cd/js-builder": "0.0.59",
+    "@jenkins-cd/js-builder": "0.0.60-SNAPSHOT-4",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.16.0",
@@ -26,12 +26,13 @@
     "gulp": "3.9.1",
     "jquery-detached": "2.1.4-v4",
     "ncp": "2.0.0",
+    "reactify": "1.1.1",
     "zombie": "4.2.1"
   },
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": "0.0.113",
     "@jenkins-cd/design-language": "0.0.128",
-    "@jenkins-cd/js-extensions": "0.0.35",
+    "@jenkins-cd/js-extensions": "0.0.36-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.8",
     "history": "2.0.2",
     "immutable": "3.8.1",
@@ -45,7 +46,7 @@
     "react-dom": "15.3.2",
     "react-i18next": "1.10.1",
     "react-redux": "4.4.5",
-    "react-router": "2.3.0",
+    "react-router": "2.8.1",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0"
   }

--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -28,6 +28,16 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>variant</artifactId>
         </dependency>
+		<dependency>
+			<groupId>io.jenkins.blueocean</groupId>
+			<artifactId>jenkins-design-language</artifactId>
+			<version>0.0.124-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jenkins.blueocean</groupId>
+			<artifactId>blueocean-core-js</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
         <!-- test scope deps -->
         <dependency>
@@ -48,6 +58,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>io.jenkins.blueocean</groupId>
+				<artifactId>blueocean-maven-plugin</artifactId>
+				<version>0.0.1</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>process-node-dependencies</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
     <profiles>

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/resources/RunBundleWatches.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/resources/RunBundleWatches.java
@@ -1,0 +1,104 @@
+package io.jenkins.blueocean.resources;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.SystemUtils;
+
+import hudson.PluginWrapper;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import io.jenkins.blueocean.BlueOceanUI;
+import jenkins.model.Jenkins;
+
+public class RunBundleWatches {
+	@Initializer(after=InitMilestone.EXTENSIONS_AUGMENTED)
+	public static void startBundleWatches() {
+		if (!(new BlueOceanUI().isDevelopmentMode())) {
+			return;
+		}
+		
+		System.out.println("Running in development mode, watching bundles...");
+		
+		HashSet<Object> loadedExtensions = new HashSet<>();
+		List<PluginWrapper> plugins = Jenkins.getInstance().pluginManager.getPlugins();;
+		for (PluginWrapper p : plugins) {
+			try {
+				Enumeration<URL> urls = p.classLoader.getResources("/package.json");
+				while (urls.hasMoreElements()) {
+					URL u = urls.nextElement();
+					if (u != null && "file".equals(u.getProtocol())) {
+						File f = new File(u.toExternalForm().replace("file:", ""));
+						final File projectDir = f.getParentFile();
+						if(!loadedExtensions.contains(projectDir)) {
+							loadedExtensions.add(projectDir);
+							if (new File(projectDir, "pom.xml").exists()) {
+								Thread watcher = new Thread() {
+									public void run() {
+										try {
+											Map<String, String> env = new HashMap<>(System.getenv());
+											String[] command;
+									        if (SystemUtils.IS_OS_WINDOWS) {
+									        	command = new String[] { "cmd", "/C", "npm", "run", "bundle:watch" };
+									        } else {
+									        	command = new String[] { "bash", "-c", "${0} ${1+\"$@\"}", "npm", "run", "bundle:watch" };
+									        }
+									        
+									        ProcessBuilder pb = new ProcessBuilder(Arrays.asList(command))
+									        		.redirectErrorStream(true)
+									        		.directory(projectDir);
+									        
+									        if (SystemUtils.IS_OS_WINDOWS) {
+										        pb.environment().put("Path",
+										        		new File(projectDir, "node").getAbsolutePath() + ";" + env.get("Path"));
+									        } else {
+									        	pb.environment().put("PATH",
+									        			new File(projectDir, "node").getAbsolutePath() + ":" + env.get("PATH"));
+									        }
+									        
+									        Process process = pb.start();
+											InputStream in = process.getInputStream();
+											try (BufferedReader rdr = new BufferedReader(new InputStreamReader(in, "utf-8"))) {
+												String line;
+												while ((line = rdr.readLine()) != null) {
+													System.out.println(line);
+													if (line.contains("Starting 'log-env'")) {
+														System.out.println("---- Rebuilding: " + projectDir.getAbsolutePath());
+													}
+													if (line.contains("missing script: bundle:watch")) {
+														System.out.println("---- Unable to find script 'bundle:watch' in: " + projectDir.getAbsolutePath());
+													}
+													if (line.contains("Finished 'bundle:watch'")) {
+														System.out.println("---- Rebuilt bundle in: " + projectDir.getAbsolutePath());
+													}
+												}
+											}
+										} catch(RuntimeException e) { // Thanks findbugs
+											e.printStackTrace();
+										} catch(Exception e) {
+											e.printStackTrace();
+										}
+									}
+								};
+								watcher.setDaemon(true);
+								watcher.setName("Watching: " + projectDir);
+								watcher.start();
+							}
+						}
+					}
+				}
+			} catch(Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/blueocean-web/src/main/js/init.js
+++ b/blueocean-web/src/main/js/init.js
@@ -1,19 +1,4 @@
 
 export function execute(done, bundleConfig) {
-    // Get the extension list metadata from Jenkins.
-    // Might want to do some flux fancy-pants stuff for this.
-    const appRoot = document.getElementsByTagName("head")[0].getAttribute("data-appurl");
-    const Extensions = require('@jenkins-cd/js-extensions');
-
-    Extensions.init({
-        extensionData: window.$blueocean.jsExtensions,
-        classMetadataProvider: (type, cb) => {
-            const fetch = require('@jenkins-cd/blueocean-core-js/dist/js/fetch');
-            fetch.Fetch.fetchJSON(`${appRoot}/rest/classes/${type}/`).then(cb).catch(fetch.Fetch.consoleError);
-        }
-    });
-
-    // Bootstrap the i18n resources too...
-    const i18nBootstrap = require('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup');
-    i18nBootstrap.execute(done, bundleConfig);
+    done();
 }

--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -75,6 +75,8 @@
             The following Stapler adjunct adds the blueocean JavaScript bundle, as well
             as the blueocean CSS. See gulpfile.js.
             -->
+            <st:adjunct includes="io.jenkins.blueocean.jenkins-design-language"/>
+            <st:adjunct includes="io.jenkins.blueocean.blueocean-core-js"/>
             <st:adjunct includes="io.jenkins.blueocean.blueocean"/>
         </body>
 

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -22,6 +22,10 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>blueocean-core-js</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-web</artifactId>
         </dependency>
         <dependency>
@@ -152,6 +156,7 @@
                         //
                         // Link in other sub-modules. Add as needed.
                         //
+                        linkHPI('blueocean-core-js');
                         linkHPI('blueocean-web');
                         linkHPI('blueocean-dashboard');
                         linkHPI('blueocean-personalization');

--- a/js-extensions/@jenkins-cd/subs/extensions-bundle.js
+++ b/js-extensions/@jenkins-cd/subs/extensions-bundle.js
@@ -172,7 +172,7 @@ function transformToJSX() {
 function createBundle(jsxFile) {
     __builder.bundle(jsxFile)
         .namespace(maven.getArtifactId())
-        .onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
+        //.onStartup('@jenkins-cd/blueocean-core-js/dist/js/i18n/bundle-startup')
         .inDir('target/classes/org/jenkins/ui/jsmodules/' + maven.getArtifactId());
 }
 

--- a/js-extensions/@jenkins-cd/subs/require-transform.js
+++ b/js-extensions/@jenkins-cd/subs/require-transform.js
@@ -1,0 +1,49 @@
+var path = require('path');
+var transformTools = require('browserify-transform-tools');
+
+var directModuleReplacements = {
+	'@jenkins-cd/logging': 'jenkins-cd-logging:jenkins-cd-logging@any',
+	'@jenkins-cd/js-extensions': 'jenkins-cd-js-extensions:jenkins-cd-js-extensions@any',
+	'@jenkins-cd/blueocean-core-js': 'jenkins-cd-blueocean-core-js:jenkins-cd-blueocean-core-js@any',
+	'mobx': 'mobx:mobx@any',
+	'mobx-react': 'mobx-react:mobx-react@any',
+	'react': 'react:react@any',
+	'react-dom': 'react-dom:react-dom@any',
+	'react-router': 'react-router:react-router@any',
+	'react-addons-css-transition-group': 'react-addons-css-transition-group:react-addons-css-transition-group@any',
+};
+
+var makeTransform = function(file, exports) {
+  return transformTools.makeFunctionTransform('exclude-upstream-requires', {
+    jsFilesOnly: true,
+    global: true,
+    functionNames: ['require']
+  }, function(functionParams, opts, done) {
+	  var name = functionParams.args && functionParams.args.length && functionParams.args[0].value;
+	  if (exports.indexOf(name) !== -1) {
+		  return done();
+	  }
+	  var replacement = directModuleReplacements[name];
+      if (replacement) {
+    	  result = "require('@jenkins-cd/js-modules').requireModule('" + replacement + "')";
+    	  return done(null, result);
+      }
+      if (exports.indexOf('react') === -1 && name.indexOf('react/') !== -1) {
+    	  console.error(" stray react library: ", name, 'in', opts.file);
+      }
+	  return done();
+  });
+};
+
+module.exports = function(file, config) {
+  var wrappedTransform = makeTransform(file, config.exports);
+  return wrappedTransform(file, config);
+};
+
+module.exports.configure = function(config) {
+  return function(file) {
+    return module.exports(file, config);
+  };
+};
+
+module.exports.makeTransform = makeTransform;

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.35",
+  "version": "0.0.36-SNAPSHOT-2",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [
@@ -14,7 +14,8 @@
     "compile": "babel --presets es2015,react src -d dist",
     "test": "gulp test",
     "compile-test": "npm run compile && npm run test",
-    "lint": "gulp lint"
+    "lint": "gulp lint",
+    "prepublish": "npm run compile"
   },
   "author": "Tom Fennelly <tom.fennelly@gmail.com> (https://github.com/tfennelly)",
   "license": "MIT",
@@ -45,8 +46,8 @@
     "envify": "3.4.1",
     "js-yaml": "^3.6.0"
   },
-  "peerDependencies": {
-    "@jenkins-cd/logging": "0.0.6",
+  "_peerDependencies": {
+    "@jenkins-cd/logging": "^0.0.6",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   }

--- a/js-extensions/src/init/blueocean-core-js.js
+++ b/js-extensions/src/init/blueocean-core-js.js
@@ -1,0 +1,22 @@
+import * as modules from '@jenkins-cd/js-modules';
+
+/**
+ * Executes extension init and hack for blueocean-web i18n
+ */
+export function execute(done, config) {
+	// Get the extension list metadata from Jenkins.
+	// have a special handling for core-js, must load the web bundle...
+	const Extensions = require('@jenkins-cd/js-extensions');
+	const appRoot = document.getElementsByTagName('head')[0].getAttribute('data-appurl');
+	
+	Extensions.init({
+	    extensionData: window.$blueocean.jsExtensions,
+	    classMetadataProvider: (type, cb) => {
+	        const fetch = require('../../../../../src/js/fetch').Fetch;
+	        fetch.fetchJSON(`${appRoot}/rest/classes/${type}/`).then(cb).catch(fetch.consoleError);
+	    },
+	});
+	
+	// core-js has references to blueocean-web translations
+	require('../../../../../src/js/i18n/bundle-startup').execute(done, { hpiPluginId: 'blueocean-web' });
+};

--- a/js-extensions/src/init/extension.js
+++ b/js-extensions/src/init/extension.js
@@ -1,0 +1,9 @@
+import * as modules from '@jenkins-cd/js-modules';
+
+/**
+ * Executes i18n for non-core-js modules
+ */
+export function execute(done, config) {
+	const CoreJs = modules.requireModule('jenkins-cd-blueocean-core-js:jenkins-cd-blueocean-core-js@any');
+	CoreJs.i18nBundleStartup(done, config);
+};

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
   </developers>
 
   <modules>
+    <module>blueocean-maven-plugin</module>
+    <module>blueocean-core-js</module>
     <module>blueocean-commons</module>
     <module>blueocean-i18n</module>
     <module>blueocean-web</module>
@@ -194,6 +196,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-i18n</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blueocean-core-js</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
# Description

Turns core-js into a plugin, publish extensions to plugins.

NOTE: Probably should not merge this until JDL is merged and appropriate change is also merged here; this won't build or run until there's a JDL plugin available.

See [JENKINS-42602](https://issues.jenkins-ci.org/browse/JENKINS-42602).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

