### PR TITLE
[JENKINS-45442] [JENKINS-45482] [JENKINS-45360] 1.1 branch: Pipeline creation compatibility with custom orgs

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -21,6 +21,7 @@ import jenkins.branch.CustomOrganizationFolderDescriptor;
 import jenkins.branch.MultiBranchProject;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -92,8 +93,10 @@ public class GithubPipelineCreateRequest extends AbstractPipelineCreateRequest {
         String singleRepo = repos.size() == 1 ? repos.get(0) : null;
 
         User authenticatedUser =  User.current();
-
-        Item item = Jenkins.getInstance().getItemByFullName(orgName);
+        
+        ModifiableTopLevelItemGroup orgRoot = getParent();
+        
+        Item item = Jenkins.getInstance().getItemByFullName(orgRoot.getFullName() + '/' + orgName);
         boolean creatingNewItem = item == null;
         try {
 

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.model.User;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.impl.pipeline.PipelineBaseTest;
 import org.junit.Rule;
 
@@ -82,7 +83,7 @@ public abstract class GithubMockBase extends PipelineBaseTest {
                 .data(ImmutableMap.of("accessToken", accessToken))
                 .status(200)
                 .jwtToken(getJwtToken(j.jenkins, user.getId(), user.getId()))
-                .put("/organizations/jenkins/scm/github/validate/")
+                .put("/organizations/" + OrganizationFactory.getInstance().list().iterator().next().getName() + "/scm/github/validate/")
                 .build(Map.class);
         String credentialId = (String) r.get("credentialId");
         assertEquals("github", credentialId);

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
@@ -1,0 +1,166 @@
+package io.jenkins.blueocean.blueocean_github_pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestExtension;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mashape.unirest.http.exceptions.UnirestException;
+
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.TopLevelItem;
+import hudson.model.User;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.service.embedded.OrganizationFactoryImpl;
+import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
+import jenkins.branch.OrganizationFolder;
+import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
+
+
+public class GithubOrgFolderPermissionsTest extends GithubMockBase {
+
+    @Test
+    public void canCreateWhenHavePermissionsOnDefaultOrg() throws Exception {
+        MockAuthorizationStrategy authz = new MockAuthorizationStrategy();
+        authz.grant(Jenkins.ADMINISTER).everywhere().to(user);
+        j.jenkins.setAuthorizationStrategy(authz);
+        // refresh the JWT token otherwise all hell breaks loose.
+        jwtToken = getJwtToken(j.jenkins, "vivek", "vivek");
+        createGithubOrgFolder(true);
+    }
+
+    @Test
+    public void canNotCreateWhenHaveNoPermissionOnDefaultOrg() throws Exception {        
+        MockAuthorizationStrategy authz = new MockAuthorizationStrategy();
+        authz.grant(Item.READ).everywhere().to(user);
+        j.jenkins.setAuthorizationStrategy(authz);
+        // refresh the JWT token otherwise all hell breaks loose.
+        jwtToken = getJwtToken(j.jenkins, "vivek", "vivek");
+        createGithubOrgFolder(false);
+    }
+
+    @Test
+    public void canCreateWhenHavePermissionsOnCustomOrg() throws Exception {
+        MockAuthorizationStrategy authz = new MockAuthorizationStrategy();
+        authz.grant(Item.READ).everywhere().to(user);
+        authz.grant(Item.CREATE, Item.CONFIGURE).onFolders(getOrgRoot()).to(user);
+        j.jenkins.setAuthorizationStrategy(authz);
+        // refresh the JWT token otherwise all hell breaks loose.
+        jwtToken = getJwtToken(j.jenkins, "vivek", "vivek");
+        createGithubOrgFolder(true);
+    }
+
+    @Test
+    public void canNotCreateWhenHaveNoPermissionOnCustomOrg() throws Exception {
+        MockAuthorizationStrategy authz = new MockAuthorizationStrategy();
+        authz.grant(Item.READ).everywhere().to(user);
+        j.jenkins.setAuthorizationStrategy(authz);
+        // refresh the JWT token otherwise all hell breaks loose.
+        jwtToken = getJwtToken(j.jenkins, "vivek", "vivek");
+        createGithubOrgFolder(false);
+    }
+
+    private void createGithubOrgFolder(boolean shouldSuceed) throws Exception {
+        String credentialId = createGithubCredential(user);
+        String orgFolderName = "cloudbeers1";
+        Map resp = new RequestBuilder(baseUrl)
+                .status(shouldSuceed ? 201 : 403)
+                .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
+                .post("/organizations/" + getOrgName() + "/pipelines/")
+                .data(ImmutableMap.of("name", orgFolderName,
+                        "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
+                        "scmConfig", ImmutableMap.of("config",
+                                ImmutableMap.of("repos", ImmutableList.of("PR-demo"), "orgName","cloudbeers"),
+                                "credentialId", credentialId,
+                                "uri", githubApiUrl)
+                ))
+                .build(Map.class);
+
+        TopLevelItem item = getOrgRoot().getItem(orgFolderName);
+        if (shouldSuceed) {
+            assertEquals(orgFolderName, resp.get("name"));
+            assertEquals("io.jenkins.blueocean.blueocean_github_pipeline.GithubOrganizationFolder", resp.get("_class"));
+
+            Assert.assertTrue(item instanceof OrganizationFolder);
+            Map r = get("/organizations/"+ getOrgName() + "/pipelines/"+orgFolderName+"/");
+            assertEquals(orgFolderName, r.get("name"));
+            assertFalse((Boolean) r.get("scanAllRepos"));
+        }
+        else {
+            assertEquals(403, resp.get("code"));
+            assertEquals("Failed to create pipeline: cloudbeers1. User vivek doesn't have Job create permission", resp.get("message"));
+            Assert.assertNull(item);
+            String r = get("/organizations/"+ getOrgName() + "/pipelines/"+orgFolderName+"/", 404, String.class);
+        }
+    }
+
+    private String createGithubCredential(User user) throws UnirestException {
+        Map r = new RequestBuilder(baseUrl)
+                .data(ImmutableMap.of("accessToken", "12345"))
+                .status(200)
+                .jwtToken(getJwtToken(j.jenkins, user.getId(), user.getId()))
+                .put("/organizations/" + getOrgName() + "/scm/github/validate/")
+                .build(Map.class);
+
+        assertEquals("github", r.get("credentialId"));
+        return "github";
+    }
+
+    private static String getOrgName() {
+        return OrganizationFactory.getInstance().list().iterator().next().getName();
+    }
+
+    private static ModifiableTopLevelItemGroup getOrgRoot() {
+        return OrganizationFactory.getItemGroup(getOrgName());
+    }
+
+    @TestExtension(value={"canCreateWhenHavePermissionsOnCustomOrg","canNotCreateWhenHaveNoPermissionOnCustomOrg"})
+    public static class TestOrganizationFactoryImpl extends OrganizationFactoryImpl {
+
+        private OrganizationImpl instance;
+
+        public TestOrganizationFactoryImpl() throws IOException {
+            Folder f = Jenkins.getInstance().createProject(Folder.class, "CustomOrg");
+            instance = new OrganizationImpl("custom", f);
+        }
+
+        @Override
+        public OrganizationImpl get(String name) {
+            if (instance != null) {
+                if (instance.getName().equals(name)) {
+                    System.out.println("" + name + " Instance returned " + instance);
+                    return instance;
+                }
+            }
+            System.out.println("" + name + " no instance found");
+            return null;
+        }
+
+        @Override
+        public Collection<BlueOrganization> list() {
+            return Collections.singleton((BlueOrganization) instance);
+        }
+
+        @Override
+        public OrganizationImpl of(ItemGroup group) {
+            if (group == instance.getGroup()) {
+                return instance;
+            }
+            return null;
+        }
+    }
+}

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderTest.java
@@ -12,19 +12,34 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mashape.unirest.http.exceptions.UnirestException;
+
+import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
+import hudson.model.TopLevelItemDescriptor;
 import hudson.model.User;
 import io.jenkins.blueocean.credential.CredentialsUtils;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanCredentialsProvider;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainRequirement;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainSpecification;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.service.embedded.OrganizationFactoryImpl;
+import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
+
 import org.jenkinsci.plugins.github_branch_source.Connector;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestExtension;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,7 +49,18 @@ import static org.junit.Assert.*;
 /**
  * @author Vivek Pandey
  */
+@RunWith(Parameterized.class)
 public class GithubOrgFolderTest extends GithubMockBase {
+
+    @Parameters
+    public static Object[] data() {
+        return new Object[] { null, "TestOrg" };
+    }
+
+    public GithubOrgFolderTest(String blueOrganisation) {
+        System.out.println("setting org root to: " + blueOrganisation);
+        TestOrganizationFactoryImpl.orgRoot = blueOrganisation;
+    }
 
     @Test
     public void simpleOrgTest() throws IOException, UnirestException {
@@ -43,7 +69,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", orgFolderName,
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("config",
@@ -56,13 +82,13 @@ public class GithubOrgFolderTest extends GithubMockBase {
         assertEquals(orgFolderName, resp.get("name"));
         assertEquals("io.jenkins.blueocean.blueocean_github_pipeline.GithubOrganizationFolder", resp.get("_class"));
 
-        TopLevelItem item = j.getInstance().getItem(orgFolderName);
+        TopLevelItem item = getOrgRoot().getItem(orgFolderName);
         assertNotNull(item);
 
         Assert.assertTrue(item instanceof OrganizationFolder);
 
 
-        Map r = get("/organizations/jenkins/pipelines/"+orgFolderName+"/");
+        Map r = get("/organizations/"+ getOrgName() + "/pipelines/"+orgFolderName+"/");
         assertEquals(orgFolderName, r.get("name"));
         assertFalse((Boolean) r.get("scanAllRepos"));
     }
@@ -73,7 +99,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", "cloudbeers",
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("config",
@@ -102,7 +128,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", orgFolderName,
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("config",
@@ -126,7 +152,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", orgFolderName,
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("config",ImmutableMap.of(
@@ -145,7 +171,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         Map resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", orgFolderName,
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("config",
@@ -169,7 +195,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         resp = new RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins,user.getId(), user.getId()))
-                .post("/organizations/jenkins/pipelines/")
+                .post("/organizations/" + getOrgName() + "/pipelines/")
                 .data(ImmutableMap.of("name", orgFolderName,
                         "$class", "io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest",
                         "organization","jenkins",
@@ -213,7 +239,7 @@ public class GithubOrgFolderTest extends GithubMockBase {
         }
 
         //create org folder and attach user and credential id to it
-        OrganizationFolder organizationFolder = j.createProject(OrganizationFolder.class, "demo");
+        OrganizationFolder organizationFolder = (OrganizationFolder) getOrgRoot().createProject((TopLevelItemDescriptor)j.jenkins.getDescriptor(OrganizationFolder.class), "demo", false);
         AbstractFolderProperty prop = new BlueOceanCredentialsProvider.FolderPropertyImpl(user.getId(), credential.getId(),
                 BlueOceanCredentialsProvider.createDomain("https://api.github.com"));
 
@@ -248,10 +274,73 @@ public class GithubOrgFolderTest extends GithubMockBase {
                 .data(ImmutableMap.of("accessToken", "12345"))
                 .status(200)
                 .jwtToken(getJwtToken(j.jenkins, user.getId(), user.getId()))
-                .put("/organizations/jenkins/scm/github/validate/")
+                .put("/organizations/" + getOrgName() + "/scm/github/validate/")
                 .build(Map.class);
 
         assertEquals("github", r.get("credentialId"));
         return "github";
     }
+
+    private String getOrgName() {
+        return OrganizationFactory.getInstance().list().iterator().next().getName();
+    }
+
+    private ModifiableTopLevelItemGroup getOrgRoot() {
+        return OrganizationFactory.getItemGroup(getOrgName());
+    }
+
+    
+    @TestExtension
+    public static class TestOrganizationFactoryImpl extends OrganizationFactoryImpl {
+        
+        public static String orgRoot;
+        
+        private OrganizationImpl instance;
+
+        public TestOrganizationFactoryImpl() {
+            System.out.println("TestOrganizationFactoryImpl org root is: " + orgRoot);
+            setOrgRoot(orgRoot);
+        }
+
+        private void setOrgRoot(String root) {
+            if (root != null) {
+                try {
+                    MockFolder itemGroup = Jenkins.getInstance().createProject(MockFolder.class, root);
+                    instance = new OrganizationImpl(root, itemGroup);
+                } catch (IOException e) {
+                    throw new RuntimeException("Test setup failed!", e);
+                }
+                
+            }
+            else {
+                instance = new OrganizationImpl("jenkins", Jenkins.getInstance());
+            }
+        }
+
+        @Override
+        public OrganizationImpl get(String name) {
+            if (instance != null) {
+                if (instance.getName().equals(name)) {
+                    System.out.println("" + name + " Instance returned " + instance);
+                    return instance;
+                }
+            }
+            System.out.println("" + name + " no instance found");
+            return null;
+        }
+
+        @Override
+        public Collection<BlueOrganization> list() {
+            return Collections.singleton((BlueOrganization) instance);
+        }
+
+        @Override
+        public OrganizationImpl of(ItemGroup group) {
+            if (group == instance.getGroup()) {
+                return instance;
+            }
+            return null;
+        }
+    }
+
 }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/credential/CredentialContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/credential/CredentialContainer.java
@@ -10,6 +10,8 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.Container;
 import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
+
 import org.kohsuke.stapler.export.ExportedBean;
 
 import javax.annotation.Nonnull;
@@ -30,7 +32,9 @@ public class CredentialContainer extends Container<CredentialApi> implements Org
     private final Link self;
 
     public CredentialContainer() {
-        BlueOrganization organization= OrganizationFactory.getInstance().getContainingOrg(Jenkins.getInstance());
+        // seems like this is now getting common and should have a helper function
+        Iterator<BlueOrganization> iterator = OrganizationFactory.getInstance().list().iterator();
+        BlueOrganization organization = iterator.hasNext() ? iterator.next() : null; 
         this.self = (organization != null) ? organization.getLink().rel("credentials")
                 : null;
     }
@@ -71,9 +75,14 @@ public class CredentialContainer extends Container<CredentialApi> implements Org
                 }
             }
         }else{
-            for(CredentialsStore store: CredentialsProvider.lookupStores(Jenkins.getInstance())){
-                if(store.getStoreAction() != null) {
-                    apis.add(new CredentialApi(store.getStoreAction(), this));
+            Iterator<BlueOrganization> iterator = OrganizationFactory.getInstance().list().iterator();
+            BlueOrganization organization = iterator.hasNext() ? iterator.next() : null; 
+            if (organization != null) {
+                ModifiableTopLevelItemGroup itemGroup = OrganizationFactory.getItemGroup(organization.getName());
+                for(CredentialsStore store: CredentialsProvider.lookupStores(itemGroup)){
+                    if(store.getStoreAction() != null) {
+                        apis.add(new CredentialApi(store.getStoreAction(), this));
+                    }
                 }
             }
         }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -26,8 +26,10 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StageChunkFinder;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.slf4j.Logger;
@@ -52,12 +54,18 @@ import static org.junit.Assert.fail;
 public abstract class PipelineBaseTest{
     private static  final Logger LOGGER = LoggerFactory.getLogger(PipelineBaseTest.class);
 
-    public PipelineBaseTest() {
+    @BeforeClass
+    public static void enableJWT() {
         System.setProperty("BLUEOCEAN_FEATURE_JWT_AUTHENTICATION", "true");
-        j = new JenkinsRule();
     }
+
+    @AfterClass
+    public static void resetJWT() {
+        System.clearProperty("BLUEOCEAN_FEATURE_JWT_AUTHENTICATION");
+    }
+
     @Rule
-    public JenkinsRule j;
+    public JenkinsRule j = new JenkinsRule();
 
     protected  String baseUrl;
 

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
@@ -139,7 +139,7 @@ public abstract class AbstractMultiBranchCreateRequest extends AbstractPipelineC
             errors.add(new Error(ERROR_FIELD_SCM_CONFIG_NAME, Error.ErrorCodes.INVALID.toString(),  getName() + " in not a valid name"));
         }
 
-        if(Jenkins.getInstance().getItem(name)!=null) {
+        if(getParent().getItem(name)!=null) {
             errors.add(new Error(ERROR_NAME, Error.ErrorCodes.ALREADY_EXISTS.toString(), getName() + " already exists"));
         }
 

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractPipelineCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractPipelineCreateRequest.java
@@ -5,6 +5,7 @@ import hudson.model.Items;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.security.ACL;
+import hudson.security.AccessControlled;
 import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
@@ -40,7 +41,8 @@ public abstract class AbstractPipelineCreateRequest extends BluePipelineCreateRe
 
 
     protected  @Nonnull TopLevelItem createProject(String name, String descriptorName, Class<? extends TopLevelItemDescriptor> descriptorClass) throws IOException{
-        ACL acl = Jenkins.getInstance().getACL();
+        final ModifiableTopLevelItemGroup p = getParent();
+        final ACL acl = (p instanceof AccessControlled) ? ((AccessControlled) p).getACL() : Jenkins.getInstance().getACL(); 
         Authentication a = Jenkins.getAuthentication();
         if(!acl.hasPermission(a, Item.CREATE)){
             throw new ServiceException.ForbiddenException(
@@ -51,14 +53,13 @@ public abstract class AbstractPipelineCreateRequest extends BluePipelineCreateRe
             throw new ServiceException.BadRequestException(String.format("Failed to create pipeline: %s, descriptor %s is not found", name, descriptorName));
         }
 
-        ModifiableTopLevelItemGroup p = getParent();
         if(!descriptor.isApplicableIn(p)){
             throw new ServiceException.ForbiddenException(
-                    String.format("Failed to create pipeline: %s. pipeline can't be created in Jenkins root folder", name));
+                    String.format("Failed to create pipeline: %s. Pipeline can't be created in Jenkins root folder", name));
         }
 
         if(!acl.hasCreatePermission(a, p, descriptor)){
-            throw new ServiceException.ForbiddenException("Missing permission: " +Item.CREATE.group.title+"/"+Item.CREATE.name + Item.CREATE + "/" + descriptor.getDisplayName());
+            throw new ServiceException.ForbiddenException("Missing permission: " + Item.CREATE.group.title+"/"+Item.CREATE.name + " " + Item.CREATE + "/" + descriptor.getDisplayName());
         }
         return p.createProject(descriptor, name, true);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <jacoco.line.coverage>0.70</jacoco.line.coverage>
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
-    <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.23</jenkins-test-harness.version>
     <scm-api.version>2.1.1</scm-api.version>
     <git.version>3.3.0</git.version>
   </properties>


### PR DESCRIPTION
# Description

Fixes compatabilty with pipeline (GitHubOrg/MBP) creation and custom organisations.

See [JENKINS-45442](https://issues.jenkins-ci.org/browse/JENKINS-45442) / [JENKINS-45482](https://issues.jenkins-ci.org/browse/JENKINS-45482) / [JENKINS-45360](https://issues.jenkins-ci.org/browse/JENKINS-45260)

To Manually test, build and deploy inside a setup that uses a custom organisation.

- Create a GitHubOrg limited to one repo.
- Update the GitHUb Org (add a different repo)
- Create a MBP from a git repo
- try and create a MBP from the same repo

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 