### PR TITLE
ATH runtime dependencies bump

### DIFF
--- a/acceptance-tests/runner/runtime-plugins/runtime-deps/pom.xml
+++ b/acceptance-tests/runner/runtime-plugins/runtime-deps/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.13</version>
+            <version>2.1.14</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/acceptance-tests/runner/runtime-plugins/runtime-deps/pom.xml
+++ b/acceptance-tests/runner/runtime-plugins/runtime-deps/pom.xml
@@ -64,6 +64,8 @@
             <artifactId>fake-realm</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        
+        <!-- following are required to run on newer jenkins versions (after 2.7) as it changed how classloading works a bit for plugins -->        
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
@@ -73,6 +75,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <version>2.1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.7.3</version>
         </dependency>
     </dependencies>
     <profiles>


### PR DESCRIPTION
# Description
ATH needs to run on newer jenkins versions - will see if this works first with vanilla