### PR TITLE
use @Ignore so tests show up on skipped report

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -25,6 +25,7 @@ import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -50,7 +51,7 @@ public class AbstractRunImplTest extends PipelineBaseTest {
         sampleRepo.init();
     }
     //Disabled, see JENKINS-36453
-    //@Test
+    @Test @Ignore
     public void replayRunTest() throws Exception {
         WorkflowJob job1 = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
         j.createOnlineSlave(Label.get("remote"));
@@ -83,7 +84,7 @@ public class AbstractRunImplTest extends PipelineBaseTest {
     }
 
     // Disabled, see JENKINS-40084
-    // @Test
+    @Test @Ignore
     public void replayRunTestMB() throws Exception {
         j.createOnlineSlave(Label.get("remote"));
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -37,6 +37,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -1049,7 +1050,7 @@ public class MultiBranchTest extends PipelineBaseTest {
 
 
     //Disabled test for now as I can't get it to work. Tested manually.
-    //@Test
+    @Test @Ignore
     public void getPipelineJobrRuns() throws Exception {
         WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
         sampleRepo1.init();

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineApiTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineApiTest.java
@@ -14,6 +14,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.stapler.AcceptHeader;
 import org.kohsuke.stapler.export.Exported;
@@ -73,7 +74,7 @@ public class PipelineApiTest extends PipelineBaseTest {
     }
 
     //TODO: Fix test - see JENKINS-38319
-    //@Test
+    @Test @Ignore
     public void getPipelineRunblockingStopTest() throws Exception {
         WorkflowJob job1 = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -24,6 +24,7 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -78,7 +79,7 @@ public class PipelineNodeTest extends PipelineBaseTest {
     }
 
     //TODO: Enable this test if there is way to determine when test starts running and not waiting till launched
-//    @Test
+    @Test @Ignore
     public void nodesTest1() throws IOException, ExecutionException, InterruptedException {
         WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "p1");
         job.setDefinition(new CpsFlowDefinition("node {\n" +

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ArtifactContainerImplTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ArtifactContainerImplTest.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.Shell;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -31,7 +32,8 @@ public class ArtifactContainerImplTest extends BaseTest {
         Assert.assertEquals("/job/artifactTest/1/artifact/test/me/out/0.txt", ((Map) artifacts.get(0)).get("url"));
      }
 
-    //@Test TODO needs viveks input
+    // TODO: needs viveks input
+    @Test @Ignore
     public void testArtifact() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject(JOB_NAME);
         p.getBuildersList().add(new Shell("mkdir -p test/me/out; touch test/me/out/{{a..z},{A..Z},{0..99}}.txt"));

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -46,6 +46,7 @@ import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
 import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
@@ -236,7 +237,7 @@ public class PipelineApiTest extends BaseTest {
     }
 
     /** TODO: latest stapler change broke delete, disabled for now */
-//    @Test
+    @Test @Ignore
     public void deletePipelineTest() throws IOException {
         Project p = j.createFreeStyleProject("pipeline1");
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
@@ -101,7 +101,7 @@ public class ProfileApiTest extends BaseTest{
     //XXX: There is no method on User API to respond to POST or PUT or PATH. Since there are other tests that
     // does POST, PUT for successful case, its ok to disable them.
     //UX-159
-//    @Test
+    @Test @Ignore
     public void postCrumbTest() throws Exception {
         User system = j.jenkins.getUser("SYSTEM");
         Map response = post("/users/"+system.getId()+"/", Collections.emptyMap());
@@ -118,7 +118,7 @@ public class ProfileApiTest extends BaseTest{
     }
 
     //UX-159
-    //@Test
+    @Test @Ignore
     public void putMimeTest() throws Exception {
         User system = j.jenkins.getUser("SYSTEM");
         Map response = put("/users/"+system.getId()+"/", Collections.emptyMap());
@@ -133,7 +133,7 @@ public class ProfileApiTest extends BaseTest{
     }
 
     //UX-159
-//    @Test
+    @Test @Ignore
     public void patchMimeTest() throws Exception {
         User system = j.jenkins.getUser("SYSTEM");
 


### PR DESCRIPTION
# Description
- When we have to disable flaky or broken tests, we should use `@Ignore` so they show up on the skipped report.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

