### PR TITLE
JENKINS-45589 Fix NPE when matching queued items

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
@@ -21,7 +21,7 @@ public class QueueUtil {
     public static BlueQueueItem getQueuedItem(final hudson.model.Queue.Item item, Job job) {
 
         for(BlueQueueItem qi: getQueuedItems(job)){
-            if(qi.getId().equalsIgnoreCase(Long.toString(item.getId()))){
+            if(qi.getId() != null && qi.getId().equalsIgnoreCase(Long.toString(item.getId()))){
                 return qi;
             }
         }


### PR DESCRIPTION
# Description

```
Caused by: java.lang.NullPointerException
    at io.jenkins.blueocean.service.embedded.rest.QueueUtil.getQueuedItem(QueueUtil.java:24)
    at io.jenkins.blueocean.events.BlueMessageEnricher.enrich(BlueMessageEnricher.java:96)
    at org.jenkinsci.plugins.pubsub.PubsubBus.publish(PubsubBus.java:133)
    ... 21 more
```

Reported on [JENKINS-45589](https://issues.jenkins-ci.org/browse/JENKINS-45589) but unrelated to that issue.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
