### PR TITLE
fix official Docker image

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -6,6 +6,6 @@ USER root
 # Add the docker binary so running Docker commands from the master works nicely
 RUN apk -U add docker
 
-RUN install-plugins.sh antisamy-markup-formatter matrix-auth pipeline-model-definition blueocean:$BLUEOCEAN_VERSION
+RUN install-plugins.sh workflow-job:2.11 antisamy-markup-formatter matrix-auth blueocean:$BLUEOCEAN_VERSION
 
 USER jenkins

--- a/docker/official/build.sh
+++ b/docker/official/build.sh
@@ -3,6 +3,8 @@
 HERE=$(dirname $0)
 cd $HERE
 
+# Useful to rebuild an already existing image, in case it's broken
+FORCE_REBUILD=${FORCE_REBUILD:-$false}
 BLUEOCEAN_VERSION=$(git for-each-ref --sort=-taggerdate refs/tags/blueocean-parent-\*  | grep -v 'beta' | head -1 |awk '{print $3 }' | sed 's/refs\/tags\/blueocean-parent-//')
 
 # Check we have the latest LTS for blue ocean to build on and get its image ID
@@ -14,10 +16,12 @@ LTS_IMAGE_ID=$(docker images jenkinsci/jenkins:lts-alpine | sed -n 2p | awk '{ p
 # A new LTS means there may be security fixes
 FULL_VERSION="$BLUEOCEAN_VERSION-$LTS_IMAGE_ID"
 
-# Check if the image already exists
-if docker pull jenkinsci/blueocean:$FULL_VERSION; then
-  echo "Image jenkinsci/blueocean:$FULL_VERSION already exists in Docker Hub"
-  exit 0
+if [ ! $FORCE_REBUILD ]; then
+  # Check if the image already exists
+  if docker pull jenkinsci/blueocean:$FULL_VERSION; then
+    echo "Image jenkinsci/blueocean:$FULL_VERSION already exists in Docker Hub"
+    exit 0
+  fi
 fi
 
 # Build the image


### PR DESCRIPTION
install-plugins.sh script downloads a too recent version of workflow-job
let's force it to latest compatible version with 2.46 LTS to quickly fix
the Official image.

This is in order to fix the actual 1.1.0 image. 

@i386 @rtyler 