### PR TITLE
Since version 1.6, the GitHub Organization Folder has been an obsolete tombstone

### DIFF
--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -24,12 +24,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>github-organization-folder</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -395,11 +395,6 @@
             <version>1.3.1</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-organization-folder</artifactId>
-            <version>1.6</version>
-        </dependency>
-        <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
             <version>1.27.0</version>


### PR DESCRIPTION
No need for installations to keep installing it anew, the required functionality
has been incorporated into the github-branch-source plugin.

See: https://github.com/jenkinsci/github-organization-folder-plugin


![Cheeky monkey!](https://github.com/rtyler/codevalet/raw/master/assets/monkey-128.png)