### PR TITLE
JENKINS-46156 Only attempt to stop a run once when the user clicks the stop link

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -216,14 +216,11 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
                     throw new ServiceException.BadRequestException("timeOutInSecs must be >= 0");
                 }
 
-                long timeOutInMillis = timeOutInSecs*1000;
+                stoppableRun.stop();
 
+                long timeOutInMillis = timeOutInSecs*1000;
                 long sleepingInterval = timeOutInMillis/10; //one tenth of timeout
                 do{
-                    if(isCompletedOrAborted()){
-                        return this;
-                    }
-                    stoppableRun.stop();
                     if(isCompletedOrAborted()){
                         return this;
                     }


### PR DESCRIPTION
# Description

See [JENKINS-46156](https://issues.jenkins-ci.org/browse/JENKINS-46156).

Previously, Blue Ocean would send the stop signal to a job multiple times until the job completed.
This did not allow jobs to handle aborts properly.

For example, if a job caught the abort exception, and needed to execute some additional steps to cleanup, Blue Ocean would send more stop signals while the job was attempting to clean up.

Now, Blue Ocean will send the stop signal once, and wait for the job to complete.

No existing unit test for the stop workflow to modify.  Just trying to speed up getting this fixed. 

### Manual Test

1. Create a job with the scripted pipeline from [JENKINS-46156](https://issues.jenkins-ci.org/browse/JENKINS-46156).
2. Run it
3. Abort it via the Blue Ocean UI
4. Ensure that the sh step in the cleanup stage succeeds


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

