### PR TITLE
HOTFIX: use Jacksons string encoder for JSON output

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
@@ -23,6 +23,8 @@
 
 package io.jenkins.blueocean.commons.stapler.export;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Writer;
@@ -103,17 +105,7 @@ class JSONDataWriter implements DataWriter {
     public void value(String v) throws IOException {
         StringBuilder buf = new StringBuilder(v.length());
         buf.append('\"');
-        for( int i=0; i<v.length(); i++ ) {
-            char c = v.charAt(i);
-            switch(c) {
-                case '"':   buf.append("\\\"");break;
-                case '\\':  buf.append("\\\\");break;
-                case '\n':  buf.append("\\n");break;
-                case '\r':  buf.append("\\r");break;
-                case '\t':  buf.append("\\t");break;
-                default:    buf.append(c);break;
-            }
-        }
+        JsonStringEncoder.getInstance().quoteAsString(v, buf);
         buf.append('\"');
         data(buf.toString());
     }

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
@@ -36,6 +36,9 @@ import java.lang.reflect.Type;
  * @author Kohsuke Kawaguchi
  */
 class JSONDataWriter implements DataWriter {
+
+    private static final JsonStringEncoder jsonEncoder = new JsonStringEncoder ();
+
     protected boolean needComma;
     protected final Writer out;
     protected final ExportConfig config;
@@ -105,7 +108,8 @@ class JSONDataWriter implements DataWriter {
     public void value(String v) throws IOException {
         StringBuilder buf = new StringBuilder(v.length());
         buf.append('\"');
-        JsonStringEncoder.getInstance().quoteAsString(v, buf);
+        // TODO: remove when JENKINS-45099 has been fixed correctly in upstream stapler
+        jsonEncoder.quoteAsString(v, buf);
         buf.append('\"');
         data(buf.toString());
     }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -2381,6 +2381,52 @@ public class PipelineNodeTest extends PipelineBaseTest {
         assertEquals(edges.get(2).get("id"), receivedEdges.get(2).get("id"));
     }
 
+    @Test
+    public void encodedStepDescription() throws Exception {
+        setupScm("pipeline {\n" +
+                "  agent any\n" +
+                "  stages {\n" +
+                "    stage('Build') {\n" +
+                "      steps {\n" +
+                "          sh 'echo \"\\033[32m some text \\033[0m\"'    \n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+        WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false)));
+        for (SCMSource source : mp.getSCMSources()) {
+            assertEquals(mp, source.getOwner());
+        }
+
+        mp.scheduleBuild2(0).getFuture().get();
+
+        j.waitUntilNoActivity();
+
+        WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
+        j.waitUntilNoActivity();
+        WorkflowRun b1 = p.getLastBuild();
+        Assert.assertEquals(Result.SUCCESS, b1.getResult());
+
+        List<FlowNode> stages = getStages(NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(b1));
+
+        Assert.assertEquals(1, stages.size());
+
+        Assert.assertEquals("Build", stages.get(0).getDisplayName());
+
+        List<Map> resp = get("/organizations/jenkins/pipelines/p/pipelines/master/runs/"+b1.getId()+"/nodes/", List.class);
+        Assert.assertEquals(1, resp.size());
+        Assert.assertEquals("Build", resp.get(0).get("displayName"));
+
+        resp = get("/organizations/jenkins/pipelines/p/pipelines/master/runs/"+b1.getId()+"/steps/", List.class);
+        Assert.assertEquals(2, resp.size());
+
+        assertEquals("General SCM", resp.get(0).get("displayName"));
+
+        assertEquals("Shell Script", resp.get(1).get("displayName"));
+        assertEquals("echo \"\u001B[32m some text \u001B[0m\"", resp.get(1).get("displayDescription"));
+    }
+
     private void setupScm(String script) throws Exception {
         // create git repo
         sampleRepo.init();


### PR DESCRIPTION
# Description
We need to get something in here until we've got a real fix upstream in Stapler.

@kohsuke we should discuss the role of Stapler in JSON generation. It doesn't quite work and I think we would be better off using Jackson.

# Steps to reproduce

1. Run `https://github.com/i386/colortest`
2. Steps don't load due to invalid characters in the step name

# What you should see

After running this PR

![screencapture-localhost-8080-jenkins-blue-organizations-jenkins-i386-2fnyancat-detail-master-3-pipeline-1503310468752](https://user-images.githubusercontent.com/50156/29514850-6264b44e-86ad-11e7-8372-a4f7345f28ae.png)

See [JENKINS-45099](https://issues.jenkins-ci.org/browse/JENKINS-45099).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given