### PR TITLE
JENKINS-44631# Fix to show organization name on Dashboard

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -64,8 +64,8 @@ export class Pipelines extends Component {
                                 <Link to="/" query={ location.query }>
                                     { translate('home.header.dashboard', { defaultValue: 'Dashboard' }) }
                                 </Link>
-                                { organization && ' / ' }
-                                { organization && orgLink }
+                                { AppConfig.showOrg() && organization && ' / ' }
+                                { AppConfig.showOrg() && organization && orgLink }
                             </h1>
                         </Extensions.Renderer>
                     </div>


### PR DESCRIPTION
If blueocean dashboard is accessed in context of organization route it
always showed organizations ignoring organizations.emabled flag. This
fix encorces this flag to show organization name on dashboard.

# Description

See [JENKINS-44631](https://issues.jenkins-ci.org/browse/JENKINS-44631).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

