### PR TITLE
Topic/gh enterprise

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
@@ -30,11 +30,6 @@ public class GithubEnterpriseScm extends GithubScm {
     }
 
     @Override
-    public @Nonnull String getUri() {
-        return super.getUri()+DEFAULT_ENTERPRISE_API_SUFFIX;
-    }
-
-    @Override
     public String getCredentialDomainName() {
         java.net.URI uri;
         try {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -82,7 +82,7 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequest {
         List<String> repos = new ArrayList<>();
 
         if (scmConfig != null) {
-            apiUrl = StringUtils.defaultIfBlank(scmConfig.getUri(), GithubScm.DEFAULT_API_URI);
+            apiUrl = StringUtils.defaultIfBlank(scmConfig.getUri(), GitHubSCMSource.GITHUB_URL);
 
             GitHubConfiguration config = GitHubConfiguration.get();
             synchronized (config) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Cause;
@@ -206,17 +207,15 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequest {
     private void updateEndpoints(String apiUrl) {
         GitHubConfiguration config = GitHubConfiguration.get();
         synchronized (config) {
-            List<Endpoint> endpoints = config.getEndpoints();
             final String finalApiUrl = apiUrl;
-            Endpoint endpoint = Iterables.find(endpoints, new Predicate<Endpoint>() {
+            Endpoint endpoint = Iterables.find(config.getEndpoints(), new Predicate<Endpoint>() {
                 @Override
                 public boolean apply(@Nullable Endpoint input) {
                     return input != null && input.getApiUri().equals(finalApiUrl);
                 }
             }, null);
             if (endpoint == null) {
-                endpoints.add(new Endpoint(apiUrl, apiUrl));
-                config.setEndpoints(endpoints);
+                config.setEndpoints(ImmutableList.of(new Endpoint(apiUrl, apiUrl)));
                 config.save();
             }
         }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -7,6 +7,7 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
@@ -98,6 +99,7 @@ public class GithubScm extends Scm {
     @Override
     public @Nonnull String getUri() {
         StaplerRequest request = Stapler.getCurrentRequest();
+        Preconditions.checkNotNull(request, "Must be called in HTTP request context");
         String apiURI = request.getParameter("api_uri");
         return (apiURI != null) ? apiURI : DEFAULT_API_URI;
     }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -97,9 +97,9 @@ public class GithubScm extends Scm {
 
     @Override
     public @Nonnull String getUri() {
-        String url = System.getProperty(GITHUB_API_URL_PROPERTY);
-        String githubUrl = (url != null) ? url : DEFAULT_API_URI;
-        return githubUrl;
+        StaplerRequest request = Stapler.getCurrentRequest();
+        String apiURI = request.getParameter("api_uri");
+        return (apiURI != null) ? apiURI : DEFAULT_API_URI;
     }
 
     public String getCredentialDomainName(){

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -28,6 +28,7 @@ import io.jenkins.blueocean.rest.model.Container;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHUser;
@@ -65,7 +66,6 @@ public class GithubScm extends Scm {
     //Used by tests to mock github
     static final String GITHUB_API_URL_PROPERTY = "blueocean.github.url";
 
-    static final String DEFAULT_API_URI = "https://api.github.com";
     private static final String ID = "github";
 
     //desired scopes
@@ -100,8 +100,8 @@ public class GithubScm extends Scm {
     public @Nonnull String getUri() {
         StaplerRequest request = Stapler.getCurrentRequest();
         Preconditions.checkNotNull(request, "Must be called in HTTP request context");
-        String apiURI = request.getParameter("api_uri");
-        return (apiURI != null) ? apiURI : DEFAULT_API_URI;
+        String endpointUri = request.getParameter("endpoint_url");
+        return (endpointUri != null) ? endpointUri : GitHubSCMSource.GITHUB_URL;
     }
 
     public String getCredentialDomainName(){

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -64,8 +64,6 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
  */
 public class GithubScm extends Scm {
     //Used by tests to mock github
-    static final String GITHUB_API_URL_PROPERTY = "blueocean.github.url";
-
     private static final String ID = "github";
 
     //desired scopes

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -98,7 +98,7 @@ public class GithubScm extends Scm {
     public @Nonnull String getUri() {
         StaplerRequest request = Stapler.getCurrentRequest();
         Preconditions.checkNotNull(request, "Must be called in HTTP request context");
-        String endpointUri = request.getParameter("endpoint_url");
+        String endpointUri = request.getParameter("apiUrl");
         return (endpointUri != null) ? endpointUri : GitHubSCMSource.GITHUB_URL;
     }
 

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
@@ -140,7 +140,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
 
     @SuppressWarnings("unchecked")
     private Object saveContent(@Nonnull GithubScmSaveFileRequest githubRequest, @Nonnull Item item) {
-        String apiUrl = GithubScm.DEFAULT_API_URI;
+        String apiUrl = GitHubSCMSource.GITHUB_URL;
         String owner = null;
         String repo = null;
         String accessToken = null;
@@ -251,7 +251,7 @@ public class GithubScmContentProvider extends ScmContentProvider {
                     repo = repo(source);
                 }
             }
-            this.apiUrl = apiUrl == null ? GithubScm.DEFAULT_API_URI : apiUrl;
+            this.apiUrl = apiUrl == null ? GitHubSCMSource.GITHUB_URL : apiUrl;
 
             if (credentialId != null) {
                 StandardCredentials credentials = Connector.lookupScanCredentials((SCMSourceOwner) item, this.apiUrl, credentialId);

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
@@ -75,16 +75,15 @@ public abstract class GithubMockBase extends PipelineBaseTest {
         this.githubApiUrl = String.format("http://localhost:%s",githubApi.port());
     }
 
-    protected String CreateGithubCredential() throws UnirestException {
+    protected String createGithubCredential() throws UnirestException {
         Map r = new RequestBuilder(baseUrl)
                 .data(ImmutableMap.of("accessToken", accessToken))
                 .status(200)
                 .jwtToken(getJwtToken(j.jenkins, user.getId(), user.getId()))
-                .put("/organizations/jenkins/scm/github/validate/")
+                .put("/organizations/jenkins/scm/github/validate/?apiUrl="+githubApiUrl)
                 .build(Map.class);
         String credentialId = (String) r.get("credentialId");
         assertEquals("github", credentialId);
         return credentialId;
     }
-
 }

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static io.jenkins.blueocean.blueocean_github_pipeline.GithubScm.GITHUB_API_URL_PROPERTY;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -74,7 +73,6 @@ public abstract class GithubMockBase extends PipelineBaseTest {
 
         this.user = login("vivek", "Vivek Pandey", "vivek.pandey@gmail.com");
         this.githubApiUrl = String.format("http://localhost:%s",githubApi.port());
-        System.setProperty(GITHUB_API_URL_PROPERTY, githubApiUrl);
     }
 
     protected String CreateGithubCredential() throws UnirestException {

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderTest.java
@@ -38,7 +38,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
 
     @Test
     public void simpleOrgTest() throws IOException, UnirestException {
-        String credentialId = createGithubCredential(user);
+        String credentialId = createGithubCredential();
         String orgFolderName = "cloudbeers1";
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
@@ -69,7 +69,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
 
     @Test
     public void createGithubOrgTest() throws IOException, UnirestException {
-        String credentialId = createGithubCredential(user);
+        String credentialId = createGithubCredential();
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
@@ -97,7 +97,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
 
     @Test
     public void orgUpdateWithPOSTTest() throws IOException, UnirestException {
-        String credentialId = createGithubCredential(user);
+        String credentialId = createGithubCredential();
         String orgFolderName = "cloudbeers";
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
@@ -140,7 +140,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
 
     @Test
     public void orgUpdateTest() throws IOException, UnirestException {
-        String credentialId = createGithubCredential(user);
+        String credentialId = createGithubCredential();
         String orgFolderName = "cloudbeers";
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
@@ -241,17 +241,5 @@ public class GithubOrgFolderTest extends GithubMockBase {
         //it must resolve to system credential
         c = Connector.lookupScanCredentials(organizationFolder, null, credential.getId());
         assertEquals("System Github Access Token", c.getDescription());
-    }
-
-    private String createGithubCredential(User user) throws UnirestException {
-        Map r = new RequestBuilder(baseUrl)
-                .data(ImmutableMap.of("accessToken", "12345"))
-                .status(200)
-                .jwtToken(getJwtToken(j.jenkins, user.getId(), user.getId()))
-                .put("/organizations/jenkins/scm/github/validate/")
-                .build(Map.class);
-
-        assertEquals("github", r.get("credentialId"));
-        return "github";
     }
 }

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
@@ -40,7 +40,7 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test
     public void getContentForOrgFolder() throws UnirestException {
-        String credentialId = CreateGithubCredential();
+        String credentialId = createGithubCredential();
 
         StaplerRequest staplerRequest = mockStapler();
 
@@ -55,7 +55,7 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test
     public void getContentForMbp() throws UnirestException {
-        String credentialId = CreateGithubCredential();
+        String credentialId = createGithubCredential();
 
         StaplerRequest staplerRequest = mockStapler();
 
@@ -72,7 +72,7 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test
     public void saveContentToOrgFolder() throws UnirestException, IOException {
-        String credentialId = CreateGithubCredential();
+        String credentialId = createGithubCredential();
 
         StaplerRequest staplerRequest = mockStapler();
 
@@ -105,7 +105,7 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test
     public void saveContentToMbp() throws UnirestException, IOException {
-        String credentialId = CreateGithubCredential();
+        String credentialId = createGithubCredential();
 
         StaplerRequest staplerRequest = mockStapler();
 
@@ -140,7 +140,7 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test
     public void saveContentToMbpMissingBranch() throws UnirestException, IOException {
-        String credentialId = CreateGithubCredential();
+        String credentialId = createGithubCredential();
 
         StaplerRequest staplerRequest = mockStapler();
 

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
@@ -130,6 +130,10 @@ public class GithubScmTest {
 
         String guser = "{\n  \"login\": \"joe\",\n  \"id\": 1, \"email\": \"joe@example.com\", \"created_at\": \"2008-01-14T04:33:35Z\"}";
 
+        mockStatic(Stapler.class);
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(Stapler.getCurrentRequest()).thenReturn(request);
+
         when(httpURLConnectionMock.getInputStream()).thenReturn(new ByteArrayInputStream(guser.getBytes("UTF-8")));
 
         githubScm.validateAndCreate(req);

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
@@ -19,6 +19,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +37,12 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import static io.jenkins.blueocean.rest.impl.pipeline.scm.Scm.CREDENTIAL_ID;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.method;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 
 /**
@@ -87,7 +93,7 @@ public class GithubScmTest {
         when(httpURLConnectionMock.getHeaderField("X-OAuth-Scopes")).thenReturn("user:email,repo");
         when(httpURLConnectionMock.getResponseCode()).thenReturn(200);
 
-        HttpURLConnection httpURLConnection = GithubScm.connect(GithubScm.DEFAULT_API_URI, "abcd");
+        HttpURLConnection httpURLConnection = GithubScm.connect(GitHubSCMSource.GITHUB_URL, "abcd");
         GithubScm.validateAccessTokenScopes(httpURLConnection);
     }
 


### PR DESCRIPTION
# Description

@cliffmeyers the user will enter something like "http://github.mycorp.com/" for their Github server URL and you will need to append the API endpoint path.

So user enters `http://github.mycorp.com/` and then the API URL becomes `http://github.mycorp.com/api/v3`

Anything on `/organizations/jenkins/scm/` will require you to pass a param for the Github Enterprise server.
For example:
```
GET /organizations/jenkins/scm/repositories?apiUrl=http://github.mycorp.com/api/v3
```

When constructing the `GithubPipelineCreateRequest` to create the pipeline we need we will need to pass the `apiUrl` in as: 
```
{
  uri: "http://github.mycorp.com/api/v3"
}
```

When constructing the `GithubScmSaveFileRequest` to save the Jenkinsfile we will need to pass the `apiUrl` in as: 
```
{
   apiUrl: "http://github.mycorp.com/api/v3"
}
```

See [JENKINS-40855](https://issues.jenkins-ci.org/browse/JENKINS-40855).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

