### PR TITLE
Sanitise step descriptions

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JSON.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JSON.java
@@ -13,7 +13,7 @@ public class JSON {
      * @return sanitized string
      */
     public static String sanitizeString(@Nonnull String input) {
-        return CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(input);
+        return CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t")).removeFrom(input);
     }
 
     private JSON() {}

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JSON.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/JSON.java
@@ -1,0 +1,20 @@
+package io.jenkins.blueocean.commons;
+
+import com.google.common.base.CharMatcher;
+
+import javax.annotation.Nonnull;
+
+/** JSON Utility */
+public class JSON {
+
+    /**
+     * Sanitises string by removing any ISO control characters, tabs and line breaks
+     * @param input string
+     * @return sanitized string
+     */
+    public static String sanitizeString(@Nonnull String input) {
+        return CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(input);
+    }
+
+    private JSON() {}
+}

--- a/blueocean-commons/src/test/java/io/jenkins/blueocean/commons/JSONTest.java
+++ b/blueocean-commons/src/test/java/io/jenkins/blueocean/commons/JSONTest.java
@@ -1,0 +1,11 @@
+package io.jenkins.blueocean.commons;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JSONTest {
+    @Test
+    public void sanitize() throws Exception {
+        Assert.assertEquals("hello vivek :)", JSON.sanitizeString("hello\r vivek\n\t :)"));
+    }
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Predicate;
 import hudson.ExtensionList;
 import hudson.FilePath;
@@ -74,7 +75,12 @@ public class PipelineStepImpl extends BluePipelineStep {
 
     @Override
     public String getDisplayDescription() {
-        return ArgumentsAction.getStepArgumentsAsString(node.getNode());
+        String displayDescription = ArgumentsAction.getStepArgumentsAsString(node.getNode());
+        if (displayDescription != null) {
+            // Remove any control characters that may have found their way out of a script
+            displayDescription = CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(displayDescription);
+        }
+        return displayDescription;
     }
 
     @Override
@@ -280,6 +286,10 @@ public class PipelineStepImpl extends BluePipelineStep {
     }
     private boolean canSubmit(InputStep inputStep){
         return inputStep.canSubmit();
+    }
+
+    static String removeIllegalCharacters(String input) {
+        return CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(input);
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -77,7 +77,7 @@ public class PipelineStepImpl extends BluePipelineStep {
     public String getDisplayDescription() {
         String displayDescription = ArgumentsAction.getStepArgumentsAsString(node.getNode());
         if (displayDescription != null) {
-            // Remove any control characters that may have found their way out of a script
+            // JENKINS-45099 Remove any control characters that may have found their way out of a script
             displayDescription = CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(displayDescription);
         }
         return displayDescription;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -1,6 +1,5 @@
 package io.jenkins.blueocean.rest.impl.pipeline;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Predicate;
 import hudson.ExtensionList;
 import hudson.FilePath;
@@ -9,6 +8,7 @@ import hudson.model.Action;
 import hudson.model.FileParameterValue;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
+import io.jenkins.blueocean.commons.JSON;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
@@ -78,7 +78,7 @@ public class PipelineStepImpl extends BluePipelineStep {
         String displayDescription = ArgumentsAction.getStepArgumentsAsString(node.getNode());
         if (displayDescription != null) {
             // JENKINS-45099 Remove any control characters that may have found their way out of a script
-            displayDescription = CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(displayDescription);
+            displayDescription = JSON.sanitizeString(displayDescription);
         }
         return displayDescription;
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -288,10 +288,6 @@ public class PipelineStepImpl extends BluePipelineStep {
         return inputStep.canSubmit();
     }
 
-    static String removeIllegalCharacters(String input) {
-        return CharMatcher.JAVA_ISO_CONTROL.and(CharMatcher.anyOf("\r\n\t").negate()).removeFrom(input);
-    }
-
     @Override
     public Link getLink() {
         return self;


### PR DESCRIPTION
# Description

@abayer @vivek looks like `ArgumentsAction.getStepArgumentsAsString` might include `\t` and other characters that are bad for JSON. Should this really be updated in workflow-api? I am not sure having a `\t` character in a step name is something good for human eyeballs anyway. Feels some sanitation should occur there rather in blue ocean?

The problem is that when we encounter these issues parts of the UI fail to load as described in the ticket below.

See [JENKINS-45099](https://issues.jenkins-ci.org/browse/JENKINS-45099).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given