### PR TITLE
Properly use the latest Docker credentials in our trusted.ci env for publishing

### DIFF
--- a/docker/official/Jenkinsfile
+++ b/docker/official/Jenkinsfile
@@ -7,12 +7,14 @@ properties([
 ])
 
 node('docker') {
-  stage('Checkout') {
-    deleteDir()
-    checkout scm
-  }
+    stage('Checkout') {
+        deleteDir()
+        checkout scm
+    }
 
-  stage('Build and publish container') {
-      sh 'docker/official/build.sh'
-  }
+    stage('Build and publish container') {
+        infra.withDockerCredentials {
+            sh 'docker/official/build.sh'
+        }
+    }
 }


### PR DESCRIPTION
The assumption that the Jenkins agent will simply have ~/.docker/config.json
around is no longer true.

Related to INFRA-1066