### PR TITLE
Bug/jenkins 43907 creation console error

### DIFF
--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.121-SNAPSHOT-2",
+  "version": "0.0.121",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.118-SNAPSHOT-nicu",
+  "version": "0.0.121-SNAPSHOT-2",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -9,6 +9,7 @@
     "storybook:port": "npm run start-storybook -- -p ",
     "flow": "flow",
     "gulp": "gulp",
+    "gulp:fast": "gulp clean-build",
     "bundle:watch": "gulp watch",
     "test": "gulp test",
     "prepublish": "gulp"

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.121-SNAPSHOT-2",
+  "version": "0.0.121",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.120",
+  "version": "0.0.121-SNAPSHOT-2",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -86,8 +86,15 @@ export class DefaultSSEHandler {
     }
 
     queueLeft(event) {
+        // ignore the event if there's no build number
+        // it's not related to a run, rather something like repo or branch indexing
+        if (!event.blueocean_queue_item_expected_build_number) {
+            return;
+        }
+
         const id = event.blueocean_queue_item_expected_build_number;
         const href = `${event.blueocean_job_rest_url}runs/${id}/`;
+
         if (event.job_run_status === 'CANCELLED') {
             // Cancelled runs are removed from the stores. They are gone *poof*.
             this._removeRun(event, href);

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.121-SNAPSHOT-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
+      "version": "0.0.121",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.120",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.120",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.120.tgz"
+      "version": "0.0.121-SNAPSHOT-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.121",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -39,7 +39,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.120",
+    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.120",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.120",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.120.tgz"
+      "version": "0.0.121-SNAPSHOT-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.121-SNAPSHOT-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
+      "version": "0.0.121",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.121",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.120",
+    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.121-SNAPSHOT-2",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
+      "version": "0.0.121",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.120",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.120",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.120.tgz"
+      "version": "0.0.121-SNAPSHOT-2",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.121-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.121-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.128",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.120",
+    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -29,7 +29,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.121-SNAPSHOT-2",
+    "@jenkins-cd/blueocean-core-js": "0.0.121",
     "@jenkins-cd/design-language": "0.0.128",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",


### PR DESCRIPTION
# Description
- See [JENKINS-43907](https://issues.jenkins-ci.org/browse/JENKINS-43907).
- I noticed this error at the end of Github creation too. The indexing events leave the queue as well, but they don't have an expected build number, so "queueLeft" method was trying to fetching runs with undefined ID's. This should short circuit that.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

