### PR TITLE
verify pubsub-light 1.10 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pubsub-light</artifactId>
-            <version>1.8</version>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
No need to merge this (unless ye want it). Just verifying BO compatibility with pubsub-light 1.10.

If ye want to upgrade, we can create a ticket etc and relabel this PR.