### PR TITLE
JENKINS-44736 - Fix for unstable status

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -137,7 +137,7 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         Assert.assertEquals(m.get("artifactsZipFile"), "/job/artifactTest/1/artifact/*zip*/archive.zip");
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20000)
     @Issue("JENKINS-44736")
     public void earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "project");

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -1,5 +1,7 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
 import hudson.model.Queue;
@@ -20,7 +22,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
+import java.net.URL;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -131,5 +135,33 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         Map m = request().get("/organizations/jenkins/pipelines/"+JOB_NAME+"/runs/"+r.getId()+"/").build(Map.class);
 
         Assert.assertEquals(m.get("artifactsZipFile"), "/job/artifactTest/1/artifact/*zip*/archive.zip");
+    }
+
+    @Test
+    @Issue("JENKINS-44736")
+    public void earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown() throws Exception {
+        WorkflowJob p = j.createProject(WorkflowJob.class, "project");
+
+        URL resource = Resources.getResource(getClass(), "earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown.jenkinsfile");
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+        p.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+        p.save();
+
+        Run r = p.scheduleBuild2(0).waitForStart();
+
+        String url = "/organizations/jenkins/pipelines/project/runs/" + r.getId() + "/";
+        Map m = request().get(url).build(Map.class);
+
+        // While the run has not finished keep checking that the result is unknown
+        while (!"FINISHED".equals(m.get("state").toString())) {
+            Assert.assertEquals("RUNNING", m.get("state"));
+            Assert.assertEquals("UNKNOWN", m.get("result"));
+            Thread.sleep(1000);
+            m = request().get(url).build(Map.class);
+        }
+
+        // Ensure that the run has finished and was marked as unstable when completed
+        Assert.assertEquals("FINISHED", m.get("state"));
+        Assert.assertEquals("UNSTABLE", m.get("result"));
     }
 }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -137,7 +137,7 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         Assert.assertEquals(m.get("artifactsZipFile"), "/job/artifactTest/1/artifact/*zip*/archive.zip");
     }
 
-    @Test
+    @Test(timeout = 10000)
     @Issue("JENKINS-44736")
     public void earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "project");

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/earlyUnstableStatusShouldReportPunStateAsRunningAndResultAsUnknown.jenkinsfile
@@ -1,0 +1,8 @@
+node {
+    stage ("stage 1 marked as unstable") {
+        currentBuild.result = 'UNSTABLE';
+    }
+    stage ("stage 2 wait") {
+        sleep 5
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -103,6 +103,7 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
 
     @Override
     public BlueRunResult getResult() {
+        // A runs result is always unknown until it has finished running
         if (getStateObj() == BlueRunState.RUNNING) {
             return BlueRunResult.UNKNOWN;
         } else {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -103,8 +103,12 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
 
     @Override
     public BlueRunResult getResult() {
-        Result result = run.getResult();
-        return result != null ? BlueRunResult.valueOf(result.toString()) : BlueRunResult.UNKNOWN;
+        if (getStateObj() == BlueRunState.RUNNING) {
+            return BlueRunResult.UNKNOWN;
+        } else {
+            Result result = run.getResult();
+            return result != null ? BlueRunResult.valueOf(result.toString()) : BlueRunResult.UNKNOWN;
+        }
     }
 
 


### PR DESCRIPTION
Pipeline that is set as unstable early in the execution is never shown as running

# Description
*Problem*
Pipeline that is set as unstable early in the execution is never shown as running

*What you should see*
The run should always be shown as running if it is still executing

*Screencast for bug*
![unstable](https://user-images.githubusercontent.com/50156/26864878-a5f88456-4b9d-11e7-8637-8772e921f147.gif)

See [JENKINS-44736](https://issues.jenkins-ci.org/browse/JENKINS-44736).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

