### PR TITLE
Use official image (with fixed install-script)

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,11 +1,11 @@
 # This image is based off the latest Jenkins LTS
-FROM jenkinsci/jenkins:lts-alpine
+FROM jenkins:alpine
 
 USER root
 
 # Add the docker binary so running Docker commands from the master works nicely
 RUN apk -U add docker
 
-RUN install-plugins.sh workflow-job:2.11 antisamy-markup-formatter matrix-auth blueocean:$BLUEOCEAN_VERSION
+RUN install-plugins.sh antisamy-markup-formatter matrix-auth blueocean:$BLUEOCEAN_VERSION
 
 USER jenkins


### PR DESCRIPTION
related to https://github.com/jenkinsci/blueocean-plugin/pull/1148
using official `jenkins` docker image we benefit a fixed install-script which uses LTS update center to download plugins, so avoid installing incompatible