### PR TITLE
add a parameter to rebuild the last official Docker image

### DIFF
--- a/docker/official/Jenkinsfile
+++ b/docker/official/Jenkinsfile
@@ -3,6 +3,7 @@
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     pipelineTriggers([cron('@daily')]),
+    parameters([string(defaultValue: 'false', description: 'Should rebuild the latest image if it exists on DockerHub?', name: 'FORCE_REBUILD')]),
 ])
 
 node('docker') {


### PR DESCRIPTION
In order to fix [JENKINS-44752](https://issues.jenkins-ci.org/browse/JENKINS-44752).

@i386 

@rtyler could you launch a build after it gets merged (with FORCE_REBUILD=true)? thanks