### PR TITLE
Bitbucket username and password fields should be full width

### DIFF
--- a/blueocean-dashboard/src/main/js/creation/bitbucket/steps/BbCredentialStep.jsx
+++ b/blueocean-dashboard/src/main/js/creation/bitbucket/steps/BbCredentialStep.jsx
@@ -112,7 +112,7 @@ export default class BbCredentialsStep extends React.Component {
         };
 
         return (
-            <FlowStep {...this.props} className="github-credentials-step" disabled={disabled} title={title}>
+            <FlowStep {...this.props} className="bitbucket-credentials-step" disabled={disabled} title={title}>
                 <p className="instructions">
                     {t('creation.bitbucket.connect.authorize')}. &nbsp;
                 </p>

--- a/blueocean-dashboard/src/main/less/creation/bitbucket.less
+++ b/blueocean-dashboard/src/main/less/creation/bitbucket.less
@@ -1,0 +1,6 @@
+.bitbucket-credentials-step {
+    .text-username,
+    .text-password {
+        width: 100%;
+    }
+}

--- a/blueocean-dashboard/src/main/less/creation/index.less
+++ b/blueocean-dashboard/src/main/less/creation/index.less
@@ -3,6 +3,7 @@
 @import 'git';
 @import 'github';
 @import 'github-enterprise';
+@import 'bitbucket';
 
 .create-pipeline {
     .ContentPageHeader-main {


### PR DESCRIPTION
# Description

Set username / password fields in Bitbucket cloud login step to 100% width

See [JENKINS-45560](https://issues.jenkins-ci.org/browse/JENKINS-45560).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

