### PR TITLE
Hotfix/js extensions revert

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubAddServerDialogPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubAddServerDialogPage.java
@@ -44,6 +44,7 @@ public class GithubAddServerDialogPage {
 
 
     public void enterServerName(String name) {
+        logger.info(String.format("enter server name '%s", name));
         WebElementUtils.setText(
             wait.until(ExpectedConditions.visibilityOf(textName)),
             name
@@ -51,6 +52,7 @@ public class GithubAddServerDialogPage {
     }
 
     public void enterServerUrl(String url) {
+        logger.info(String.format("enter server url '%s", url));
         WebElementUtils.setText(
             wait.until(ExpectedConditions.visibilityOf(textUrl)),
             url
@@ -58,6 +60,7 @@ public class GithubAddServerDialogPage {
     }
 
     public void clickSaveServerButton() {
+        logger.info("clicking save button");
         wait.until(ExpectedConditions.visibilityOf(buttonCreate)).click();
     }
 

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEnterpriseCreationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEnterpriseCreationTest.java
@@ -81,6 +81,7 @@ public class GithubEnterpriseCreationTest {
 
         // valid form data should submit
         dialog.enterServerUrl(serverUrl);
+        dialog.waitForErrorMessagesGone();
         dialog.clickSaveServerButton();
 
         // As currently api.github.com may up in list thank to github branch source, this can mess up this test

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.152-SNAPSHOT",
+  "version": "0.0.152",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -14,9 +14,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.37-SNAPSHOT-2",
-      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
+      "version": "0.0.37",
+      "from": "@jenkins-cd/js-extensions@0.0.37",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",

--- a/blueocean-core-js/npm-shrinkwrap.json
+++ b/blueocean-core-js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.151-SNAPSHOT",
+  "version": "0.0.152-SNAPSHOT",
   "dependencies": {
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -14,9 +14,9 @@
       "dev": true
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.36",
-      "from": "@jenkins-cd/js-extensions@0.0.36",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36.tgz"
+      "version": "0.0.37-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",
@@ -7160,9 +7160,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },
@@ -7525,7 +7525,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "from": "setimmediate@>=1.0.5 <2.0.0",
+      "from": "setimmediate@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
     "setprototypeof": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.152-SNAPSHOT",
+  "version": "0.0.152-SNAPSHOT-1",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.36",
+    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.10",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/sse-gateway": "0.0.21",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.152-SNAPSHOT-1",
+  "version": "0.0.152",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
+    "@jenkins-cd/js-extensions": "0.0.37",
     "@jenkins-cd/js-modules": "0.0.10",
     "@jenkins-cd/logging": "0.0.6",
     "@jenkins-cd/sse-gateway": "0.0.21",

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/blueocean-core-js",
-  "version": "0.0.152",
+  "version": "0.0.153-SNAPSHOT",
   "description": "Shared JavaScript libraries for use with Jenkins Blue Ocean",
   "main": "dist/js/index.js",
   "scripts": {

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.151",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.151",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.151.tgz"
+      "version": "0.0.152-SNAPSHOT-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -53,9 +53,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.36",
-      "from": "@jenkins-cd/js-extensions@0.0.36",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36.tgz"
+      "version": "0.0.37-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",
@@ -7675,9 +7675,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },

--- a/blueocean-dashboard/npm-shrinkwrap.json
+++ b/blueocean-dashboard/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.152-SNAPSHOT-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
+      "version": "0.0.152",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -53,9 +53,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.37-SNAPSHOT-2",
-      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
+      "version": "0.0.37",
+      "from": "@jenkins-cd/js-extensions@0.0.37",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -43,9 +43,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.151",
+    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.36",
+    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.10",
     "@jenkins-cd/preferences": "0.0.4",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -43,9 +43,9 @@
     "skin-deep": "0.16.0"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.152",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
+    "@jenkins-cd/js-extensions": "0.0.37",
     "@jenkins-cd/js-modules": "0.0.10",
     "@jenkins-cd/preferences": "0.0.4",
     "babel-plugin-transform-decorators-legacy": "1.3.4",

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.151",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.151",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.151.tgz"
+      "version": "0.0.152-SNAPSHOT-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -53,9 +53,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.36",
-      "from": "@jenkins-cd/js-extensions@0.0.36",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36.tgz"
+      "version": "0.0.37-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",
@@ -7655,9 +7655,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },

--- a/blueocean-personalization/npm-shrinkwrap.json
+++ b/blueocean-personalization/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.2-unpublished",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.152-SNAPSHOT-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
+      "version": "0.0.152",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -53,9 +53,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.37-SNAPSHOT-2",
-      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
+      "version": "0.0.37",
+      "from": "@jenkins-cd/js-extensions@0.0.37",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -39,9 +39,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.151",
+    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.36",
+    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.10",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -39,9 +39,9 @@
     "react-addons-test-utils": "15.3.2"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.152",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
+    "@jenkins-cd/js-extensions": "0.0.37",
     "@jenkins-cd/js-modules": "0.0.10",
     "immutable": "3.8.1",
     "keymirror": "0.1.1",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.152-SNAPSHOT-1",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
+      "version": "0.0.152",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -39,9 +39,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.37-SNAPSHOT-2",
-      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
+      "version": "0.0.37",
+      "from": "@jenkins-cd/js-extensions@0.0.37",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",

--- a/blueocean-web/npm-shrinkwrap.json
+++ b/blueocean-web/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "@jenkins-cd/blueocean-core-js": {
-      "version": "0.0.151",
-      "from": "@jenkins-cd/blueocean-core-js@0.0.151",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.151.tgz"
+      "version": "0.0.152-SNAPSHOT-1",
+      "from": "@jenkins-cd/blueocean-core-js@0.0.152-SNAPSHOT-1",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/blueocean-core-js/-/blueocean-core-js-0.0.152-SNAPSHOT-1.tgz"
     },
     "@jenkins-cd/design-language": {
       "version": "0.0.146",
@@ -39,9 +39,9 @@
       }
     },
     "@jenkins-cd/js-extensions": {
-      "version": "0.0.36",
-      "from": "@jenkins-cd/js-extensions@0.0.36",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.36.tgz"
+      "version": "0.0.37-SNAPSHOT-2",
+      "from": "@jenkins-cd/js-extensions@0.0.37-SNAPSHOT-2",
+      "resolved": "https://registry.npmjs.org/@jenkins-cd/js-extensions/-/js-extensions-0.0.37-SNAPSHOT-2.tgz"
     },
     "@jenkins-cd/js-modules": {
       "version": "0.0.10",
@@ -1421,9 +1421,9 @@
       "optional": true
     },
     "commander": {
-      "version": "2.9.0",
+      "version": "2.11.0",
       "from": "commander@>=2.5.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "commoner": {
       "version": "0.10.8",
@@ -2421,11 +2421,6 @@
       "version": "4.1.11",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growly": {
       "version": "1.3.0",
@@ -4482,9 +4477,9 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
         }
       }
     },

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -30,9 +30,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.151",
+    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.36",
+    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
     "@jenkins-cd/js-modules": "0.0.10",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -30,9 +30,9 @@
     "zombie": "4.2.1"
   },
   "dependencies": {
-    "@jenkins-cd/blueocean-core-js": "0.0.152-SNAPSHOT-1",
+    "@jenkins-cd/blueocean-core-js": "0.0.152",
     "@jenkins-cd/design-language": "0.0.146",
-    "@jenkins-cd/js-extensions": "0.0.37-SNAPSHOT-2",
+    "@jenkins-cd/js-extensions": "0.0.37",
     "@jenkins-cd/js-modules": "0.0.10",
     "history": "2.0.2",
     "immutable": "3.8.1",

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.36",
+  "version": "0.0.37-SNAPSHOT-2",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.37",
+  "version": "0.0.38-SNAPSHOT",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-extensions",
-  "version": "0.0.37-SNAPSHOT-2",
+  "version": "0.0.37",
   "description": "Jenkins Extension Store",
   "main": "index.js",
   "files": [

--- a/js-extensions/spec/ExtensionRenderer-spec.js
+++ b/js-extensions/spec/ExtensionRenderer-spec.js
@@ -27,8 +27,8 @@ const mockExtensionStore = {
 };
 
 const mockResourceLoadTracker = {
-    onMount: function(extensionPoint, readyCallback) {
-        readyCallback();  // Invoke immediately, just like an extension with no CSS to load
+    onMount: function() {
+        // Don't care
     },
 
     onUnmount: function() {

--- a/js-extensions/src/ExtensionRenderer.jsx
+++ b/js-extensions/src/ExtensionRenderer.jsx
@@ -20,9 +20,8 @@ export default class ExtensionRenderer extends React.Component {
     }
 
     componentDidMount() {
-        ExtensionRenderer.resourceLoadTracker.onMount(this.props.extensionPoint, () => {
+        ExtensionRenderer.resourceLoadTracker.onMount(this.props.extensionPoint);
             this._renderAllExtensions();
-        });
     }
 
     componentWillUpdate(nextProps, nextState) {

--- a/js-extensions/src/ResourceLoadTracker.js
+++ b/js-extensions/src/ResourceLoadTracker.js
@@ -69,25 +69,12 @@ export default class ResourceLoadTracker {
      *
      * @param extensionPointName The extension point name.
      */
-    onMount(extensionPointName, callback) {
+    onMount(extensionPointName) {
         const pointCSS = this.pointCSSs[extensionPointName];
         if (pointCSS) {
-            let counter = 0;
-
-            function onLoad() {
-                counter++;
-                if (counter === pointCSS.length) {
-                    callback();
-                }
-            }
-
             for (var i = 0; i < pointCSS.length; i++) {
-                this._requireCSS(pointCSS[i], () => {
-                    onLoad();
-                });
+                this._requireCSS(pointCSS[i]);
             }
-        } else {
-            callback();
         }
     }
 


### PR DESCRIPTION
# Description
- Current state of js-extensions in master did not match what was last published as 0.0.36. The revert of js-extensions in #1132 was incomplete. See df42fdf which rolls back the remaining code that was added to js-extensions in #1043.
- Also a small tweak to an ATH test case that was frequently flaky.
- Discovered while implementing code cleanup for [JENKINS-46218](https://issues.jenkins-ci.org/browse/JENKINS-46218).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

