### PR TITLE
JENKINS-44742 fix issue where step with block failure log appended is…

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
@@ -1,5 +1,7 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import io.jenkins.blueocean.rest.model.BlueRun.BlueRunResult;
+import io.jenkins.blueocean.rest.model.BlueRun.BlueRunState;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -78,6 +80,9 @@ public class FlowNodeWrapper {
     }
 
     public @Nonnull NodeRunStatus getStatus(){
+        if (hasBlockError()) {
+            return new NodeRunStatus(BlueRunResult.FAILURE, BlueRunState.FINISHED);
+        }
         return status;
     }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
@@ -82,9 +82,12 @@ public class FlowNodeWrapper {
     }
 
     public @Nonnull NodeRunStatus getStatus() {
-        // Do not count block errors that are aborts
-        if (hasBlockError() && !isBlockErrorInterruptedWithAbort()) {
-            return new NodeRunStatus(BlueRunResult.FAILURE, BlueRunState.FINISHED);
+        if (hasBlockError()) {
+            if (isBlockErrorInterruptedWithAbort()) {
+                return new NodeRunStatus(BlueRunResult.ABORTED, BlueRunState.FINISHED);
+            } else {
+                return new NodeRunStatus(BlueRunResult.FAILURE, BlueRunState.FINISHED);
+            }
         }
         return status;
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
@@ -153,10 +153,6 @@ public class FlowNodeWrapper {
         return node.hashCode();
     }
 
-    ErrorAction getBlockErrorAction() {
-        return blockErrorAction;
-    }
-
     boolean hasBlockError(){
         return blockErrorAction != null
                 && blockErrorAction.getError() != null;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
@@ -1,6 +1,7 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
 import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.rest.model.BlueRun.BlueRunResult;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
@@ -209,8 +210,9 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
             }
             stepMap.put(node.getId(), node);
 
-            //If there is closest block boundary, we capture it's error to the last step encountered and prepare for next block.
-            if(closestEndNode!=null && closestEndNode.getError() != null) {
+            // If there is closest block boundary, we capture it's error to the last step encountered and prepare for next block.
+            // If the previous step is in error, don't mark this step with a failure
+            if(closestEndNode!=null && closestEndNode.getError() != null && new NodeRunStatus(before).result != BlueRunResult.FAILURE) {
                 node.setBlockErrorAction(closestEndNode.getError());
                 closestEndNode = null; //prepare for next block
             }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepVisitor.java
@@ -211,7 +211,7 @@ public class PipelineStepVisitor extends StandardChunkVisitor {
             stepMap.put(node.getId(), node);
 
             // If there is closest block boundary, we capture it's error to the last step encountered and prepare for next block.
-            // If the previous step is in error, don't mark this step with a failure
+            // but only if the previous node did not fail
             if(closestEndNode!=null && closestEndNode.getError() != null && new NodeRunStatus(before).result != BlueRunResult.FAILURE) {
                 node.setBlockErrorAction(closestEndNode.getError());
                 closestEndNode = null; //prepare for next block

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -170,8 +170,8 @@ public class PipelineNodeTest extends PipelineBaseTest {
 
     }
 
-    //JENKINS-39296
     @Test
+    @Issue("JENKINS-39296")
     public void stepStatusForFailedBuild() throws Exception{
         String p = "node {\n" +
                 "   echo 'Hello World'\n" +
@@ -179,7 +179,7 @@ public class PipelineNodeTest extends PipelineBaseTest {
                 "    echo 'Inside try'\n" +
                 "    sh 'this should fail'" +
                 "   }finally{\n" +
-                "    sh 'echo \"blah\"' \n" +
+                "    echo 'this should pass'\n" +
                 "   }\n" +
                 "}";
 
@@ -193,16 +193,29 @@ public class PipelineNodeTest extends PipelineBaseTest {
         List<Map> resp = get("/organizations/jenkins/pipelines/pipeline1/runs/1/steps/", List.class);
         Assert.assertEquals(resp.size(),4);
 
-        for(int i=0; i< resp.size();i++) {
-            Map rn = resp.get(i);
-            if(i==2){
-                Assert.assertEquals("FAILURE", rn.get("result"));
-            }else {
-                Assert.assertEquals("SUCCESS", rn.get("result"));
-            }
-            Assert.assertEquals("FINISHED", rn.get("state"));
-        }
+        Map helloWorldStep = resp.get(0);
 
+        Assert.assertEquals("Hello World", helloWorldStep.get("displayDescription"));
+        Assert.assertEquals("SUCCESS", helloWorldStep.get("result"));
+        Assert.assertEquals("FINISHED", helloWorldStep.get("state"));
+
+        Map insideTryStep = resp.get(1);
+
+        Assert.assertEquals("Inside try", insideTryStep.get("displayDescription"));
+        Assert.assertEquals("SUCCESS", insideTryStep.get("result"));
+        Assert.assertEquals("FINISHED", insideTryStep.get("state"));
+
+        Map thisShouldFailStep = resp.get(2);
+
+        Assert.assertEquals("this should fail", thisShouldFailStep.get("displayDescription"));
+        Assert.assertEquals("FAILURE", thisShouldFailStep.get("result"));
+        Assert.assertEquals("FINISHED", thisShouldFailStep.get("state"));
+
+        Map thisShouldPassStep = resp.get(3);
+
+        Assert.assertEquals("this should pass", thisShouldPassStep.get("displayDescription"));
+        Assert.assertEquals("SUCCESS", thisShouldPassStep.get("result"));
+        Assert.assertEquals("FINISHED", thisShouldPassStep.get("state"));
     }
 
     @Test

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/successfulStepWithBlockFailureAfterward.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/successfulStepWithBlockFailureAfterward.jenkinsfile
@@ -1,0 +1,7 @@
+stage ('first') {
+    echo 'Hello world'
+}
+stage ('second') {
+    echo 'Hello world'
+    garbage
+}


### PR DESCRIPTION
… always successful

# Description

Step with block failure log appended is always successful when it should be failed.

See [JENKINS-44742](https://issues.jenkins-ci.org/browse/JENKINS-44742) for test instructions.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [x] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

