### PR TITLE
Move to addEndpoint() to retain binary compatibility

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -43,6 +43,6 @@ public class GithubServer extends Resource {
 
     @Override
     public Link getLink() {
-        return parent.rel(BaseEncoding.base32().encode(endpoint.getApiUri().getBytes()));
+        return parent.rel(BaseEncoding.base32().encode(endpoint.getApiUri().getBytes(Charsets.UTF_8)));
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -1,5 +1,7 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Resource;
@@ -12,6 +14,7 @@ import static hudson.Util.rawEncode;
 @ExportedBean
 public class GithubServer extends Resource {
 
+    public static final String ID = "ID";
     public static final String NAME = "name";
     public static final String API_URL = "apiUrl";
 
@@ -21,6 +24,11 @@ public class GithubServer extends Resource {
     GithubServer(Endpoint endpoint, Link parent) {
         this.endpoint = endpoint;
         this.parent = parent;
+    }
+
+    @Exported(name = ID)
+    public String getId() {
+        return Hashing.sha256().hashString(endpoint.getApiUri(), Charsets.UTF_8).toString();
     }
 
     @Exported(name = NAME)

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -43,6 +43,6 @@ public class GithubServer extends Resource {
 
     @Override
     public Link getLink() {
-        return parent.rel(BaseEncoding.base32().encode(endpoint.getApiUri().getBytes(Charsets.UTF_8)));
+        return parent.rel(getId());
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServer.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
+import com.google.common.io.BaseEncoding;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.Resource;
 import org.jenkinsci.plugins.github_branch_source.Endpoint;
@@ -34,6 +35,6 @@ public class GithubServer extends Resource {
 
     @Override
     public Link getLink() {
-        return parent.rel(rawEncode(endpoint.getName()));
+        return parent.rel(BaseEncoding.base32().encode(endpoint.getApiUri().getBytes()));
     }
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -90,23 +90,13 @@ public class GithubServerContainer extends Container<GithubServer> {
             throw new ServiceException.BadRequestException(message);
         } else {
             GitHubConfiguration config = GitHubConfiguration.get();
-            GithubServer server;
-            synchronized (config) {
-                // TODO: this is a temp workaround to facilitate automated Selenium tests
-                // since duplicate URLs are not allowed, Selenium appends a random query string param to the API URL
-                // this bypasses the uniqueness check but a URL with a query string param will cause downstream errors
-                // therefore this method trims off the query string when actually saving the server so a clean URL is used
-                // once there is an easy way to delete existing GitHub servers this same logic should be added to validation above
-                String sanitizedUrl = discardQueryString(url);
-                Endpoint endpoint = new Endpoint(sanitizedUrl, name);
-                if (!config.addEndpoint(endpoint)) {
-                    message.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.API_URL + " is already registered as '" + endpoint.getName() + "'"));
-                    throw new ServiceException.BadRequestException(message);
-                }
-                config.save();
-                server = new GithubServer(endpoint, getLink());
+            String sanitizedUrl = discardQueryString(url);
+            Endpoint endpoint = new Endpoint(sanitizedUrl, name);
+            if (!config.addEndpoint(endpoint)) {
+                message.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.API_URL + " is already registered as '" + endpoint.getName() + "'"));
+                throw new ServiceException.BadRequestException(message);
             }
-            return server;
+            return new GithubServer(endpoint, getLink());
         }
      }
 
@@ -127,15 +117,12 @@ public class GithubServerContainer extends Container<GithubServer> {
     @Override
     public Iterator<GithubServer> iterator() {
         GitHubConfiguration config = GitHubConfiguration.get();
-        List<Endpoint> endpoints;
-        synchronized (config) {
-            endpoints = Ordering.from(new Comparator<Endpoint>() {
-                @Override
-                public int compare(Endpoint o1, Endpoint o2) {
-                    return ComparatorUtils.NATURAL_COMPARATOR.compare(o1.getName(), o2.getName());
-                }
-            }).sortedCopy(config.getEndpoints());
-        }
+        List<Endpoint> endpoints = Ordering.from(new Comparator<Endpoint>() {
+            @Override
+            public int compare(Endpoint o1, Endpoint o2) {
+                return ComparatorUtils.NATURAL_COMPARATOR.compare(o1.getName(), o2.getName());
+            }
+        }).sortedCopy(config.getEndpoints());
         return Iterators.transform(endpoints.iterator(), new Function<Endpoint, GithubServer>() {
             @Override
             public GithubServer apply(Endpoint input) {

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -84,20 +84,20 @@ public class GithubServerContainer extends Container<GithubServer> {
             }
         }
 
-        ErrorMessage message = new ErrorMessage(400, "Failed to create Github server");
-        if (!errors.isEmpty()) {
-            message.addAll(errors);
-            throw new ServiceException.BadRequestException(message);
-        } else {
+        if (errors.isEmpty()) {
             GitHubConfiguration config = GitHubConfiguration.get();
             String sanitizedUrl = discardQueryString(url);
             Endpoint endpoint = new Endpoint(sanitizedUrl, name);
             if (!config.addEndpoint(endpoint)) {
-                message.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.API_URL + " is already registered as '" + endpoint.getName() + "'"));
-                throw new ServiceException.BadRequestException(message);
+                errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.ALREADY_EXISTS.toString(), GithubServer.API_URL + " is already registered as '" + endpoint.getName() + "'"));
             }
-            return new GithubServer(endpoint, getLink());
+            else {
+                return new GithubServer(endpoint, getLink());
+            }
         }
+        ErrorMessage message = new ErrorMessage(400, "Failed to create Github server");
+        message.addAll(errors);
+        throw new ServiceException.BadRequestException(message);
      }
 
     @Override

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.Util;
@@ -240,7 +241,7 @@ public class GithubServerTest extends PipelineBaseTest {
         // Load the server entry
         server = request()
             .status(200)
-            .get("/organizations/jenkins/scm/github-enterprise/servers/" + BaseEncoding.base64().encode(getApiUrl().getBytes(Charsets.UTF_8)) + "/")
+            .get("/organizations/jenkins/scm/github-enterprise/servers/" + Hashing.sha256().hashString(getApiUrl(), Charsets.UTF_8).toString() + "/")
             .build(Map.class);
         Assert.assertEquals("My Server", server.get("name"));
         Assert.assertEquals(getApiUrl(), server.get("apiUrl"));

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -251,7 +251,7 @@ public class GithubServerTest extends PipelineBaseTest {
     }
 
     private String getApiUrl() {
-        return "http://localhost:" + wireMockRule.port() + "/";
+        return "http://localhost:" + wireMockRule.port();
     }
 
     private void validGithubServer(boolean hasHeader) throws Exception {

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -56,7 +56,7 @@ public class GithubServerTest extends PipelineBaseTest {
     }
 
     @Test
-    public void testServerBadServer() throws Exception {
+    public void badServer() throws Exception {
         // Create a server
         Map resp = request()
             .status(400)

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerTest.java
@@ -3,8 +3,11 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import hudson.Util;
 import io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,6 +15,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -236,7 +240,7 @@ public class GithubServerTest extends PipelineBaseTest {
         // Load the server entry
         server = request()
             .status(200)
-            .get("/organizations/jenkins/scm/github-enterprise/servers/My%20Server")
+            .get("/organizations/jenkins/scm/github-enterprise/servers/" + BaseEncoding.base64().encode(getApiUrl().getBytes(Charsets.UTF_8)) + "/")
             .build(Map.class);
         Assert.assertEquals("My Server", server.get("name"));
         Assert.assertEquals(getApiUrl(), server.get("apiUrl"));

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Stephen tells me that addEndpoint() will survive the API changes he
has planned for Github Branch Source and endpoint unification.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

