### PR TITLE
JENKINS-45589 check for null when using OrganizationFactory

### DIFF
--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -71,13 +71,16 @@ public class BlueMessageEnricher extends MessageEnricher {
             if(jobChannelItem == null){
                 return;
             }
+
             Link jobUrl = LinkResolver.resolveLink(jobChannelItem);
+            if (jobUrl == null) {
+                return;
+            }
 
             BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(jobChannelItem);
             if (org!=null) {
                 message.set(EventProps.Jenkins.jenkins_org, org.getName());
             }
-
             jobChannelMessage.set(BlueEventProps.blueocean_job_rest_url, jobUrl.getHref());
             jobChannelMessage.set(BlueEventProps.blueocean_job_pipeline_name, AbstractPipelineImpl.getFullName(org, jobChannelItem));
             if (jobChannelItem instanceof WorkflowJob) {

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -4,7 +4,10 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import hudson.model.Job;
+import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineContainer;
 import io.jenkins.blueocean.rest.model.BlueRun;
@@ -131,10 +134,14 @@ public class BranchContainerImpl extends BluePipelineContainer {
     @Override
     public BluePipeline get(String name) {
         Job job = pipeline.mbp.getItem(name);
-        if(job != null){
-            return new BranchImpl(job, getLink());
+        if (job == null) {
+            return null;
         }
-        return null;
+        BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(job);
+        if (organization == null) {
+            return null;
+        }
+        return new BranchImpl(organization, job, getLink());
     }
 
     @Override
@@ -145,6 +152,10 @@ public class BranchContainerImpl extends BluePipelineContainer {
     @Override
     @SuppressWarnings("unchecked")
     public Iterator<BluePipeline> iterator(int start, int limit) {
+        final BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(pipeline.mbp.getItemGroup());
+        if (organization == null) {
+            throw new ServiceException.UnexpectedErrorException("Could not find organization for " + pipeline.mbp.getFullName());
+        }
         final Link link = getLink();
         // Filter will decide if the requester wants branches or pull requests
         Collection allJobsMatchinFilter = ContainerFilter.filter(pipeline.mbp.getAllJobs());
@@ -152,7 +163,7 @@ public class BranchContainerImpl extends BluePipelineContainer {
         Iterable<BluePipeline> branches = Iterables.transform(allJobsMatchinFilter, new Function<Job, BluePipeline>() {
             @Override
             public BluePipeline apply(Job input) {
-                return new BranchImpl(input, link);
+                return new BranchImpl(organization, input, link);
             }
         });
         // Order them using the comparator

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchImpl.java
@@ -11,7 +11,9 @@ import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BluePipelineScm;
 import io.jenkins.blueocean.rest.model.Resource;
@@ -37,8 +39,8 @@ public class BranchImpl extends PipelineImpl {
     private final Link parent;
     protected final Job job;
 
-    public BranchImpl(Job job, Link parent) {
-        super(job);
+    public BranchImpl(BlueOrganization org, Job job, Link parent) {
+        super(org, job);
         this.job = job;
         this.parent = parent;
     }
@@ -76,8 +78,9 @@ public class BranchImpl extends PipelineImpl {
 
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
-            if (item instanceof WorkflowJob && item.getParent() instanceof MultiBranchProject) {
-                return new BranchImpl((Job) item, parent.getLink());
+            BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(item);
+            if (org != null && item instanceof WorkflowJob && item.getParent() instanceof MultiBranchProject) {
+                return new BranchImpl(org, (Job) item, parent.getLink());
             }
             return null;
         }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -71,6 +71,9 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
     public MultiBranchPipelineImpl(MultiBranchProject mbp) {
         this.mbp = mbp;
         this.org = OrganizationFactory.getInstance().getContainingOrg((ItemGroup) mbp);
+        if (this.org == null) {
+            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for %s", mbp.getFullName()));
+        }
         this.self = org.getLink().rel("pipelines").rel(PipelineImpl.getRecursivePathFromFullName(this));
     }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -93,7 +93,11 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
             throw new ServiceException.BadRequestException("no default branch to favorite");
         }
         FavoriteUtil.toggle(favoriteAction, job);
-        return new FavoriteImpl(new BranchImpl(job, getLink().rel("branches")), getLink().rel("favorite"));
+        BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(job);
+        if (org == null) {
+            throw new ServiceException.UnexpectedErrorException("Could not find org for " + job.getFullName());
+        }
+        return new FavoriteImpl(new BranchImpl(org, job, getLink().rel("branches")), getLink().rel("favorite"));
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
@@ -6,6 +6,8 @@ import hudson.model.Job;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.Resource;
 import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
@@ -18,8 +20,8 @@ import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_WORKFLOW
  */
 @Capability({JENKINS_WORKFLOW_JOB})
 public class PipelineImpl extends AbstractPipelineImpl {
-    protected PipelineImpl(Job job) {
-        super(job);
+    protected PipelineImpl(BlueOrganization organization, Job job) {
+        super(organization, job);
     }
 
     @Extension(ordinal = 1)
@@ -27,8 +29,9 @@ public class PipelineImpl extends AbstractPipelineImpl {
 
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
-            if (item instanceof WorkflowJob) {
-                return new PipelineImpl((Job) item);
+            BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(item);
+            if (org != null && item instanceof WorkflowJob) {
+                return new PipelineImpl(org, (Job) item);
             }
             return null;
         }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -14,6 +14,7 @@ import hudson.security.LegacyAuthorizationStrategy;
 import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.LinkResolver;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
 import io.jenkins.blueocean.rest.model.Resource;
 import jenkins.branch.BranchProperty;
@@ -96,8 +97,9 @@ public class MultiBranchTest extends PipelineBaseTest {
 
     @Test
     public void testGetURL() {
+        BlueOrganization org = mock(BlueOrganization.class);
         Job job = mock(Job.class);
-        BranchImpl branch = new BranchImpl(job, new Link("foo"));
+        BranchImpl branch = new BranchImpl(org, job, new Link("foo"));
         assertNotNull(branch.getBranch());
         assertNull(branch.getBranch().getUrl());
         assertFalse(branch.getBranch().isPrimary());
@@ -108,8 +110,9 @@ public class MultiBranchTest extends PipelineBaseTest {
 
     @Test
     public void testBranchInfo() {
+        BlueOrganization org = mock(BlueOrganization.class);
         Job job = mock(Job.class);
-        BranchImpl branch = new BranchImpl(job, new Link("foo"));
+        BranchImpl branch = new BranchImpl(org, job, new Link("foo"));
         assertNotNull(branch.getBranch());
         assertNull(branch.getBranch().getUrl());
         assertFalse(branch.getBranch().isPrimary());

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -61,6 +61,9 @@ public class AbstractPipelineImpl extends BluePipeline {
     protected AbstractPipelineImpl(Job job) {
         this.job = job;
         this.org = OrganizationFactory.getInstance().getContainingOrg(job);
+        if (this.org == null) {
+            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for job %s", job.getFullName()));
+        }
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -58,12 +58,9 @@ public class AbstractPipelineImpl extends BluePipeline {
     private final Job job;
     protected final BlueOrganization org;
 
-    protected AbstractPipelineImpl(Job job) {
+    protected AbstractPipelineImpl(BlueOrganization organization, Job job) {
         this.job = job;
-        this.org = OrganizationFactory.getInstance().getContainingOrg(job);
-        if (this.org == null) {
-            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for job %s", job.getFullName()));
-        }
+        this.org = organization;
     }
 
     @Override
@@ -256,8 +253,9 @@ public class AbstractPipelineImpl extends BluePipeline {
 
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
-            if (item instanceof Job) {
-                return new AbstractPipelineImpl((Job) item);
+            BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(item);
+            if (org != null && item instanceof Job) {
+                return new AbstractPipelineImpl(org, (Job) item);
             }
             return null;
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -4,6 +4,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import hudson.model.Action;
 import hudson.model.CauseAction;
+import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.blueocean.commons.ServiceException;
@@ -45,7 +46,11 @@ public class AbstractRunImpl<T extends Run> extends BlueRun {
     public AbstractRunImpl(T run, Reachable parent) {
         this.run = run;
         this.parent = parent;
-        this.org = OrganizationFactory.getInstance().getContainingOrg(run);
+        Job job = run.getParent();
+        this.org = OrganizationFactory.getInstance().getContainingOrg(job);
+        if (this.org == null) {
+            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for job %s", job.getFullName()));
+        }
     }
 
     @Nonnull

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineContainerImpl.java
@@ -44,6 +44,9 @@ public class PipelineContainerImpl extends BluePipelineContainer {
     public PipelineContainerImpl(ItemGroup itemGroup, Reachable parent) {
         this.itemGroup = itemGroup instanceof Jenkins ? new PermissionFilteredItemGroup((Jenkins) itemGroup) : itemGroup;
         this.org = OrganizationFactory.getInstance().getContainingOrg(itemGroup);
+        if (this.org == null) {
+            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for %s", itemGroup.getFullName()));
+        }
         if(parent!=null){
             this.self = parent.getLink().rel("pipelines");
         }else{

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -39,6 +39,9 @@ public class PipelineFolderImpl extends BluePipelineFolder {
 
     public PipelineFolderImpl(ItemGroup folder, Link parent) {
         this.org = OrganizationFactory.getInstance().getContainingOrg(folder);
+        if (this.org == null) {
+            throw new ServiceException.UnexpectedErrorException(String.format("could not find organization for %s", folder.getFullName()));
+        }
         this.folder = folder;
         this.parent = parent;
     }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueItemImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueItemImpl.java
@@ -6,6 +6,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.Links;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
 import io.jenkins.blueocean.rest.model.BlueRun;
@@ -50,12 +51,12 @@ public class QueueItemImpl extends BlueQueueItem {
 
     @Override
     public String getOrganization() {
-        if (item.task instanceof Item) {
-            Item i = (Item) item.task;
-            return OrganizationFactory.getInstance().getContainingOrg(i).getName();
-        } else {
+        if (!(item.task instanceof Item)) {
             return null;
         }
+        Item i = (Item) item.task;
+        BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(i);
+        return organization == null ? null : organization.getName();
     }
 
     @Override

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -34,6 +34,7 @@ import hudson.tasks.junit.TestResultAction;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.annotation.Capability;
 import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueArtifact;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
@@ -596,7 +597,8 @@ public class PipelineApiTest extends BaseTest {
         @Override
         public BluePipeline getPipeline(Item item, Reachable parent) {
             if(item instanceof TestProject){
-                return new TestPipelineImpl((Job)item);
+                BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(item);
+                return new TestPipelineImpl(organization, (Job)item);
             }
             return null;
         }
@@ -610,8 +612,8 @@ public class PipelineApiTest extends BaseTest {
     @Capability({"io.jenkins.blueocean.rest.annotation.test.TestPipeline", "io.jenkins.blueocean.rest.annotation.test.TestPipelineExample"})
     public static class TestPipelineImpl extends AbstractPipelineImpl {
 
-        public TestPipelineImpl(Job job) {
-            super(null, job);
+        public TestPipelineImpl(BlueOrganization organization, Job job) {
+            super(organization, job);
         }
 
         @Exported(name = "hello")

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -611,7 +611,7 @@ public class PipelineApiTest extends BaseTest {
     public static class TestPipelineImpl extends AbstractPipelineImpl {
 
         public TestPipelineImpl(Job job) {
-            super(job);
+            super(null, job);
         }
 
         @Exported(name = "hello")

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BluePipelineFactory.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BluePipelineFactory.java
@@ -58,6 +58,9 @@ public abstract class BluePipelineFactory implements ExtensionPoint {
      */
     public static Resource resolve(Item item) {
         BlueOrganization org = OrganizationFactory.getInstance().getContainingOrg(item);
+        if (org == null) {
+            return null;
+        }
         Item nextStep = findNextStep(Jenkins.getInstance(), item);
 
         for (BluePipelineFactory f : all()) {

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/organization/OrganizationFactory.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/organization/OrganizationFactory.java
@@ -9,6 +9,8 @@ import io.jenkins.blueocean.rest.model.BlueOrganization;
 import jenkins.model.ModifiableTopLevelItemGroup;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
@@ -52,6 +54,7 @@ public abstract class OrganizationFactory implements ExtensionPoint {
      * @return
      *      null if the given object doesn't belong to any organization.
      */
+    @CheckForNull
     public BlueOrganization getContainingOrg(ItemGroup p) {
         while (true) {
             BlueOrganization n = of(p);
@@ -66,10 +69,19 @@ public abstract class OrganizationFactory implements ExtensionPoint {
         }
     }
 
+    /**
+     * Use {@link #getContainingOrg(Item)} instead.
+     * @deprecated in 1.2
+     * @param r run
+     * @return organization
+     */
+    @CheckForNull
+    @Deprecated
     public final BlueOrganization getContainingOrg(Run r) {
         return getContainingOrg(r.getParent());
     }
 
+    @CheckForNull
     public final BlueOrganization getContainingOrg(Item i) {
         if (i instanceof ItemGroup) {
             return getContainingOrg((ItemGroup) i);
@@ -78,6 +90,7 @@ public abstract class OrganizationFactory implements ExtensionPoint {
         }
     }
 
+    @Nonnull
     public static OrganizationFactory getInstance() {
         OrganizationFactory r = ExtensionList.lookup(OrganizationFactory.class).get(0);
         if (r==null) {

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/organization/OrganizationFactory.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/organization/OrganizationFactory.java
@@ -10,7 +10,6 @@ import jenkins.model.ModifiableTopLevelItemGroup;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**


### PR DESCRIPTION
# Description

It's possible not to get back a valid `BlueOrganization` when using methods on `OrganizationFactory`. There still feels like there is a bug somewhere here but without paths for the items that we are resolving there is no way to tell.

This should add some better exception messages and setup expectations that `OrganizationFactory` may not work in some circumstances.

See [JENKINS-45589](https://issues.jenkins-ci.org/browse/JENKINS-45589).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
