### PR TITLE
Bug/jenkins 43926 loading worm turns white too early

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.114",
+  "version": "0.0.114-SNAPSHOT-nicu",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/fetch.js
+++ b/blueocean-core-js/src/js/fetch.js
@@ -277,14 +277,14 @@ export const Fetch = {
      * @param {Object} [options.fetchOptions] - Optional isomorphic-fetch options.
      * @returns fetch body.
      */
-    fetch(url, { onSuccess, onError, fetchOptions } = {}) {
+    fetch(url, { onSuccess, onError, fetchOptions, disableLoadingIndicator } = {}) {
         let fixedUrl = url;
 
         if (urlconfig.getJenkinsRootURL() !== '' && !url.startsWith(urlconfig.getJenkinsRootURL())) {
             fixedUrl = `${urlconfig.getJenkinsRootURL()}${url}`;
         }
         if (!config.isJWTEnabled()) {
-            return FetchFunctions.rawFetch(fixedUrl, { onSuccess, onError, fetchOptions });
+            return FetchFunctions.rawFetch(fixedUrl, { onSuccess, onError, fetchOptions, disableLoadingIndicator });
         }
 
         return jwt.getToken()

--- a/blueocean-core-js/src/js/i18n/i18n.js
+++ b/blueocean-core-js/src/js/i18n/i18n.js
@@ -43,7 +43,8 @@ function newPluginXHR(pluginName, onLoad) {
                 logger.debug('loading data for', url);
             }
             let status;
-            return Fetch.fetch(url, {'disableLoadingIndicator': true})
+            // eslint-disable-next-line
+            return Fetch.fetch(url, { 'disableLoadingIndicator': true })
                 .then(response => {
                     // i18n xhr-backend needs the status
                     status = response.status;

--- a/blueocean-core-js/src/js/i18n/i18n.js
+++ b/blueocean-core-js/src/js/i18n/i18n.js
@@ -43,7 +43,7 @@ function newPluginXHR(pluginName, onLoad) {
                 logger.debug('loading data for', url);
             }
             let status;
-            return Fetch.fetch(url)
+            return Fetch.fetch(url, {'disableLoadingIndicator': true})
                 .then(response => {
                     // i18n xhr-backend needs the status
                     status = response.status;

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.114",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.114",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114.tgz"
+      "version": "0.0.114-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.114-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.114",
+    "@jenkins-cd/blueocean-core-js": "0.0.114-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.114",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.114",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114.tgz"
+      "version": "0.0.114-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.114-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -7010,9 +7010,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
+      "version": "5.1.0",
       "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
     },
     "sax": {
       "version": "1.2.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.114",
+    "@jenkins-cd/blueocean-core-js": "0.0.114-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.114",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.114",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114.tgz"
+      "version": "0.0.114-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.114-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.114-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",
@@ -4575,9 +4575,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
+      "version": "5.1.0",
       "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
     },
     "sax": {
       "version": "1.2.2",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.114",
+    "@jenkins-cd/blueocean-core-js": "0.0.114-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",


### PR DESCRIPTION
# Description
The loading animation was completed too early, i18n would trigger the hide method before the rest of the extensions got loaded

See [JENKINS-43926](https://issues.jenkins-ci.org/browse/JENKINS-43926).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

