### PR TITLE
Check for usage of restricted api calls and fail the build if found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <npm.version>3.10.3</npm.version>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
+    <access-modifier.version>1.12</access-modifier.version>
     <powermock.version>1.6.6</powermock.version>
     <guava.version>11.0.1</guava.version>
     <jacoco.version>0.7.9</jacoco.version>
@@ -510,7 +511,11 @@
           <artifactId>blueocean-pipeline-editor</artifactId>
           <version>0.2.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>${access-modifier.version}</version>
+        </dependency>
 
         <!-- Needed for blueocean-display-url plugin -->
         <dependency>
@@ -697,6 +702,11 @@
                           </configuration>
                       </execution>
                   </executions>
+              </plugin>
+              <plugin>
+                  <groupId>org.kohsuke</groupId>
+                  <artifactId>access-modifier-checker</artifactId>
+                  <version>${access-modifier.version}</version>
               </plugin>
           </plugins>
       </pluginManagement>


### PR DESCRIPTION
# Description

@michaelneale I found the reason #1186 is not failing... the version of access-modifier-checker that you are using does not enforce access restrictions on methods.

We do not want to merge this change yet, as that will make testing #1186 difficult, but filing this as a PR to confirm that you have not accidentally slipped in any other usage of `@Restricted` methods.

See #1186 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

