### PR TITLE
JENKINS-45748 Blue Ocean display URL provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>blueocean-display-url</artifactId>
-            <version>2.0</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Upgrade to Blue Ocean display URL provider 2.1.0

# Description

Just bumping the POM to incorporate https://github.com/jenkinsci/blueocean-display-url-plugin/pull/8

See [JENKINS-45748](https://issues.jenkins-ci.org/browse/JENKINS-45748).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
