### PR TITLE
JENKINS-46458# Add support for Bitbucket Server personal repos

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -16,7 +16,6 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbOrg;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbPage;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbRepo;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbSaveContentResponse;
-import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbUser;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerBranch;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerPage;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerProject;
@@ -24,6 +23,7 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerRe
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerSaveContentResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerUser;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
@@ -89,7 +89,7 @@ public class BitbucketServerApi extends BitbucketApi {
     }
 
     @Override
-    public @Nonnull BbUser getUser(@Nonnull String userName){
+    public @Nonnull BbServerUser getUser(@Nonnull String userName){
         try {
             InputStream inputStream = Request.Get(String.format("%s/%s",baseUrl+"users", userName))
                     .addHeader("Authorization", basicAuthHeaderValue)
@@ -100,15 +100,29 @@ public class BitbucketServerApi extends BitbucketApi {
         }
     }
 
-
     @Override
     public @Nonnull
     BbPage<BbOrg> getOrgs(int pageNumber, int pageSize){
         try {
+            if(pageNumber <= 0){
+                pageNumber = 1;
+            }
+
+            if(pageSize <=0){
+                pageSize = PagedResponse.DEFAULT_LIMIT;
+            }
             InputStream inputStream = Request.Get(String.format("%s?start=%s&limit=%s",baseUrl+"projects/", toStart(pageNumber, pageSize), pageSize))
                     .addHeader("Authorization", basicAuthHeaderValue)
                     .execute().returnContent().asStream();
-            return om.readValue(inputStream, new TypeReference<BbServerPage<BbServerProject>>(){});
+            BbPage<BbOrg> page =  om.readValue(inputStream, new TypeReference<BbServerPage<BbServerProject>>(){});
+            if(pageNumber == 1){ //add user org as the first org on first page
+                BbServerUser user = getUser(userName);
+                List<BbOrg> teams = new ArrayList<>();
+                teams.add(user.toPersonalProject());
+                teams.addAll(page.getValues());
+                return new BbServerPage<>(page.getStart(), page.getLimit(), page.getSize()+1, teams, page.isLastPage());
+            }
+            return page;
         } catch (IOException e) {
             throw handleException(e);
         }

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/model/BbServerUser.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/model/BbServerUser.java
@@ -1,10 +1,14 @@
 package io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbUser;
+import io.jenkins.blueocean.rest.Utils;
 
 import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Vivek Pandey
@@ -14,14 +18,25 @@ public class BbServerUser extends BbUser {
     private final String displayName;
     private final String slug;
     private final String emailAddress;
+    private final String avatar;
 
     @JsonCreator
     public BbServerUser(@Nonnull @JsonProperty("name") String name, @Nonnull @JsonProperty("displayName") String displayName,
-                        @Nonnull @JsonProperty("slug") String slug, @Nonnull @JsonProperty("emailAddress") String emailAddress) {
+                        @Nonnull @JsonProperty("slug") String slug, @Nonnull @JsonProperty("emailAddress") String emailAddress, @JsonProperty("links") Map<String, List<Map<String,String>>> links) {
         this.name = name;
         this.displayName = displayName;
         this.slug = slug;
         this.emailAddress = emailAddress;
+        List<Map<String,String>> hrefs = links.get("self");
+        String a =null;
+        for(Map<String,String> hrefLink: hrefs){
+            String href = hrefLink.get("href");
+            if(href != null){
+                a = Utils.ensureTrailingSlash(href)+"avatar.png?s=50";
+                break;
+            }
+        }
+        this.avatar = a;
     }
 
     @Override
@@ -50,6 +65,16 @@ public class BbServerUser extends BbUser {
 
     @Override
     public String getAvatar() {
-        return null;
+        return avatar;
+    }
+
+    /**
+     * Every user account on bitbucket server is a project with key ~{userSlug}.
+     * see 'Personal Repositories' section at https://developer.atlassian.com/static/rest/bitbucket-server/5.3.1/bitbucket-rest.html
+     * @return project key for user account
+     */
+    @JsonIgnore
+    public BbServerProject toPersonalProject(){
+        return new BbServerProject("~"+slug, getDisplayName(), avatar);
     }
 }

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
@@ -53,9 +53,10 @@ public class BitbucketApiTest extends BbServerWireMock {
     @Test
     public void getProjects() throws JsonProcessingException {
         BbPage<BbOrg> projects = api.getOrgs(1, 100);
-        assertEquals(2, projects.getSize());
-        assertEquals("TEST", projects.getValues().get(0).getKey());
-        assertEquals("TESTP", projects.getValues().get(1).getKey());
+        assertEquals(3, projects.getSize());
+        assertEquals("~vivek", projects.getValues().get(0).getKey());
+        assertEquals("TEST", projects.getValues().get(1).getKey());
+        assertEquals("TESTP", projects.getValues().get(2).getKey());
 
     }
 
@@ -72,6 +73,13 @@ public class BitbucketApiTest extends BbServerWireMock {
         assertEquals(2, repos.getSize());
         assertEquals("empty-repo-test", repos.getValues().get(0).getSlug());
         assertEquals("pipeline-demo-test", repos.getValues().get(1).getSlug());
+    }
+
+    @Test
+    public void getPersonalRepos(){
+        BbPage<BbRepo> repos = api.getRepos("~vivek", 1, 100);
+        assertEquals(1, repos.getSize());
+        assertEquals("personalrepo1", repos.getValues().get(0).getSlug());
     }
 
     @Test

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmTest.java
@@ -87,11 +87,13 @@ public class BitbucketServerScmTest extends BbServerWireMock {
             .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
             .get("/organizations/jenkins/scm/"+BitbucketServerScm.ID+"/organizations/?apiUrl="+apiUrl+"&credentialId="+credentialId)
             .build(List.class);
-        assertEquals(2, orgs.size());
-        assertEquals("test1", ((Map)orgs.get(0)).get("name"));
-        assertEquals("TEST", ((Map)orgs.get(0)).get("key"));
-        assertEquals("testproject1", ((Map)orgs.get(1)).get("name"));
-        assertEquals("TESTP", ((Map)orgs.get(1)).get("key"));
+        assertEquals(3, orgs.size());
+        assertEquals("Vivek Pandey", ((Map)orgs.get(0)).get("name"));
+        assertEquals("~vivek", ((Map)orgs.get(0)).get("key"));
+        assertEquals("test1", ((Map)orgs.get(1)).get("name"));
+        assertEquals("TEST", ((Map)orgs.get(1)).get("key"));
+        assertEquals("testproject1", ((Map)orgs.get(2)).get("name"));
+        assertEquals("TESTP", ((Map)orgs.get(2)).get("key"));
     }
 
     @Test
@@ -102,11 +104,13 @@ public class BitbucketServerScmTest extends BbServerWireMock {
                 .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
                 .get("/organizations/jenkins/scm/"+BitbucketServerScm.ID+"/organizations/?apiUrl="+apiUrl)
                 .build(List.class);
-        assertEquals(2, orgs.size());
-        assertEquals("test1", ((Map)orgs.get(0)).get("name"));
-        assertEquals("TEST", ((Map)orgs.get(0)).get("key"));
-        assertEquals("testproject1", ((Map)orgs.get(1)).get("name"));
-        assertEquals("TESTP", ((Map)orgs.get(1)).get("key"));
+        assertEquals(3, orgs.size());
+        assertEquals("Vivek Pandey", ((Map)orgs.get(0)).get("name"));
+        assertEquals("~vivek", ((Map)orgs.get(0)).get("key"));
+        assertEquals("test1", ((Map)orgs.get(1)).get("name"));
+        assertEquals("TEST", ((Map)orgs.get(1)).get("key"));
+        assertEquals("testproject1", ((Map)orgs.get(2)).get("name"));
+        assertEquals("TESTP", ((Map)orgs.get(2)).get("key"));
     }
 
     @Test

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/__files/body-_vivek-repos-ah0x0.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/__files/body-_vivek-repos-ah0x0.json
@@ -1,0 +1,64 @@
+{
+  "size": 1,
+  "limit": 100,
+  "isLastPage": true,
+  "values": [
+    {
+      "slug": "personalrepo1",
+      "id": 23,
+      "name": "personalrepo1",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "~VIVEK",
+        "id": 44,
+        "name": "vivek pandey",
+        "type": "PERSONAL",
+        "owner": {
+          "name": "VIVEK",
+          "emailAddress": "vivek@xx.com",
+          "id": 52,
+          "displayName": "vivek pandey",
+          "active": true,
+          "slug": "vivek",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "http://localhost:7990/bitbucket/users/vivek"
+              }
+            ]
+          }
+        },
+        "links": {
+          "self": [
+            {
+              "href": "http://localhost:7990/bitbucket/users/vivek"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [
+          {
+            "href": "http://VIVEK@localhost:7990/bitbucket/scm/~vivek/personalrepo1.git",
+            "name": "http"
+          },
+          {
+            "href": "ssh://git@localhost:7999/~vivek/personalrepo1.git",
+            "name": "ssh"
+          }
+        ],
+        "self": [
+          {
+            "href": "http://localhost:7990/bitbucket/users/vivek/repos/personalrepo1/browse"
+          }
+        ]
+      }
+    }
+  ],
+  "start": 0
+}

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-_vivek-repos-ah0x0.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-_vivek-repos-ah0x0.json
@@ -1,0 +1,23 @@
+{
+  "id" : "d24751e6-9915-30ad-8609-770b25c18588",
+  "request" : {
+    "url" : "/rest/api/1.0/projects/~vivek/repos/?start=0&limit=100",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "body-_vivek-repos-ah0x0.json",
+    "headers" : {
+      "X-AREQUESTID" : "@1VAZMAQx824x462x0",
+      "X-AUSERID" : "52",
+      "X-AUSERNAME" : "VIVEK",
+      "Cache-Control" : "no-cache, no-transform",
+      "Vary" : "X-AUSERNAME,Accept-Encoding",
+      "Transfer-Encoding" : "chunked",
+      "X-Content-Type-Options" : "nosniff",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Fri, 25 Aug 2017 20:44:02 GMT"
+    }
+  },
+  "uuid" : "d24751e6-9915-30ad-8609-770b25c18588"
+}


### PR DESCRIPTION
# Description

Adds support for Bitbucket server personal repos. Personal repos are repos outside projects, created in user's personal account. Its bit obscure to find how to create personal repos, but you can do that from `View Profile=>Create Repository`.

See [JENKINS-46458](https://issues.jenkins-ci.org/browse/JENKINS-46458).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
