### PR TITLE
Add another response header to log requests to show delivered size in bytes for paging

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
@@ -86,7 +86,8 @@ public class LogResource{
                 text = appenderLogReader.read();
             }
         }
-        rsp.addHeader("X-Text-Size",String.valueOf(r));
+        rsp.addHeader("X-Text-Size", String.valueOf(r));
+        rsp.addHeader("X-Text-Delivered", String.valueOf(r - offset));
         w.close();
 
     }


### PR DESCRIPTION
# Description

Adds a new header X-Text-Delivered to the log response to make paging easier.

See [JENKINS-44699](https://issues.jenkins-ci.org/browse/JENKINS-44699).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

