### PR TITLE
Enumerate Github Servers

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
@@ -8,6 +8,7 @@ import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.credential.CredentialsUtils;
 import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainRequirement;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.Scm;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmFactory;
@@ -103,4 +104,8 @@ public class GithubEnterpriseScm extends GithubScm {
         }
     }
 
+    @Override
+    public Link getLink() {
+        return parent.getLink().rel("github-enterprise");
+    }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
@@ -6,10 +6,12 @@ import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.credential.CredentialsUtils;
+import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainRequirement;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.Scm;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmFactory;
+import io.jenkins.blueocean.rest.model.Container;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.GET;
@@ -68,6 +70,10 @@ public class GithubEnterpriseScm extends GithubScm {
         return this;
     }
 
+    @Navigable
+    public Container<GithubServer> getServers() {
+        return new GithubServerContainer(getLink());
+    }
 
     @Override
     protected @Nonnull String createCredentialId(@Nonnull String apiUri) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -75,21 +75,21 @@ public class GithubScm extends Scm {
     static final String DOMAIN_NAME="blueocean-github-domain";
     static final String CREDENTIAL_DESCRIPTION = "GitHub Access Token";
 
-    private final Link self;
-
     static final ObjectMapper om = new ObjectMapper();
     static {
         om.setVisibilityChecker(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY));
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
+    protected final Reachable parent;
+
     public GithubScm(Reachable parent) {
-        this.self = parent.getLink().rel("github");
+        this.parent = parent;
     }
 
     @Override
     public Link getLink() {
-        return self;
+        return parent.getLink().rel("github");
     }
 
     @Override

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScm.java
@@ -294,7 +294,7 @@ public class GithubScm extends Scm {
         }
     }
 
-    static HttpURLConnection connect(String apiUrl, String accessToken) throws IOException {
+    protected static HttpURLConnection connect(String apiUrl, String accessToken) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
 
         connection.setDoOutput(true);

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -1,0 +1,37 @@
+package io.jenkins.blueocean.blueocean_github_pipeline;
+
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.Resource;
+import org.jenkinsci.plugins.github_branch_source.Endpoint;
+import org.kohsuke.stapler.export.Exported;
+
+import static hudson.Util.rawEncode;
+
+public class GithubServer extends Resource {
+
+    public static final String NAME = "name";
+    public static final String API_URL = "apiUrl";
+
+    private final Endpoint endpoint;
+    private final Link parent;
+
+    GithubServer(Endpoint endpoint, Link parent) {
+        this.endpoint = endpoint;
+        this.parent = parent;
+    }
+
+    @Exported(name = NAME)
+    public String getName() {
+        return endpoint.getName();
+    }
+
+    @Exported(name = API_URL)
+    public String getApiUrl() {
+        return endpoint.getApiUri();
+    }
+
+    @Override
+    public Link getLink() {
+        return parent.rel(rawEncode(endpoint.getName()));
+    }
+}

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -3,7 +3,10 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Resource;
 import org.jenkinsci.plugins.github_branch_source.Endpoint;
+import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
+import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.verb.DELETE;
 
 import static hudson.Util.rawEncode;
 
@@ -33,5 +36,15 @@ public class GithubServer extends Resource {
     @Override
     public Link getLink() {
         return parent.rel(rawEncode(endpoint.getName()));
+    }
+
+    @DELETE
+    @WebMethod(name="delete")
+    public void delete() {
+        GitHubConfiguration config = GitHubConfiguration.get();
+        synchronized (config) {
+            config.getEndpoints().remove(endpoint);
+            config.save();
+        }
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -3,13 +3,12 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Resource;
 import org.jenkinsci.plugins.github_branch_source.Endpoint;
-import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
-import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.verb.DELETE;
+import org.kohsuke.stapler.export.ExportedBean;
 
 import static hudson.Util.rawEncode;
 
+@ExportedBean
 public class GithubServer extends Resource {
 
     public static final String NAME = "name";
@@ -36,15 +35,5 @@ public class GithubServer extends Resource {
     @Override
     public Link getLink() {
         return parent.rel(rawEncode(endpoint.getName()));
-    }
-
-    @DELETE
-    @WebMethod(name="delete")
-    public void delete() {
-        GitHubConfiguration config = GitHubConfiguration.get();
-        synchronized (config) {
-            config.getEndpoints().remove(endpoint);
-            config.save();
-        }
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -65,19 +65,21 @@ public class GithubServerContainer extends Container<GithubServer> {
             }
         }
 
-        // Validate that the URL represents a Github API endpoint
-        try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-            connection.setDoOutput(true);
-            connection.setRequestMethod("GET");
-            connection.setRequestProperty("Content-type", "application/json");
-            connection.connect();
-            if (connection.getHeaderField("X-GitHub-Request-Id") == null) {
-                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.INVALID.toString(), "Specified URL is not a Github server"));
+        if (StringUtils.isNotEmpty(url)) {
+            // Validate that the URL represents a Github API endpoint
+            try {
+                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+                connection.setDoOutput(true);
+                connection.setRequestMethod("GET");
+                connection.setRequestProperty("Content-type", "application/json");
+                connection.connect();
+                if (connection.getHeaderField("X-GitHub-Request-Id") == null) {
+                    errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.INVALID.toString(), "Specified URL is not a Github server"));
+                }
+            } catch (Throwable e) {
+                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.INVALID.toString(), "Could not connect to Github"));
+                LOGGER.log(Level.INFO, "Could not connect to Github", e);
             }
-        } catch (Throwable e) {
-            errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.INVALID.toString(), "Could not connect to Github"));
-            LOGGER.log(Level.INFO, "Could not connect to Github", e);
         }
 
         if (!errors.isEmpty()) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -1,0 +1,106 @@
+package io.jenkins.blueocean.blueocean_github_pipeline;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import io.jenkins.blueocean.commons.ErrorMessage;
+import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.Container;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.github_branch_source.Endpoint;
+import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.json.JsonBody;
+import org.kohsuke.stapler.verb.PUT;
+import org.parboiled.common.ImmutableList;
+import org.parboiled.common.StringUtils;
+
+import javax.annotation.CheckForNull;
+import java.util.Iterator;
+import java.util.List;
+
+public class GithubServerContainer extends Container<GithubServer> {
+
+    private final Link parent;
+
+    GithubServerContainer(Link parent) {
+        this.parent = parent;
+    }
+
+    @PUT
+    @WebMethod(name="create")
+    public @CheckForNull GithubServer create(@JsonBody JSONObject request) {
+
+        List<ErrorMessage.Error> errors = Lists.newLinkedList();
+
+        // Validate name
+        final String name = request.getString(GithubServer.NAME);
+        if (StringUtils.isEmpty(name)) {
+            errors.add(new ErrorMessage.Error(GithubServer.NAME, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.NAME + " is required"));
+        } else {
+            GithubServer byName = get(name);
+            if (byName != null) {
+                errors.add(new ErrorMessage.Error(GithubServer.NAME, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.NAME + " exists"));
+            }
+        }
+
+        // Validate url
+        final String url = request.getString(GithubServer.API_URL);
+        if (StringUtils.isEmpty(name)) {
+            errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.API_URL + " is required"));
+        } else {
+            GithubServer byName = get(name);
+            if (byName != null) {
+                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.API_URL + " is already registered as '" + byName.getName() + "'"));
+            }
+        }
+
+        if (errors.isEmpty()) {
+            ErrorMessage errorMessage = new ErrorMessage(400, "Failed to create Github server");
+            errorMessage.addAll(errors);
+            throw new ServiceException.BadRequestException(errorMessage);
+        } else {
+            GitHubConfiguration config = GitHubConfiguration.get();
+            GithubServer server;
+            synchronized (config) {
+                Endpoint endpoint = new Endpoint(url, name);
+                config.getEndpoints().add(endpoint);
+                config.save();
+                server = new GithubServer(endpoint, getLink());
+            }
+            return server;
+        }
+     }
+
+    @Override
+    public Link getLink() {
+        return parent.rel("servers");
+    }
+
+    @Override
+    public GithubServer get(final String name) {
+        return Iterators.find(iterator(), new Predicate<GithubServer>() {
+            @Override
+            public boolean apply( GithubServer input) {
+                return input.getName().equals(name);
+            }
+        }, null);
+    }
+
+    @Override
+    public Iterator<GithubServer> iterator() {
+        GitHubConfiguration config = GitHubConfiguration.get();
+        ImmutableList<Endpoint> endpoints;
+        synchronized (config) {
+            endpoints = ImmutableList.copyOf(config.getEndpoints());
+        }
+        return Iterators.transform(endpoints.iterator(), new Function<Endpoint, GithubServer>() {
+            @Override
+            public GithubServer apply(Endpoint input) {
+                return new GithubServer(input, getLink());
+            }
+        });
+    }
+}

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -5,12 +5,14 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Container;
 import net.sf.json.JSONObject;
+import org.apache.commons.collections.ComparatorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.Endpoint;
 import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
@@ -21,6 +23,7 @@ import org.kohsuke.stapler.verb.PUT;
 import javax.annotation.CheckForNull;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -118,10 +121,16 @@ public class GithubServerContainer extends Container<GithubServer> {
     @Override
     public Iterator<GithubServer> iterator() {
         GitHubConfiguration config = GitHubConfiguration.get();
-        ImmutableList<Endpoint> endpoints;
+        List<Endpoint> endpoints;
         synchronized (config) {
             endpoints = ImmutableList.copyOf(config.getEndpoints());
         }
+        endpoints = Ordering.from(new Comparator<Endpoint>() {
+            @Override
+            public int compare(Endpoint o1, Endpoint o2) {
+                return ComparatorUtils.NATURAL_COMPARATOR.compare(o1.getName(), o2.getName());
+            }
+        }).sortedCopy(endpoints);
         return Iterators.transform(endpoints.iterator(), new Function<Endpoint, GithubServer>() {
             @Override
             public GithubServer apply(Endpoint input) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -123,14 +123,13 @@ public class GithubServerContainer extends Container<GithubServer> {
         GitHubConfiguration config = GitHubConfiguration.get();
         List<Endpoint> endpoints;
         synchronized (config) {
-            endpoints = ImmutableList.copyOf(config.getEndpoints());
+            endpoints = Ordering.from(new Comparator<Endpoint>() {
+                @Override
+                public int compare(Endpoint o1, Endpoint o2) {
+                    return ComparatorUtils.NATURAL_COMPARATOR.compare(o1.getName(), o2.getName());
+                }
+            }).sortedCopy(config.getEndpoints());
         }
-        endpoints = Ordering.from(new Comparator<Endpoint>() {
-            @Override
-            public int compare(Endpoint o1, Endpoint o2) {
-                return ComparatorUtils.NATURAL_COMPARATOR.compare(o1.getName(), o2.getName());
-            }
-        }).sortedCopy(endpoints);
         return Iterators.transform(endpoints.iterator(), new Function<Endpoint, GithubServer>() {
             @Override
             public GithubServer apply(Endpoint input) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -81,12 +81,16 @@ public class GithubServerContainer extends Container<GithubServer> {
 
     @Override
     public GithubServer get(final String name) {
-        return Iterators.find(iterator(), new Predicate<GithubServer>() {
+        GithubServer githubServer = Iterators.find(iterator(), new Predicate<GithubServer>() {
             @Override
-            public boolean apply( GithubServer input) {
+            public boolean apply(GithubServer input) {
                 return input.getName().equals(name);
             }
         }, null);
+        if (githubServer == null) {
+            throw new ServiceException.NotFoundException("not found");
+        }
+        return githubServer;
     }
 
     @Override

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Container;
 import net.sf.json.JSONObject;
@@ -30,34 +31,35 @@ public class GithubServerContainer extends Container<GithubServer> {
     }
 
     @PUT
-    @WebMethod(name="create")
+    @WebMethod(name="")
+    @TreeResponse
     public @CheckForNull GithubServer create(@JsonBody JSONObject request) {
 
         List<ErrorMessage.Error> errors = Lists.newLinkedList();
 
         // Validate name
-        final String name = request.getString(GithubServer.NAME);
+        final String name = (String) request.get(GithubServer.NAME);
         if (StringUtils.isEmpty(name)) {
             errors.add(new ErrorMessage.Error(GithubServer.NAME, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.NAME + " is required"));
         } else {
-            GithubServer byName = get(name);
+            GithubServer byName = findByName(name);
             if (byName != null) {
-                errors.add(new ErrorMessage.Error(GithubServer.NAME, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.NAME + " exists"));
+                errors.add(new ErrorMessage.Error(GithubServer.NAME, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.NAME + " already exists for server at '" + byName.getApiUrl() + "'"));
             }
         }
 
         // Validate url
-        final String url = request.getString(GithubServer.API_URL);
-        if (StringUtils.isEmpty(name)) {
+        final String url = (String) request.get(GithubServer.API_URL);
+        if (StringUtils.isEmpty(url)) {
             errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.API_URL + " is required"));
         } else {
-            GithubServer byName = get(name);
-            if (byName != null) {
-                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.MISSING.toString(), GithubServer.API_URL + " is already registered as '" + byName.getName() + "'"));
+            GithubServer byUrl = findByURL(url);
+            if (byUrl != null) {
+                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.API_URL + " is already registered as '" + byUrl.getName() + "'"));
             }
         }
 
-        if (errors.isEmpty()) {
+        if (!errors.isEmpty()) {
             ErrorMessage errorMessage = new ErrorMessage(400, "Failed to create Github server");
             errorMessage.addAll(errors);
             throw new ServiceException.BadRequestException(errorMessage);
@@ -66,7 +68,9 @@ public class GithubServerContainer extends Container<GithubServer> {
             GithubServer server;
             synchronized (config) {
                 Endpoint endpoint = new Endpoint(url, name);
-                config.getEndpoints().add(endpoint);
+                List<Endpoint> endpoints = Lists.newLinkedList(config.getEndpoints());
+                endpoints.add(endpoint);
+                config.setEndpoints(endpoints);
                 config.save();
                 server = new GithubServer(endpoint, getLink());
             }
@@ -81,12 +85,7 @@ public class GithubServerContainer extends Container<GithubServer> {
 
     @Override
     public GithubServer get(final String name) {
-        GithubServer githubServer = Iterators.find(iterator(), new Predicate<GithubServer>() {
-            @Override
-            public boolean apply(GithubServer input) {
-                return input.getName().equals(name);
-            }
-        }, null);
+        GithubServer githubServer = findByName(name);
         if (githubServer == null) {
             throw new ServiceException.NotFoundException("not found");
         }
@@ -106,5 +105,23 @@ public class GithubServerContainer extends Container<GithubServer> {
                 return new GithubServer(input, getLink());
             }
         });
+    }
+
+    private GithubServer findByName(final String name) {
+        return Iterators.find(iterator(), new Predicate<GithubServer>() {
+            @Override
+            public boolean apply(GithubServer input) {
+                return input.getName().equals(name);
+            }
+        }, null);
+    }
+
+    private GithubServer findByURL(final String url) {
+        return Iterators.find(iterator(), new Predicate<GithubServer>() {
+            @Override
+            public boolean apply(GithubServer input) {
+                return input.getApiUrl().equals(url);
+            }
+        }, null);
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -2,7 +2,6 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -18,7 +17,7 @@ import org.jenkinsci.plugins.github_branch_source.Endpoint;
 import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.json.JsonBody;
-import org.kohsuke.stapler.verb.PUT;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.CheckForNull;
 import java.net.HttpURLConnection;
@@ -39,7 +38,7 @@ public class GithubServerContainer extends Container<GithubServer> {
         this.parent = parent;
     }
 
-    @PUT
+    @POST
     @WebMethod(name="")
     @TreeResponse
     public @CheckForNull GithubServer create(@JsonBody JSONObject request) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.jenkins.blueocean.commons.ErrorMessage;
@@ -10,13 +11,12 @@ import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Container;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.Endpoint;
 import org.jenkinsci.plugins.github_branch_source.GitHubConfiguration;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.json.JsonBody;
 import org.kohsuke.stapler.verb.PUT;
-import org.parboiled.common.ImmutableList;
-import org.parboiled.common.StringUtils;
 
 import javax.annotation.CheckForNull;
 import java.util.Iterator;

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -7,9 +7,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
+import static org.powermock.api.mockito.PowerMockito.*;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GithubScm.class, Jenkins.class, Authentication.class, User.class, Secret.class,
+    CredentialsMatchers.class, CredentialsProvider.class, Stapler.class})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*"})
 public class GithubServerTest extends PipelineBaseTest {
 
     String token;
@@ -147,6 +157,9 @@ public class GithubServerTest extends PipelineBaseTest {
 
     @Test
     public void createAndList() throws Exception {
+
+        validGithubServer();
+
         Assert.assertEquals(0, getServers().size());
 
         // Create a server
@@ -186,6 +199,16 @@ public class GithubServerTest extends PipelineBaseTest {
 
         Assert.assertNotNull(resp);
         Assert.assertEquals(404, resp.get("code"));
+    }
+
+    void validGithubServer() throws Exception {
+        HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
+        doNothing().when(httpURLConnectionMock).connect();
+
+        URL urlMock = mock(URL.class);
+        whenNew(URL.class).withAnyArguments().thenReturn(urlMock);
+        when(urlMock.openConnection()).thenReturn(httpURLConnectionMock);
+        when(httpURLConnectionMock.getHeaderField("X-GitHub-Request-Id")).thenReturn("B0D3:28E87:2860BCA:359FACB:594C7A45");
     }
 
     private List getServers() {

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -1,0 +1,198 @@
+package io.jenkins.blueocean.blueocean_github_pipeline;
+
+import com.google.common.collect.ImmutableMap;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class GithubServerTest extends PipelineBaseTest {
+
+    String token;
+
+    @Before
+    public void createUser() throws UnirestException {
+        hudson.model.User user = j.jenkins.getUser("alice");
+        user.setFullName("Alice Cooper");
+        token = getJwtToken(j.jenkins, "alice", "alice");
+    }
+
+    @Test
+    public void testMissingParams() throws Exception {
+        Map resp = request()
+            .status(400)
+            .jwtToken(token)
+            .data(ImmutableMap.of())
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+        Assert.assertNotNull(resp);
+
+        List errors = (List) resp.get("errors");
+        Assert.assertEquals(2, errors.size());
+
+        Map error1 = (Map) errors.get(0);
+        Assert.assertEquals("name", error1.get("field"));
+
+        Map error2 = (Map) errors.get(1);
+        Assert.assertEquals("apiUrl", error2.get("field"));
+    }
+
+    @Test
+    public void testMissingUrlParam() throws Exception {
+        Map resp = request()
+            .status(400)
+            .jwtToken(token)
+            .data(ImmutableMap.of("name", "foo"))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+        Assert.assertNotNull(resp);
+
+        List errors = (List) resp.get("errors");
+        Assert.assertEquals(1, errors.size());
+
+        Map error1 = (Map) errors.get(0);
+        Assert.assertEquals("apiUrl", error1.get("field"));
+        Assert.assertEquals("MISSING", error1.get("code"));
+        Assert.assertEquals("apiUrl is required", error1.get("message"));
+    }
+
+    @Test
+    public void testMissingNameParam() throws Exception {
+        Map resp = request()
+            .status(400)
+            .jwtToken(token)
+            .data(ImmutableMap.of("apiUrl", "http://google.com/"))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+        Assert.assertNotNull(resp);
+
+        List errors = (List) resp.get("errors");
+        Assert.assertEquals(1, errors.size());
+
+        Map error1 = (Map) errors.get(0);
+        Assert.assertEquals("name", error1.get("field"));
+        Assert.assertEquals("MISSING", error1.get("code"));
+        Assert.assertEquals("name is required", error1.get("message"));
+    }
+
+    @Test
+    public void avoidDuplicateByUrl() throws Exception {
+        // Create a server
+        Map server = request()
+            .status(200)
+            .jwtToken(token)
+            .data(ImmutableMap.of(
+                "name", "My Server",
+                "apiUrl", "http://github.example.com/"
+            ))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+
+        // Create a server
+        Map resp = server = request()
+            .status(400)
+            .jwtToken(token)
+            .data(ImmutableMap.of(
+                "name", "My Server 2",
+                "apiUrl", "http://github.example.com/"
+            ))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+
+        List errors = (List) resp.get("errors");
+        Assert.assertEquals(1, errors.size());
+
+        Map error1 = (Map) errors.get(0);
+        Assert.assertEquals("apiUrl", error1.get("field"));
+        Assert.assertEquals("ALREADY_EXISTS", error1.get("code"));
+        Assert.assertEquals("apiUrl is already registered as 'My Server'", error1.get("message"));
+    }
+
+    @Test
+    public void avoidDuplicateByName() throws Exception {
+        // Create a server
+        Map server = request()
+            .status(200)
+            .jwtToken(token)
+            .data(ImmutableMap.of(
+                "name", "My Server",
+                "apiUrl", "http://github.example.com/"
+            ))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+
+        // Create a server
+        Map resp = request()
+            .status(400)
+            .jwtToken(token)
+            .data(ImmutableMap.of(
+                "name", "My Server",
+                "apiUrl", "http://github.corp.example.com/"
+            ))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+
+        List errors = (List) resp.get("errors");
+        Assert.assertEquals(1, errors.size());
+
+        Map error1 = (Map) errors.get(0);
+        Assert.assertEquals("name", error1.get("field"));
+        Assert.assertEquals("ALREADY_EXISTS", error1.get("code"));
+        Assert.assertEquals("name already exists for server at 'http://github.example.com/'", error1.get("message"));
+    }
+
+    @Test
+    public void createListDelete() throws Exception {
+        Assert.assertEquals(0, getServers().size());
+
+        // Create a server
+        Map server = request()
+            .status(200)
+            .jwtToken(token)
+            .data(ImmutableMap.of(
+                "name", "My Server",
+                "apiUrl", "http://github.example.com/"
+            ))
+            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(Map.class);
+
+        Assert.assertEquals("My Server", server.get("name"));
+        Assert.assertEquals("http://github.example.com/", server.get("apiUrl"));
+
+        // Get the list of servers and check that it persisted
+        List servers = getServers();
+        Assert.assertEquals(1, servers.size());
+
+        server = (Map) servers.get(0);
+        Assert.assertEquals("My Server", server.get("name"));
+        Assert.assertEquals("http://github.example.com/", server.get("apiUrl"));
+
+        // Load the server entry
+        server = request()
+            .status(200)
+            .get("/organizations/jenkins/scm/github-enterprise/servers/My%20Server")
+            .build(Map.class);
+        Assert.assertEquals("My Server", server.get("name"));
+        Assert.assertEquals("http://github.example.com/", server.get("apiUrl"));
+
+        Map resp = request()
+            .status(404)
+            .get("/organizations/jenkins/scm/github-enterprise/servers/hello%20vivek")
+            .build(Map.class);
+
+        Assert.assertNotNull(resp);
+        Assert.assertEquals(404, resp.get("code"));
+    }
+
+    private List getServers() {
+        return request()
+            .status(200)
+            .jwtToken(token)
+            .get("/organizations/jenkins/scm/github-enterprise/servers/")
+            .build(List.class);
+    }
+}

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -146,7 +146,7 @@ public class GithubServerTest extends PipelineBaseTest {
     }
 
     @Test
-    public void createListDelete() throws Exception {
+    public void createAndList() throws Exception {
         Assert.assertEquals(0, getServers().size());
 
         // Create a server

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -42,7 +42,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         List errors = (List) resp.get("errors");
@@ -64,7 +64,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", "http://foobar/"
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         List errors = (List) resp.get("errors");
@@ -83,7 +83,7 @@ public class GithubServerTest extends PipelineBaseTest {
             .status(400)
             .jwtToken(token)
             .data(ImmutableMap.of())
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
         Assert.assertNotNull(resp);
 
@@ -104,7 +104,7 @@ public class GithubServerTest extends PipelineBaseTest {
             .status(400)
             .jwtToken(token)
             .data(ImmutableMap.of("name", "foo"))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
         Assert.assertNotNull(resp);
 
@@ -124,7 +124,7 @@ public class GithubServerTest extends PipelineBaseTest {
             .status(400)
             .jwtToken(token)
             .data(ImmutableMap.of("apiUrl", getApiUrl()))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
         Assert.assertNotNull(resp);
 
@@ -148,7 +148,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         // Create a server
@@ -159,7 +159,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server 2",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         List errors = (List) resp.get("errors");
@@ -182,7 +182,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         // Create a server
@@ -193,7 +193,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         List errors = (List) resp.get("errors");
@@ -218,7 +218,7 @@ public class GithubServerTest extends PipelineBaseTest {
                 "name", "My Server",
                 "apiUrl", getApiUrl()
             ))
-            .put("/organizations/jenkins/scm/github-enterprise/servers/")
+            .post("/organizations/jenkins/scm/github-enterprise/servers/")
             .build(Map.class);
 
         Assert.assertEquals("My Server", server.get("name"));

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -536,7 +536,7 @@ public abstract class PipelineBaseTest{
                 }
 
                 HttpResponse<T> response = request.asObject(clzzz);
-                Assert.assertEquals(expectedStatus, response.getStatus());
+                Assert.assertEquals(response.getStatusText(), expectedStatus, response.getStatus());
                 return response.getBody();
             } catch (UnirestException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
# Description

You can manage the GitHub servers that Jenkins has registered with this API

## Create
```
POST /blue/rest/organizations/jenkins/scm/github-enterprise/servers/
{
  "name": "Github Enterprise",
  "apiUrl": "http://github.mycorp.com"
}
```

## List
```
GET /blue/rest/organizations/jenkins/scm/github-enterprise/servers/
[
  {
    "_class": "io.jenkins.blueocean.blueocean_github_pipeline.GithubServer",
    "_links": {
      "self": {
        "_class": "io.jenkins.blueocean.rest.hal.Link",
        "href": "/blue/rest/organizations/jenkins/scm/github-enterprise/servers/Github%20Enterprise/"
      }
    },
    "apiUrl": "http://github.mycorp.com",
    "name": "Github Enterprise"
  }
]
```

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

