### PR TITLE
Use fixed jenjins-test-harness version to 2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <jacoco.line.coverage>0.70</jacoco.line.coverage>
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
+    <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This is probable fix for flakiness we observed that might be due to
other dpendencies bringin in later version of JTH that fails with some
tests failing in blueocean.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

