### PR TITLE
JENKINS-46009 Pipeline graph on safari is incorrectly placed to the left

### DIFF
--- a/blueocean-dashboard/src/main/less/pipeline-run-graph.less
+++ b/blueocean-dashboard/src/main/less/pipeline-run-graph.less
@@ -1,6 +1,7 @@
 .PipelineGraph-container {
     display: flex;
     flex-direction: column;
+    align-items: center;
     overflow: auto;
     margin-bottom: 16px;
     max-height: ~"calc(70vh - 120px)"; // Leave room for header (120px) and log (30vh)


### PR DESCRIPTION
bug/JENKINS-46009-safari-pipeline-alignment * Fix pipeline graph alignment issue in Safari

# Description

See [JENKINS-46009](https://issues.jenkins-ci.org/browse/JENKINS-46009).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

