### PR TITLE
Fix flaky pipeline blocking test

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -1952,9 +1952,12 @@ public class PipelineNodeTest extends PipelineBaseTest {
         CpsFlowExecution e = (CpsFlowExecution) run.getExecutionPromise().get();
 
         if(waitForItemToAppearInQueue(1000*300)) { //5 min timeout
-            List<Map> stepsResp = get("/organizations/jenkins/pipelines/pipeline1/runs/1/nodes/11/steps/", List.class);
-            assertEquals(1, stepsResp.size());
-            assertEquals("QUEUED", stepsResp.get(0).get("state"));
+            List<FlowNode> nodes = getStages(NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(run));
+            if(nodes.size() == 2) {
+                List<Map> stepsResp = get("/organizations/jenkins/pipelines/pipeline1/runs/1/nodes/11/steps/", List.class);
+                assertEquals(1, stepsResp.size());
+                assertEquals("QUEUED", stepsResp.get(0).get("state"));
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Attempt to fix `causeofBlockage` related test flakiness. This test has been observed to fail fetching a node that doesn't exist and the stack trace is due to deserialization failure.

```
com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.util.ArrayList out of START_OBJECT token
 at [Source: {
  "message" : "Stage 11 not found in pipeline pipeline1.",
  "code" : 404,
  "errors" : [ ]
}; line: 1, column: 1]
	at io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest.get(PipelineBaseTest.java:142)
	at io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest.get(PipelineBaseTest.java:120)
	at io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest.get(PipelineBaseTest.java:111)
	at io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeTest.testBlockedStep(PipelineNodeTest.java:1955)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.jvnet.hudson.test.JenkinsRule$2.evaluate(JenkinsRule.java:533)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
```

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
