### PR TITLE
[JENKINS-46452] Don't reference null Jira session

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
@@ -36,6 +36,9 @@ public class JiraSCMListener extends SCMListener {
         }
         String jql = constructJQLQuery(issueKeys);
         JiraSession session = jiraSite.getSession();
+        if (session == null) {
+            return;
+        }
         // Query for JIRA issues
         Set<JiraIssue> issuesFromJqlSearch = Sets.newHashSet(Iterables.transform(session.getIssuesFromJqlSearch(jql), new Function<Issue, JiraIssue>() {
             @Override


### PR DESCRIPTION
[JENKINS-46452](https://issues.jenkins-ci.org/browse/JENKINS-46452) reports null pointer exceptions which cause build failures if the Jira plugin is configured without credentials.

I use the Jira plugin to rewrite bug report URL's, but do not want it to submit updates to the bugs.  This change should allow my use model to work again.

My apologies that I have not written a test for the bug.  I'm OK if you reject this change in favor of a change which includes a test that shows the failure.

My apologies that I don't have a reliable set of steps to duplicate the problem.  I suspect that the steps would include something like:

- Build the docker image from [my lts-with-plugins branch](https://github.com/MarkEWaite/docker-lfs/tree/lts-with-plugins)
- Execute the jobs in the "Bugs - Individual Checks" folder
- Review failures, checking for a null pointer exception as described in the bug report

# Submitter checklist

- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or **explanation to why this change has no tests**
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist

- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

