### PR TITLE
[JENKINS-44725] Move UserStatePreloader to a more appropiate location

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/UserStatePreloader.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/UserStatePreloader.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package io.jenkins.blueocean.preload;
+package io.jenkins.blueocean.service.embedded;
 
 import hudson.Extension;
 import hudson.model.User;


### PR DESCRIPTION
# Description

See [JENKINS-44725](https://issues.jenkins-ci.org/browse/JENKINS-44725).

Current tests should be covering this change (it is not adding or modifying any feature). For manual test: just check that the logout button appears correctly when navigating from classic to BO and the user was already authenticated.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

