### PR TITLE
Eliminate pointless PipelineNodeUtil.getStatus call

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/NodeRunStatus.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/NodeRunStatus.java
@@ -34,7 +34,7 @@ public class NodeRunStatus {
             this.result = BlueRun.BlueRunResult.UNKNOWN;
             this.state = BlueRun.BlueRunState.RUNNING;
         } else if (NotExecutedNodeAction.isExecuted(endNode)) {
-            this.result = PipelineNodeUtil.getStatus(endNode.getError());
+            this.result = BlueRun.BlueRunResult.SUCCESS;
             this.state = BlueRun.BlueRunState.FINISHED;
         } else {
             this.result = BlueRun.BlueRunResult.NOT_BUILT;


### PR DESCRIPTION
# Description

This literally always returned SUCCESS, since it could only *not*
return SUCCESS if errorAction != null, and we already have an if
statement for exactly that. So let's simplify the code a little.
(no ticket - this is such a tiny change I assumed it didn't merit one)

No tests are added - this is a simplification of existing code that should match the existing behavior perfectly, so it just has to pass the existing tests to be valid.

No manual tests are needed either, IMO.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

cc @reviewbybees @vivek 