### PR TITLE
Ensure latest comes from the run container

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -24,9 +24,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.concurrent.ExecutionException;
 
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_BRANCH;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW_JOB;
-import static io.jenkins.blueocean.rest.model.KnownCapabilities.PULL_REQUEST;
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.*;
 
 /**
  * @author Vivek Pandey

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.jenkins.blueocean.rest.impl.pipeline.PipelineJobFilters.isPullRequest;
+import static io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl.LATEST_RUN_START_TIME_COMPARATOR;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_MULTI_BRANCH_PROJECT;
 
 /**
@@ -288,12 +289,7 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
                     }
                 }
 
-                Collections.sort(c, new Comparator<BlueRun>() {
-                    @Override
-                    public int compare(BlueRun o1, BlueRun o2) {
-                        return o2.getStartTime().compareTo(o1.getStartTime());
-                    }
-                });
+                Collections.sort(c, LATEST_RUN_START_TIME_COMPARATOR);
 
                 return Iterators.limit(c.iterator(), limit);
             }
@@ -358,10 +354,9 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
         Collections.sort(branches, new Comparator<BluePipeline>() {
             @Override
             public int compare(BluePipeline o1, BluePipeline o2) {
-                Long t1 = o1.getLatestRun() != null ? o1.getLatestRun().getStartTime().getTime() : 0;
-                Long t2 = o2.getLatestRun() != null ? o2.getLatestRun().getStartTime().getTime() : 0;
-
-                return t2.compareTo(t1);
+                BlueRun o1LatestRun = o1.getLatestRun();
+                BlueRun o2LatestRun = o2.getLatestRun();
+                return LATEST_RUN_START_TIME_COMPARATOR.compare(o1LatestRun, o2LatestRun);
             }
         });
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -207,5 +208,14 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
             return null;
         }
     }
+
+    static final Comparator<BlueRun> LATEST_RUN_START_TIME_COMPARATOR = new Comparator<BlueRun>() {
+        @Override
+        public int compare(BlueRun o1, BlueRun o2) {
+            Long t1 = (o1 != null  && o1.getStartTime() != null) ? o1.getStartTime().getTime() : 0;
+            Long t2 = (o2 != null  && o2.getStartTime() != null) ? o2.getStartTime().getTime() : 0;
+            return t2.compareTo(t1);
+        }
+    };
 
 }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -174,6 +174,10 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         p.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
         p.save();
 
+        // Ensure null before first run
+        Map pipeline = request().get("/organizations/jenkins/pipelines/project/").build(Map.class);
+        Assert.assertNull(pipeline.get("latestRun"));
+
         // Run until completed
         Run r = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(r);
@@ -185,7 +189,7 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         p.scheduleBuild2(0);
 
         // Get latest run for this pipeline
-        Map pipeline = request().get("/organizations/jenkins/pipelines/project/").build(Map.class);
+        pipeline = request().get("/organizations/jenkins/pipelines/project/").build(Map.class);
         Map latestRun = (Map) pipeline.get("latestRun");
 
         Assert.assertEquals("RUNNING", latestRun.get("state"));

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -164,4 +164,44 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         Assert.assertEquals("FINISHED", m.get("state"));
         Assert.assertEquals("UNSTABLE", m.get("result"));
     }
+
+    @Test
+    public void pipelineLatestRunIncludesRunning() throws Exception {
+        WorkflowJob p = j.createProject(WorkflowJob.class, "project");
+
+        URL resource = Resources.getResource(getClass(), "latestRunIncludesQueued.jenkinsfile");
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+        p.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+        p.save();
+
+        // Run until completed
+        Run r = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(r);
+
+        // Make the next runs queue
+        j.jenkins.setNumExecutors(0);
+
+        // Schedule another run so it goes in the queue
+        p.scheduleBuild2(0);
+
+        // Get latest run for this pipeline
+        Map pipeline = request().get("/organizations/jenkins/pipelines/project/").build(Map.class);
+        Map latestRun = (Map) pipeline.get("latestRun");
+
+        Assert.assertEquals("RUNNING", latestRun.get("state"));
+        Assert.assertEquals("2", latestRun.get("id"));
+
+        String idOfSecondRun = (String) latestRun.get("id");
+
+        // Replay this
+        request().post("/organizations/jenkins/pipelines/project/runs/" + idOfSecondRun + "/replay/").build(String.class);
+
+        // Get latest run for this pipeline
+        pipeline = request().get("/organizations/jenkins/pipelines/project/").build(Map.class);
+        latestRun = (Map) pipeline.get("latestRun");
+
+        // It should be running
+        Assert.assertEquals("RUNNING", latestRun.get("state"));
+        Assert.assertEquals("3", latestRun.get("id"));
+    }
 }

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/latestRunIncludesQueued.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/latestRunIncludesQueued.jenkinsfile
@@ -1,0 +1,4 @@
+
+node {
+    echo 'very nice'
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -84,10 +84,7 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     @Override
     public BlueRun getLatestRun() {
-        if(job.getLastBuild() == null){
-            return null;
-        }
-        return AbstractRunImpl.getBlueRun(job.getLastBuild(), this);
+        return getRuns().iterator().next();
     }
 
     @Override
@@ -164,13 +161,13 @@ public class AbstractPipelineImpl extends BluePipeline {
                 encondedDisplayName.append(String.format("%s", Util.rawEncode(displayNames[i])));
             }
         }
-        
+
         return encondedDisplayName.toString();
     }
 
     /**
      * Returns full name relative to the <code>BlueOrganization</code> base. Each name is separated by '/'
-     * 
+     *
      * @param org the organization the item belongs to
      * @param item to return the full name of
      * @return
@@ -182,7 +179,7 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     /**
      * Tries to obtain the base group for a <code>BlueOrganization</code>
-     * 
+     *
      * @param org to get the base group of
      * @return the base group
      */
@@ -201,7 +198,7 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     /**
      * Calculates the recursive path for the <code>BluePipeline</code>. The path is relative to the org base
-     * 
+     *
      * @param pipeline to get the recursive path from
      * @return the recursive path
      */

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -84,7 +85,8 @@ public class AbstractPipelineImpl extends BluePipeline {
 
     @Override
     public BlueRun getLatestRun() {
-        return getRuns().iterator().next();
+        Iterator<BlueRun> iterator = getRuns().iterator();
+        return iterator.hasNext() ? iterator.next() : null;
     }
 
     @Override


### PR DESCRIPTION
# Description

Mic and I wrote this test to try to track down a bug (we thought latestRun might not have shown queued items). Thought it was worth keeping the test and ensuring that the latest run comes from the run container since the data her is synthesised (its a union of what we believe is in the queue and the runlist)

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

