### PR TITLE
MBP pipeline run pagination fix

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -3,6 +3,7 @@ package io.jenkins.blueocean.rest.impl.pipeline;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.model.Item;
@@ -294,7 +295,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
                     }
                 });
 
-                return c.iterator();
+                return Iterators.limit(c.iterator(), limit);
             }
 
             private boolean retry(boolean[] retries) {

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -40,22 +40,15 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static io.jenkins.blueocean.rest.model.BlueRun.DATE_FORMAT_STRING;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_JOB;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -877,7 +870,59 @@ public class MultiBranchTest extends PipelineBaseTest {
         resp = get("/organizations/jenkins/pipelines/p/branches/"+Util.rawEncode(branches[1])+"/runs/2/");
         Assert.assertEquals("SUCCESS", resp.get("result"));
         Assert.assertEquals("FINISHED", resp.get("state"));
+    }
 
+    @Test
+    public void testMbpPagination() throws Exception {
+        WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false),
+                new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        for (SCMSource source : mp.getSCMSources()) {
+            assertEquals(mp, source.getOwner());
+        }
+        mp.scheduleBuild2(0).getFuture().get();
+        this.j.waitUntilNoActivity();
+
+        //create 6 runs
+        List<WorkflowRun> launchedItems = new ArrayList<>();
+        for(String branch:branches) {
+            WorkflowJob job = findBranchProject(mp, branch);
+            launchedItems.addAll(job.getBuilds());
+            for (int j = 0; j < 2; j++) {
+                launchedItems.add(job.scheduleBuild2(0).waitForStart());
+                this.j.waitUntilNoActivity();
+            }
+        }
+
+        //total 9. 3 triggered from indexing and 6 we launched
+        assertEquals(9, launchedItems.size());
+
+        //sort runs
+        Collections.sort(launchedItems, new Comparator<WorkflowRun>() {
+            @Override
+            public int compare(WorkflowRun o1, WorkflowRun o2) {
+                return new Date(o2.getStartTimeInMillis()).compareTo(new Date(o1.getStartTimeInMillis()));
+
+            }
+        });
+
+        //request 10 runs, but should not return 9 runs.
+        List<Map> resp = get("/organizations/jenkins/pipelines/p/runs?start=0&limit=10", List.class);
+
+        assertEquals(9, resp.size()); //max number of runs are 9
+
+        for(int i=0; i< 9; i++){
+            Assert.assertEquals(launchedItems.get(i).getId(), (resp.get(i).get("id")));
+        }
+
+        // now call 3 out of 9 runs and see pagination returns only 3 and in right sort order
+        resp = get("/organizations/jenkins/pipelines/p/runs?start=0&limit=3", List.class);
+
+        assertEquals(3, resp.size());
+
+        for(int i=0; i< 3; i++){
+            Assert.assertEquals(launchedItems.get(i).getId(), (resp.get(i).get("id")));
+        }
     }
 
     private void setupParameterizedScm() throws Exception {


### PR DESCRIPTION
Return latest 'limit' number of runs across all branches.

# Description

See https://issues.jenkins-ci.org/browse/JENKINS-44501

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

