### PR TITLE
Bump cloudbees-folder-plugin to 6.1.0 to fix classic dashboard error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.0.4</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
branch-api-plugin 2.0.11 depends on cloudbees-folder-plugin 6.1.0, it uses code from it. This is causing classic page load failure with:

```
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NoSuchMethodError: com.cloudbees.hudson.plugins.folder.AbstractFolder.isDisabled()Z
	at jenkins.branch.MetadataActionFolderIcon.getIconClassName(MetadataActionFolderIcon.java:73)
	... 152 more
```

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
