### PR TITLE
[JENKINS-44686] Wrong imported class

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/PageStatePreloader.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/PageStatePreloader.java
@@ -24,7 +24,7 @@
 package io.jenkins.blueocean.commons;
 
 import hudson.ExtensionList;
-import org.apache.tools.ant.ExtensionPoint;
+import hudson.ExtensionPoint;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public abstract class PageStatePreloader extends ExtensionPoint {
+public abstract class PageStatePreloader implements ExtensionPoint {
 
     /**
      * Get the JavaScript object graph path at shiwh the state is to be stored.


### PR DESCRIPTION
# Description

See [JENKINS-44686](https://issues.jenkins-ci.org/browse/JENKINS-44686).

To test it, just call `ExtensionList.lookup(io.jenkins.blueocean.commons.PageStatePreloader.class)` in the script console, before the fix the result is `[null, null, null, null]`, after the fix it is `[com.cloudbees.opscenter.server.bluesteel.BlueSteelCJOCJSContext@52ffb95c, io.jenkins.blueocean.config.BlueOceanConfigStatePreloader@22de629e, io.jenkins.blueocean.config.JenkinsJSExtensionsStatePreloader@6ea2a76c]`

There is nothing to test as there is nothing broken for a user AFAICT.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

