### PR TITLE
JENKINS-43916# blueocean-pipeline-api-impl test coverage improvement

### DIFF
--- a/blueocean-commons/pom.xml
+++ b/blueocean-commons/pom.xml
@@ -25,6 +25,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <configuration>
+          <excludes>
+            <!-- Dont run code coverage for imported stapler classes -->
+            <exclude>io/jenkins/blueocean/commons/stapler/export/**/*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -14,6 +14,10 @@
     <name>Pipeline implementation for Blue Ocean</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
+    <properties>
+        <jacoco.haltOnFailure>true</jacoco.haltOnFailure>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -132,6 +136,20 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude scm abstract classes from code coverage, these are already covered in their implementations in
+                             blueocean-git-pipeline and blueocean-github-pipeline modules.
+                             These should move over to blueocean-rest module
+                        -->
+                        <exclude>io/jenkins/blueocean/rest/impl/pipeline/scm/**/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/scm/ScmContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/scm/ScmContainer.java
@@ -2,11 +2,11 @@ package io.jenkins.blueocean.rest.impl.pipeline.scm;
 
 import hudson.Extension;
 import io.jenkins.blueocean.rest.OrganizationRoute;
-import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.Container;
-import jenkins.model.Jenkins;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.Iterator;
@@ -25,7 +25,11 @@ public class ScmContainer extends Container<Scm> implements OrganizationRoute {
     private static final String URL_NAME="scm";
 
     public ScmContainer() {
-        BlueOrganization organization= OrganizationFactory.getInstance().getContainingOrg(Jenkins.getInstance());
+        Ancestor ancestor = Stapler.getCurrentRequest().findAncestor(BlueOrganization.class);
+        BlueOrganization organization = null;
+        if(ancestor != null){
+            organization = (BlueOrganization) ancestor.getObject();
+        }
         this.self = (organization != null) ? organization.getLink().rel("scm")
                 : new Link("/organizations/jenkins/scm/");
     }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolderTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolderTest.java
@@ -1,0 +1,172 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.google.common.collect.Lists;
+import hudson.ExtensionList;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.rest.model.BlueOrganizationFolder;
+import jenkins.branch.MultiBranchProject;
+import jenkins.branch.OrganizationFolder;
+import jenkins.scm.api.metadata.AvatarMetadataAction;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.WithoutJenkins;
+import org.kohsuke.stapler.StaplerRequest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Vivek Pandey
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PrepareForTest({OrganizationFactory.class, OrganizationFolder.class, StaplerRequest.class})
+public class OrganizationFolderTest{
+    @Rule
+    JenkinsRule j = new JenkinsRule();
+
+    private BlueOrganization organization;
+    private OrganizationFolder orgFolder;
+
+    @Before
+    public void setup(){
+        this.organization = mockOrganization();
+        this.orgFolder = mockOrgFolder(organization);
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testOrgFolderPipeline() throws IOException {
+        AvatarMetadataAction avatarMetadataAction = mock(AvatarMetadataAction.class);
+        when(orgFolder.getAction(AvatarMetadataAction.class)).thenReturn(avatarMetadataAction);
+
+        BlueOrganizationFolder organizationFolder = new OrganizationFolderPipelineImpl(orgFolder, organization.getLink().rel("/pipelines/")){};
+        assertEquals(organizationFolder.getName(), organizationFolder.getName());
+        assertEquals(organizationFolder.getDisplayName(), organizationFolder.getDisplayName());
+        assertEquals(organization.getName(), organizationFolder.getOrganization());
+        assertNotNull(organizationFolder.getIcon());
+        MultiBranchProject multiBranchProject = PowerMockito.mock(MultiBranchProject.class);
+        when(orgFolder.getItem("repo1")).thenReturn(multiBranchProject);
+        PowerMockito.when(OrganizationFactory.getInstance().getContainingOrg((ItemGroup)multiBranchProject)).thenReturn(organization);
+        PowerMockito.when(multiBranchProject.getFullName()).thenReturn("p1");
+        PowerMockito.when(multiBranchProject.getName()).thenReturn("p1");
+        MultiBranchPipelineContainerImpl multiBranchPipelineContainer =
+                new MultiBranchPipelineContainerImpl(orgFolder, organizationFolder);
+
+        assertEquals(multiBranchProject.getName(), multiBranchPipelineContainer.get("repo1").getName());
+        when(orgFolder.getItems()).thenReturn(Lists.<MultiBranchProject<?, ?>>newArrayList(multiBranchProject));
+        assertNotNull(organizationFolder.getPipelineFolderNames());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testOrgFolderRun(){
+        OrganizationFolderPipelineImpl organizationFolder = new OrganizationFolderPipelineImpl(orgFolder, new Link("/a/b/")){};
+
+        OrganizationFolderRunImpl organizationFolderRun =  new OrganizationFolderRunImpl(organizationFolder, new Reachable() {
+            @Override
+            public Link getLink() {
+                return new Link("/a/b/");
+            }
+        });
+
+        assertEquals(orgFolder.getName(), organizationFolderRun.getPipeline());
+        assertEquals(organization.getName(), organizationFolderRun.getOrganization());
+
+        assertNotNull(organizationFolder.getRuns());
+    }
+
+    @Test
+    public void testOrganizationFolderFactory() throws Exception{
+        List<OrganizationFolderPipelineImpl.OrganizationFolderFactory> organizationFolderFactoryList
+                = ExtensionList.lookup(OrganizationFolderPipelineImpl.OrganizationFolderFactory.class);
+        assertEquals(1, organizationFolderFactoryList.size());
+        assertTrue(organizationFolderFactoryList.get(0) instanceof OrganizationFolderFactoryTestImpl);
+        OrganizationFolderFactoryTestImpl organizationFolderFactoryTest =
+                (OrganizationFolderFactoryTestImpl) organizationFolderFactoryList.get(0);
+
+        OrganizationFolderPipelineImpl folderPipeline = organizationFolderFactoryTest.getFolder(orgFolder, new Reachable() {
+            @Override
+            public Link getLink() {
+                return organization.getLink().rel("/pipelines/");
+            }
+        });
+        assertNotNull(folderPipeline);
+
+        assertNotNull(folderPipeline.getQueue());
+        assertNotNull(folderPipeline.getQueue().iterator());
+
+        ScmResourceImpl scmResource = new ScmResourceImpl(orgFolder, folderPipeline);
+        StaplerRequest staplerRequest = PowerMockito.mock(StaplerRequest.class);
+        assertEquals("hello", scmResource.getContent(staplerRequest));
+    }
+
+    @TestExtension("testOrganizationFolderFactory")
+    public static class ScmContentProviderTest extends ScmContentProvider{
+
+        @Override
+        public Object getContent(@Nonnull StaplerRequest staplerRequest, @Nonnull Item item) {
+            return "hello";
+        }
+
+        @Override
+        public Object saveContent(@Nonnull StaplerRequest staplerRequest, @Nonnull Item item) {
+            return null;
+        }
+
+        @Override
+        public boolean support(@Nonnull Item item) {
+            return item instanceof OrganizationFolder;
+        }
+    }
+
+    static OrganizationFolder mockOrgFolder(BlueOrganization organization){
+        OrganizationFolder orgFolder = PowerMockito.mock(OrganizationFolder.class);
+
+        OrganizationFactory organizationFactory = mock(OrganizationFactory.class);
+        PowerMockito.mockStatic(OrganizationFactory.class);
+        PowerMockito.when(OrganizationFactory.getInstance()).thenReturn(organizationFactory);
+        when(organizationFactory.getContainingOrg((ItemGroup) orgFolder)).thenReturn(organization);
+        PowerMockito.when(orgFolder.getDisplayName()).thenReturn("vivek");
+        PowerMockito.when(orgFolder.getName()).thenReturn("vivek");
+        PowerMockito.when(orgFolder.getFullName()).thenReturn("vivek");
+
+        return orgFolder;
+    }
+
+    static BlueOrganization mockOrganization(){
+        BlueOrganization organization = mock(BlueOrganization.class);
+        when(organization.getName()).thenReturn("jenkins");
+        when(organization.getLink()).thenReturn(new Link("/blue/rest/organizations/jenkins/"));
+        return organization;
+    }
+
+    @TestExtension("testOrganizationFolderFactory")
+    public static class OrganizationFolderFactoryTestImpl extends OrganizationFolderPipelineImpl.OrganizationFolderFactory {
+        @Override
+        protected OrganizationFolderPipelineImpl getFolder(OrganizationFolder folder, Reachable parent) {
+            BlueOrganization organization = mockOrganization();
+            OrganizationFolder orgFolder = mockOrgFolder(organization);
+            return new OrganizationFolderPipelineImpl(orgFolder, organization.getLink().rel("/pipelines/")){};
+        }
+    }
+}

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineJobFiltersTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineJobFiltersTest.java
@@ -1,0 +1,46 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import jenkins.branch.OrganizationFolder;
+import jenkins.scm.api.SCMHead;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMHead;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static io.jenkins.blueocean.rest.impl.pipeline.OrganizationFolderTest.mockOrgFolder;
+import static io.jenkins.blueocean.rest.impl.pipeline.OrganizationFolderTest.mockOrganization;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * @author Vivek Pandey
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PrepareForTest({OrganizationFactory.class, OrganizationFolder.class, SCMHead.HeadByItem.class,PullRequestSCMHead.class})
+public class PipelineJobFiltersTest {
+
+    @Test
+    public void testFolderJobFilter(){
+        BlueOrganization organization = mockOrganization();
+        OrganizationFolder organizationFolder = mockOrgFolder(organization);
+        assertFalse(new PipelineJobFilters.FolderJobFilter().getFilter().apply(organizationFolder));
+    }
+
+    @Test
+    public void testIsPullRequest(){
+        BlueOrganization organization = mockOrganization();
+        OrganizationFolder organizationFolder = mockOrgFolder(organization);
+        PullRequestSCMHead changeRequestSCMHead = mock(PullRequestSCMHead.class);
+        mockStatic(SCMHead.HeadByItem.class);
+        when(SCMHead.HeadByItem.findHead(organizationFolder)).thenReturn(changeRequestSCMHead);
+        assertTrue(PipelineJobFilters.isPullRequest(organizationFolder));
+        assertFalse(new PipelineJobFilters.OriginFilter().getFilter().apply(organizationFolder));
+        assertTrue(new PipelineJobFilters.PullRequestFilter().getFilter().apply(organizationFolder));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -638,9 +638,6 @@
                               <goal>check</goal>
                           </goals>
                           <configuration>
-                              <excludes>
-                                  <exclude>io/jenkins/blueocean/commons/stapler/export/**/*</exclude>
-                              </excludes>
                               <rules>
                                   <rule>
                                       <element>BUNDLE</element>


### PR DESCRIPTION
# Description

See [JENKINS-43916](https://issues.jenkins-ci.org/browse/JENKINS-43916).

Test coverage improved to 100% class and 75% line. We need to move out `scm.*` classes over to rest module as they are strictly abstract models for SCM api. These are excluded from coverage in this module as their coverage is in `blueocean-github-pipeline`.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
