### PR TITLE
JENKINS-44867# PR tab regression fix

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -6,6 +6,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineContainer;
 import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import io.jenkins.blueocean.service.embedded.rest.ContainerFilter;
 
 import java.util.ArrayList;
@@ -137,11 +138,17 @@ public class BranchContainerImpl extends BluePipelineContainer {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Iterator<BluePipeline> iterator() {
+        return iterator(0, PagedResponse.DEFAULT_LIMIT);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterator<BluePipeline> iterator(int start, int limit) {
         List<BluePipeline> branches = new ArrayList<>();
         Collection<Job> jobs = pipeline.mbp.getAllJobs();
-        jobs = ContainerFilter.filter(jobs);
+
+        jobs = ContainerFilter.filter(jobs, start, limit);
         for(Job j: jobs){
             branches.add(new BranchImpl(j, getLink()));
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ContainerFilter.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ContainerFilter.java
@@ -1,17 +1,15 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-
 import com.google.common.base.Predicate;
-
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Item;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Simple extension point to allow filtering item types by a specific key
@@ -34,24 +32,63 @@ public abstract class ContainerFilter implements ExtensionPoint {
      * Filters the item list based on the current StaplerRequest
      */
     public static <T extends Item>  Collection<T> filter(Collection<T> items) {
-        StaplerRequest req = Stapler.getCurrentRequest();
-        if (req == null) {
+        String[] filterNames =  filterNames();
+        if(filterNames.length == 0){
             return items;
         }
-        String itemFilter = req.getParameter("filter");
-        if (itemFilter == null) {
-            return items;
-        }
-        return filter(items, itemFilter.split(","));
+        return filter(items, filterNames);
     }
 
     /**
      * Filters the item list based on the supplied filter name
      */
-    @SuppressWarnings("unchecked")
     public static <T extends Item> Collection<T> filter(Collection<T> items, String ... filterNames) {
-        if (filterNames != null && filterNames.length > 0) {
-            Predicate<Item>[] filters = new Predicate[filterNames.length];
+        Predicate<Item>[] filters = getFilters(filterNames);
+        Collection<T> out = new LinkedList<>();
+        nextItem: for (T item : items) {
+            for (Predicate<Item> filter : filters) {
+                if (!filter.apply(item)) {
+                    continue nextItem;
+                }
+            }
+            out.add(item);
+        }
+        return out;
+    }
+
+    /**
+     * Filter items based on supplied fiter and paging criteria
+     */
+    public static <T extends Item> Collection<T> filter(Collection<T> items, int start, int limit) {
+        String[] filterNames = filterNames();
+
+        int skipped=start;
+        Predicate<Item>[] filters = getFilters(filterNames);
+        Collection<T> out = new LinkedList<>();
+
+        nextItem: for (T item : items) {
+            //if collected items of size 'limit' we are done
+            if(out.size() == limit){
+                break;
+            }
+            for (Predicate<Item> filter : filters) {
+                if (!filter.apply(item)) {
+                    continue nextItem;
+                }
+            }
+            //if there is need to skip, skip these items
+            if(start > 0 && start > skipped++){
+                continue;
+            }
+            out.add(item);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Predicate<Item>[] getFilters(@Nonnull String...filterNames){
+        Predicate<Item>[] filters = new Predicate[filterNames.length];
+        if (filterNames.length > 0) {
             for (int i = 0; i < filterNames.length; i++) {
                 final Predicate<Item> f = getItemFilter(filterNames[i]);
                 if (f == null) {
@@ -59,19 +96,22 @@ public abstract class ContainerFilter implements ExtensionPoint {
                 }
                 filters[i] = f;
             }
-            Collection<T> out = new LinkedList<>();
-            nextItem: for (T item : items) {
-                for (int i = 0; i < filters.length; i++) {
-                    if (!filters[i].apply(item)) {
-                        continue nextItem;
-                    }
-                }
-                out.add(item);
-            }
-            return out;
         }
-        return items;
+        return filters;
     }
+
+    private static String[] filterNames(){
+        StaplerRequest req = Stapler.getCurrentRequest();
+        if (req == null) {
+            return new String[0];
+        }
+        String itemFilter = req.getParameter("filter");
+        if (itemFilter == null) {
+            return new String[0];
+        }
+        return itemFilter.split(",");
+    }
+
 
     /**
      * Finds a item filter by name

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ContainerFilter.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ContainerFilter.java
@@ -62,7 +62,7 @@ public abstract class ContainerFilter implements ExtensionPoint {
     public static <T extends Item> Collection<T> filter(Collection<T> items, int start, int limit) {
         String[] filterNames = filterNames();
 
-        int skipped=start;
+        int skipped=0;
         Predicate<Item>[] filters = getFilters(filterNames);
         Collection<T> out = new LinkedList<>();
 
@@ -77,7 +77,7 @@ public abstract class ContainerFilter implements ExtensionPoint {
                 }
             }
             //if there is need to skip, skip these items
-            if(start > 0 && start > skipped++){
+            if(skipped++ < start){
                 continue;
             }
             out.add(item);

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ContainerFilterTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ContainerFilterTest.java
@@ -1,0 +1,91 @@
+package io.jenkins.blueocean.service.embedded;
+
+import com.google.common.base.Predicate;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Project;
+import io.jenkins.blueocean.service.embedded.rest.ContainerFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * @author Vivek Pandey
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PrepareForTest(Stapler.class)
+public class ContainerFilterTest extends BaseTest{
+
+    @Test
+    public void testPagedFilter() throws IOException {
+        StaplerRequest request = mock(StaplerRequest.class);
+        when(request.getParameter("filter")).thenReturn("itemgroup-only");
+        mockStatic(Stapler.class);
+        when(Stapler.getCurrentRequest()).thenReturn(request);
+
+        List<Item> items = new ArrayList<>();
+        MockFolder folder = j.createFolder("folder");
+        for(int i=0; i<50; i++){
+            FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job"+i);
+            items.add(folder.createProject(MockFolder.class, "subFolder"+i));
+            items.add(job);
+        }
+        assertEquals(100, items.size());
+        //there are total 50 folders in items, we want 25 of them starting 25th ending at 49th.
+        Collection<Item> jobs = ContainerFilter.filter(items, 25, 25);
+        assertEquals(25, jobs.size());
+        int i = 25;
+        for(Item item: jobs){
+            assertTrue(item instanceof ItemGroup);
+            assertEquals("subFolder"+i++, item.getName());
+        }
+    }
+
+    @Test
+    public void customFilter() throws IOException {
+        MockFolder folder = j.createFolder("folder1");
+        Project p = folder.createProject(FreeStyleProject.class, "test1");
+        Collection<Item> items = ContainerFilter.filter(j.getInstance().getAllItems(), "itemgroup-only");
+        assertEquals(1, items.size());
+        assertEquals(folder.getFullName(), items.iterator().next().getFullName());
+    }
+
+    @TestExtension
+    public static class ItemGroupFilter extends ContainerFilter {
+
+        private final Predicate<Item> filter = new Predicate<Item>() {
+            @Override
+            public boolean apply(Item job) {
+                return (job instanceof ItemGroup);
+            }
+        };
+        @Override
+        public String getName() {
+            return "itemgroup-only";
+        }
+
+        @Override
+        public Predicate<Item> getFilter() {
+            return filter;
+        }
+    }
+
+
+}

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -1,6 +1,5 @@
 package io.jenkins.blueocean.service.embedded;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mashape.unirest.http.HttpResponse;
@@ -43,7 +42,6 @@ import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
 import io.jenkins.blueocean.service.embedded.rest.ArtifactContainerImpl;
-import io.jenkins.blueocean.service.embedded.rest.ContainerFilter;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
 import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import jenkins.model.Jenkins;
@@ -898,35 +896,4 @@ public class PipelineApiTest extends BaseTest {
             return null;
         }
     }
-
-    //custom filter test
-    @TestExtension("customFilter")
-    public static class ItemGroupFilter extends ContainerFilter{
-
-        private final Predicate<Item> filter = new Predicate<Item>() {
-            @Override
-            public boolean apply(Item job) {
-                return (job instanceof ItemGroup);
-            }
-        };
-        @Override
-        public String getName() {
-            return "itemgroup-only";
-        }
-
-        @Override
-        public Predicate<Item> getFilter() {
-            return filter;
-        }
-    }
-
-    @Test
-    public void customFilter() throws IOException {
-        MockFolder folder = j.createFolder("folder1");
-        Project p = folder.createProject(FreeStyleProject.class, "test1");
-        Collection<Item> items = ContainerFilter.filter(j.getInstance().getAllItems(), "itemgroup-only");
-        assertEquals(1, items.size());
-        assertEquals(folder.getFullName(), items.iterator().next().getFullName());
-    }
-
 }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
@@ -29,8 +29,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @InterceptorAnnotation(PagedResponse.Processor.class)
 public @interface PagedResponse {
+    public static final int DEFAULT_LIMIT=100;
     class Processor extends Interceptor {
-        private static final int DEFAULT_LIMIT=100;
         @Override
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
             throws IllegalAccessException, InvocationTargetException, ServletException {
@@ -45,7 +45,7 @@ public @interface PagedResponse {
                 @Override
                 public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
                     int start = (req.getParameter("start") != null) ? Integer.parseInt(req.getParameter("start")) : 0;
-                    int limit = (req.getParameter("limit") != null) ? Integer.parseInt(req.getParameter("limit")) : 100;
+                    int limit = (req.getParameter("limit") != null) ? Integer.parseInt(req.getParameter("limit")) : DEFAULT_LIMIT;
 
                     if(start < 0){
                         start = 0;


### PR DESCRIPTION
Added pagination to ContainerFilter to avoid checking for PR action only
till page size numbers are collected.

PR https://github.com/jenkinsci/blueocean-plugin/pull/1150 adds caching of Branch and Pull Request to further improve performance.

# Description

See [JENKINS-44867](https://issues.jenkins-ci.org/browse/JENKINS-44867).



# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
- [ ] Ran Acceptance Test Harness against PR changes.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
