### PR TITLE
Enable ANSI colours for night watch

### DIFF
--- a/acceptance-tests/src/main/nightwatch.json
+++ b/acceptance-tests/src/main/nightwatch.json
@@ -6,7 +6,7 @@
   "custom_commands_path": "src/main/js/custom_commands",
   "custom_assertions_path": "src/main/js/custom_assertions",
   "globals_path": "src/main/js/globals.js",
-  "disable_colors": true,
+  "disable_colors": false,
   "page_objects_path": [
     "src/main/js/page_objects/classic_jenkins",
     "src/main/js/page_objects/blueocean"


### PR DESCRIPTION
# Description

I disabled this ages ago as ANSI color appeared as garbage. But now due to @sophistifunk wizardry everything is perfect.

https://github.com/jenkinsci/blueocean-acceptance-test/pull/141/files

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
