### PR TITLE
encode search string when pushing it to the url string

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -31,7 +31,7 @@ export class Pipelines extends Component {
     }
 
     updateSearchText = debounce(value => {
-        this.context.router.push(`${this.props.location.pathname}${updateGetParam('search', value, this.props.location.query)}`);
+        this.context.router.push(`${this.props.location.pathname}${updateGetParam('search', encodeURIComponent(value), this.props.location.query)}`);
     }, 200);
 
     _initPager() {


### PR DESCRIPTION
fixes the search param not being url safe by encoding the value before pushing it to the url

See [JENKINS-44759](https://issues.jenkins-ci.org/browse/JENKINS-44759).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

