### PR TITLE
Bug/jenkins 45083 ms edge x icon doubled on fastsearch

### DIFF
--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.134-SNAPSHOT-nicu",
+  "version": "0.0.134",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.134-SNAPSHOT",
+  "version": "0.0.134-SNAPSHOT-nicu",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-core-js/src/less/header.less
+++ b/blueocean-core-js/src/less/header.less
@@ -166,6 +166,12 @@
         }
     }
 
+    @supports (-ms-ime-align:auto) {
+        .fastsearch-input ~ div.clear-icon-container.TextInput-icon { 
+            display: none;
+        } 
+    }
+
     input.TextInput-control {
         width: 250px;
         border: none;

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.134-SNAPSHOT-nicu",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
+      "version": "0.0.134",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.133",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.133",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.133.tgz"
+      "version": "0.0.134-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -43,7 +43,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.133",
+    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -43,7 +43,7 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
+    "@jenkins-cd/blueocean-core-js": "0.0.134",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.133",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.133",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.133.tgz"
+      "version": "0.0.134-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.134-SNAPSHOT-nicu",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
+      "version": "0.0.134",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -39,7 +39,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
+    "@jenkins-cd/blueocean-core-js": "0.0.134",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -39,7 +39,7 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.133",
+    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.134-SNAPSHOT-nicu",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
+      "version": "0.0.134",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.133",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.133",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.133.tgz"
+      "version": "0.0.134-SNAPSHOT-nicu",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.134-SNAPSHOT-nicu",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.134-SNAPSHOT-nicu.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.134",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -30,7 +30,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.133",
+    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -30,7 +30,7 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.134-SNAPSHOT-nicu",
+    "@jenkins-cd/blueocean-core-js": "0.0.134",
     "@jenkins-cd/design-language": "0.0.134",
     "@jenkins-cd/js-extensions": "0.0.36",
     "@jenkins-cd/js-modules": "0.0.10",


### PR DESCRIPTION
# Description
ms edge doesn't properly support the ':not([value=""])' selector, so it always shows the clear icon. It also has a built in clear icon that appears when text is inserted. This solution hides our custom clear icon because the built in one works as intended.

See [JENKINS-45083](https://issues.jenkins-ci.org/browse/JENKINS-45083).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

