### PR TITLE
Add ability to post to the analytics track endpoint

### DIFF
--- a/blueocean-core-js/src/js/analytics/AnalyticsService.js
+++ b/blueocean-core-js/src/js/analytics/AnalyticsService.js
@@ -4,19 +4,18 @@ import utils from '../utils';
 
 export class AnalyticsService {
     track(eventName, properties) {
-        const path = config.getJenkinsRootURL();;
+        const path = config.getJenkinsRootURL();
         const url = utils.cleanSlashes(`${path}/blue/rest/analytics/track`);
-        const body = {
-            name: eventName,
-            properties: properties
-        };
         const fetchOptions = {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: body
+            body: {
+                name: eventName,
+                properties: { properties },
+            },
         };
-        return fetch.fetch(url, { fetchOptions });
+        return Fetch.fetch(url, { fetchOptions });
     }
 }

--- a/blueocean-core-js/src/js/analytics/AnalyticsService.js
+++ b/blueocean-core-js/src/js/analytics/AnalyticsService.js
@@ -1,0 +1,22 @@
+import { Fetch } from '../fetch';
+import config from '../urlconfig';
+import utils from '../utils';
+
+export class AnalyticsService {
+    track(eventName, properties) {
+        const path = config.getJenkinsRootURL();;
+        const url = utils.cleanSlashes(`${path}/blue/rest/analytics/track`);
+        const body = {
+            name: eventName,
+            properties: properties
+        };
+        const fetchOptions = {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: body
+        };
+        return fetch.fetch(url, { fetchOptions });
+    }
+}

--- a/blueocean-core-js/src/js/index.js
+++ b/blueocean-core-js/src/js/index.js
@@ -9,7 +9,7 @@ import { RunApi } from './rest/RunApi';
 
 import { SseBus } from './sse/SseBus';
 import { ToastService } from './ToastService';
-import { AnalyticsService } from './AnalyticsService';
+import { AnalyticsService } from './analytics/AnalyticsService';
 
 // export i18n provider
 export i18nTranslator, { defaultLngDetector } from './i18n/i18n';

--- a/blueocean-core-js/src/js/index.js
+++ b/blueocean-core-js/src/js/index.js
@@ -9,6 +9,7 @@ import { RunApi } from './rest/RunApi';
 
 import { SseBus } from './sse/SseBus';
 import { ToastService } from './ToastService';
+import { AnalyticsService } from './AnalyticsService';
 
 // export i18n provider
 export i18nTranslator, { defaultLngDetector } from './i18n/i18n';
@@ -85,6 +86,7 @@ export const sseService = new SSEService(sseConnection);
 export const activityService = new ActivityService(pagerService);
 export const pipelineService = new PipelineService(pagerService, activityService);
 export const locationService = new LocationService();
+export const analyticsService = new AnalyticsService();
 
 const defaultSSEhandler = new DefaultSSEHandler(pipelineService, activityService, pagerService);
 sseService.registerHandler(defaultSSEhandler.handleEvents);


### PR DESCRIPTION
# Description

Adds `AnalyticsService` to core-js that allows events to be tracked:
```
import analyticsService from '@jenkins-cd/blueocean-core-js';
analyticsService.track('cool_event', { prop1: 123, prop2: 'hello world' });
```

**POST /blue/rest/analytics/track**
```
{
  name: 'cool_event',
  properties: {
    prop1: 123,
    prop2: 'hello world'
  }
}
```

See [JENKINS-45144](https://issues.jenkins-ci.org/browse/JENKINS-45144).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
