### PR TITLE
JENKINS-38442 Extract layout logic from PipelineGraph into separate function + Unit Tests

### DIFF
--- a/jenkins-design-language/.eslintrc
+++ b/jenkins-design-language/.eslintrc
@@ -12,7 +12,7 @@
   "rules": {
     "eol-last": 1,
     "no-unused-vars": [2, {"varsIgnorePattern": "^React$"}],
-    "max-len": [1, 160, 4],
+    "max-len": 0,
     "no-underscore-dangle": [0],
     "object-shorthand": [0, "always"],
     "quote-props": [0, "as-needed"],

--- a/jenkins-design-language/src/js/components/index.js
+++ b/jenkins-design-language/src/js/components/index.js
@@ -26,7 +26,7 @@ export { CommitId } from './CommitId';
 export { DownloadLink } from './DownloadLink';
 export { EmptyStateView } from './EmptyStateView';
 export { EmptyStateIcon } from './EmptyStateIcon';
-export { PipelineGraph } from './PipelineGraph';
+export { PipelineGraph } from './pipeline/PipelineGraph';
 export { FileSize } from './FileSize';
 export { Toast } from './Toast';
 export { Toaster } from './Toaster';

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraph.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraph.jsx
@@ -1,96 +1,25 @@
 // @flow
 
 import React, { Component, PropTypes } from 'react';
-import { getGroupForResult, decodeResultValue } from './status/StatusIndicator';
-import { strokeWidth as nodeStrokeWidth } from './status/SvgSpinner';
-import { TruncatingLabel } from './TruncatingLabel';
+import { getGroupForResult, decodeResultValue } from '../status/StatusIndicator';
+import { strokeWidth as nodeStrokeWidth } from '../status/SvgSpinner';
+import { TruncatingLabel } from '../TruncatingLabel';
 
-import type { Result } from './status/StatusIndicator';
+import { defaultLayout } from './PipelineGraphModel';
 
-const ypStart = 55;
+import { layoutGraph } from './PipelineGraphLayout';
 
-// Dimensions used for layout, px
-export const defaultLayout = {
-    nodeSpacingH: 120,
-    nodeSpacingV: 70,
-    nodeRadius: 12,
-    terminalRadius: 7,
-    curveRadius: 12,
-    connectorStrokeWidth: 3.5,
-    labelOffsetV: 20,
-    smallLabelOffsetV: 15,
-};
-
-// Typedefs
-
-type StageInfo = {
-    name: string,
-    title: string,
-    state: Result,
-    completePercent: number,
-    id: number,
-    children: Array<StageInfo>
-};
-
-type StageNodeInfo = {
-    // -- Shared with PlaceholderNodeInfo
-    key: string,
-    x: number,
-    y: number,
-    id: number,
-    name: string,
-
-    // -- Marker
-    isPlaceholder: false,
-
-    // -- Unique
-    stage: StageInfo
-};
-
-type PlaceholderNodeInfo = {
-    // -- Shared with StageNodeInfo
-    key: string,
-    x: number,
-    y: number,
-    id: number,
-    name: string,
-
-    // -- Marker
-    isPlaceholder: true,
-
-    // -- Unique
-    type: 'start' | 'end'
-}
-
-// TODO: Attempt to extract a "common" node type with intersection operator to remove duplication
-
-type NodeInfo = StageNodeInfo | PlaceholderNodeInfo;
-
-type NodeColumn = {
-    topStage?: StageInfo,
-    nodes: Array<NodeInfo>,
-}
-
-type CompositeConnection = {
-    sourceNodes: Array<NodeInfo>,
-    destinationNodes: Array<NodeInfo>,
-    skippedNodes: Array<NodeInfo>
-};
-
-type LabelInfo = {
-    x: number,
-    y: number,
-    text: string,
-    key: string,
-    stage?: StageInfo
-};
-
-type LayoutInfo = typeof defaultLayout;
+import type {
+    NodeColumn,
+    NodeInfo,
+    LabelInfo,
+    LayoutInfo,
+    StageInfo,
+    CompositeConnection,
+} from './PipelineGraphModel';
 
 type SVGChildren = Array<any>; // Fixme: Maybe refine this?
 
-// FIXME-FLOW: Currently need to duplicate react's propTypes obj in Flow.
-// See: https://github.com/facebook/flow/issues/1770
 type Props = {
     stages: Array<StageInfo>,
     layout: LayoutInfo,
@@ -172,219 +101,7 @@ export class PipelineGraph extends Component {
      * Main process for laying out the graph. Calls a bunch of individual methods on self that do each task.
      */
     stagesUpdated(newStages: Array<StageInfo> = []) {
-
-        const stageNodeColumns = this.createNodeColumns(newStages);
-        const { nodeSpacingH } = this.state.layout;
-
-        const startNode = {
-            x: 0,
-            y: 0,
-            name: 'Start',
-            id: -1,
-            isPlaceholder: true,
-            key: 'start-node',
-            type: 'start',
-        };
-
-        const endNode = {
-            x: 0,
-            y: 0,
-            name: 'End',
-            id: -2,
-            isPlaceholder: true,
-            key: 'end-node',
-            type: 'end',
-        };
-
-        const allNodeColumns = [
-            { nodes: [startNode] },
-            ...stageNodeColumns,
-            { nodes: [endNode] },
-        ];
-
-        this.positionNodes(allNodeColumns);
-
-        const bigLabels = this.createBigLabels(allNodeColumns);
-        const smallLabels = this.createSmallLabels(allNodeColumns);
-        const connections = this.createConnections(allNodeColumns);
-
-        // Calculate the size of the graph
-        let measuredWidth = 0;
-        let measuredHeight = 200;
-
-        for (const column of allNodeColumns) {
-            for (const node of column.nodes) {
-                measuredWidth = Math.max(measuredWidth, node.x + nodeSpacingH / 2);
-                measuredHeight = Math.max(measuredHeight, node.y + ypStart);
-            }
-        }
-
-        this.setState({
-            nodeColumns: allNodeColumns,
-            connections,
-            bigLabels,
-            smallLabels,
-            measuredWidth,
-            measuredHeight,
-        });
-    }
-
-    /**
-     * Generate an array of columns, based on the top-level stages
-     */
-    createNodeColumns(topLevelStages: Array<StageInfo> = []): Array<NodeColumn> {
-
-        const nodeColumns = [];
-
-        for (const topStage of topLevelStages) {
-            // If stage has children, we don't draw a node for it, just its children
-            const stagesForColumn =
-                topStage.children && topStage.children.length ? topStage.children : [topStage];
-
-            const column = {
-                topStage,
-            };
-
-            column.nodes = stagesForColumn
-                .filter(nodeStage => !!nodeStage)
-                .map(nodeStage => ({
-                    x: 0, // Layout is done later
-                    y: 0,
-                    name: nodeStage.name,
-                    id: nodeStage.id,
-                    stage: nodeStage,
-                    isPlaceholder: false,
-                    key: 'n_' + nodeStage.id,
-                }));
-
-            nodeColumns.push(column);
-        }
-
-        return nodeColumns;
-    }
-
-    /**
-     * Walks the columns of nodes giving them x and y positions. Mutates the node objects in place for now.
-     */
-    positionNodes(nodeColumns: Array<NodeColumn>) {
-
-        const { nodeSpacingH, nodeSpacingV } = this.state.layout;
-
-        let xp = nodeSpacingH / 2;
-        let previousTopNode = null;
-
-        for (const column of nodeColumns) {
-            const topNode = column.nodes[0];
-
-            let yp = ypStart; // Reset Y to top for each column
-
-            if (previousTopNode) {
-                // Advance X position
-                if (previousTopNode.isPlaceholder || topNode.isPlaceholder) {
-                    // Don't space placeholder nodes (start/end) as wide as normal.
-                    xp += Math.floor(nodeSpacingH * 0.7);
-                } else {
-                    xp += nodeSpacingH;
-                }
-            }
-
-            for (const node of column.nodes) {
-                node.x = xp;
-                node.y = yp;
-
-                yp += nodeSpacingV;
-            }
-
-            previousTopNode = topNode;
-        }
-    }
-
-    /**
-     * Generate label descriptions for big labels at the top of each column
-     */
-    createBigLabels(columns: Array<NodeColumn>) {
-
-        const labels = [];
-
-        for (const column of columns) {
-
-            const node = column.nodes[0];
-            const stage = column.topStage;
-            const text = stage ? stage.name : node.name;
-            const key = 'l_b_' + node.key;
-
-            labels.push({
-                x: node.x,
-                y: node.y,
-                node,
-                stage,
-                text,
-                key
-            });
-        }
-
-        return labels;
-    }
-
-    /**
-     * Generate label descriptions for small labels under the nodes
-     */
-    createSmallLabels(columns: Array<NodeColumn>) {
-
-        const labels = [];
-
-        for (const column of columns) {
-            if (column.nodes.length === 1) {
-                continue; // No small labels for single-node columns
-            }
-            for (const node of column.nodes) {
-                const label:LabelInfo = {
-                    x: node.x,
-                    y: node.y,
-                    text: node.name,
-                    key: 'l_s_' + node.key,
-                };
-
-                if (node.isPlaceholder === false) {
-                    label.stage = node.stage;
-                }
-
-                labels.push(label);
-            }
-        }
-
-        return labels;
-    }
-
-    /**
-     * Generate connection information from column to column
-     */
-    createConnections(columns: Array<NodeColumn>) {
-
-        const connections = [];
-
-        let sourceNodes = [];
-        let skippedNodes = [];
-
-        for (const column of columns) {
-            if (column.topStage && column.topStage.state === 'skipped') {
-                skippedNodes.push(column.nodes[0]);
-                continue;
-            }
-
-            if (sourceNodes.length) {
-                connections.push({
-                    sourceNodes,
-                    destinationNodes: column.nodes,
-                    skippedNodes: skippedNodes
-                });
-            }
-
-            sourceNodes = column.nodes;
-            skippedNodes = [];
-        }
-
-        return connections;
+        this.setState(layoutGraph(newStages, this.state.layout));
     }
 
     /**
@@ -396,6 +113,7 @@ export class PipelineGraph extends Component {
             nodeSpacingH,
             labelOffsetV,
             connectorStrokeWidth,
+            ypStart,
         } = this.state.layout;
 
         const labelWidth = nodeSpacingH - connectorStrokeWidth * 2;
@@ -536,7 +254,8 @@ export class PipelineGraph extends Component {
             terminalRadius,
             curveRadius,
             nodeSpacingV,
-            nodeSpacingH } = this.state.layout;
+            nodeSpacingH,
+        } = this.state.layout;
 
         const halfSpacingH = nodeSpacingH / 2;
 
@@ -793,7 +512,7 @@ export class PipelineGraph extends Component {
 
         if (node.isPlaceholder === true) {
             groupChildren.push(
-                <circle r={terminalRadius} className="pipeline-node-terminal"/>
+                <circle r={terminalRadius} className="pipeline-node-terminal" />,
             );
         } else {
             const { completePercent = 0, title, state } = node.stage;
@@ -802,7 +521,7 @@ export class PipelineGraph extends Component {
             groupChildren.push(getGroupForResult(resultClean, completePercent, nodeRadius));
 
             if (title) {
-                groupChildren.push(<title>{ title }</title>);
+                groupChildren.push(<title>{title}</title>);
             }
 
             nodeIsSelected = this.stageIsSelected(node.stage);
@@ -812,7 +531,7 @@ export class PipelineGraph extends Component {
         const clickableProps = {};
 
         if (node.isPlaceholder === false && node.stage.state !== 'skipped') {
-            clickableProps.cursor = "pointer";
+            clickableProps.cursor = 'pointer';
             clickableProps.onClick = () => this.nodeClicked(node);
         }
 

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
@@ -1,0 +1,230 @@
+// @flow
+
+import React from 'react';
+
+import type {
+    NodeColumn,
+    LabelInfo,
+    LayoutInfo,
+    StageInfo,
+} from './PipelineGraphModel';
+
+// TODO: Docs
+export function layoutGraph(newStages: Array<StageInfo>, layout: LayoutInfo) {
+
+    const stageNodeColumns = createNodeColumns(newStages);
+    const { nodeSpacingH, ypStart } = layout;
+
+    const startNode = {
+        x: 0,
+        y: 0,
+        name: 'Start',
+        id: -1,
+        isPlaceholder: true,
+        key: 'start-node',
+        type: 'start',
+    };
+
+    const endNode = {
+        x: 0,
+        y: 0,
+        name: 'End',
+        id: -2,
+        isPlaceholder: true,
+        key: 'end-node',
+        type: 'end',
+    };
+
+    const allNodeColumns = [
+        { nodes: [startNode] },
+        ...stageNodeColumns,
+        { nodes: [endNode] },
+    ];
+
+    positionNodes(allNodeColumns, layout);
+
+    const bigLabels = createBigLabels(allNodeColumns);
+    const smallLabels = createSmallLabels(allNodeColumns);
+    const connections = createConnections(allNodeColumns);
+
+    // Calculate the size of the graph
+    let measuredWidth = 0;
+    let measuredHeight = 200;
+
+    for (const column of allNodeColumns) {
+        for (const node of column.nodes) {
+            measuredWidth = Math.max(measuredWidth, node.x + nodeSpacingH / 2);
+            measuredHeight = Math.max(measuredHeight, node.y + ypStart);
+        }
+    }
+
+    // TODO: Type
+    return {
+        nodeColumns: allNodeColumns,
+        connections,
+        bigLabels,
+        smallLabels,
+        measuredWidth,
+        measuredHeight,
+    };
+}
+
+/**
+ * Generate an array of columns, based on the top-level stages
+ */
+function createNodeColumns(topLevelStages: Array<StageInfo> = []): Array<NodeColumn> {
+
+    const nodeColumns = [];
+
+    for (const topStage of topLevelStages) {
+        // If stage has children, we don't draw a node for it, just its children
+        const stagesForColumn =
+            topStage.children && topStage.children.length ? topStage.children : [topStage];
+
+        const column = {
+            topStage,
+            nodes: [],
+        };
+
+        column.nodes = stagesForColumn
+            .filter(nodeStage => !!nodeStage)
+            .map(nodeStage => ({
+                x: 0, // Layout is done later
+                y: 0,
+                name: nodeStage.name,
+                id: nodeStage.id,
+                stage: nodeStage,
+                isPlaceholder: false,
+                key: 'n_' + nodeStage.id,
+            }));
+
+        nodeColumns.push(column);
+    }
+
+    return nodeColumns;
+}
+
+
+/**
+ * Walks the columns of nodes giving them x and y positions. Mutates the node objects in place for now.
+ */
+function positionNodes(nodeColumns: Array<NodeColumn>, { nodeSpacingH, nodeSpacingV, ypStart }) {
+
+    let xp = nodeSpacingH / 2;
+    let previousTopNode = null;
+
+    for (const column of nodeColumns) {
+        const topNode = column.nodes[0];
+
+        let yp = ypStart; // Reset Y to top for each column
+
+        if (previousTopNode) {
+            // Advance X position
+            if (previousTopNode.isPlaceholder || topNode.isPlaceholder) {
+                // Don't space placeholder nodes (start/end) as wide as normal.
+                xp += Math.floor(nodeSpacingH * 0.7);
+            } else {
+                xp += nodeSpacingH;
+            }
+        }
+
+        for (const node of column.nodes) {
+            node.x = xp;
+            node.y = yp;
+
+            yp += nodeSpacingV;
+        }
+
+        previousTopNode = topNode;
+    }
+}
+
+
+/**
+ * Generate label descriptions for big labels at the top of each column
+ */
+function createBigLabels(columns: Array<NodeColumn>) {
+
+    const labels = [];
+
+    for (const column of columns) {
+
+        const node = column.nodes[0];
+        const stage = column.topStage;
+        const text = stage ? stage.name : node.name;
+        const key = 'l_b_' + node.key;
+
+        labels.push({
+            x: node.x,
+            y: node.y,
+            node,
+            stage,
+            text,
+            key,
+        });
+    }
+
+    return labels;
+}
+
+/**
+ * Generate label descriptions for small labels under the nodes
+ */
+function createSmallLabels(columns: Array<NodeColumn>) {
+
+    const labels = [];
+
+    for (const column of columns) {
+        if (column.nodes.length === 1) {
+            continue; // No small labels for single-node columns
+        }
+        for (const node of column.nodes) {
+            const label: LabelInfo = {
+                x: node.x,
+                y: node.y,
+                text: node.name,
+                key: 'l_s_' + node.key,
+                node,
+            };
+
+            if (node.isPlaceholder === false) {
+                label.stage = node.stage;
+            }
+
+            labels.push(label);
+        }
+    }
+
+    return labels;
+}
+
+/**
+ * Generate connection information from column to column
+ */
+function createConnections(columns: Array<NodeColumn>) {
+
+    const connections = [];
+
+    let sourceNodes = [];
+    let skippedNodes = [];
+
+    for (const column of columns) {
+        if (column.topStage && column.topStage.state === 'skipped') {
+            skippedNodes.push(column.nodes[0]);
+            continue;
+        }
+
+        if (sourceNodes.length) {
+            connections.push({
+                sourceNodes,
+                destinationNodes: column.nodes,
+                skippedNodes: skippedNodes,
+            });
+        }
+
+        sourceNodes = column.nodes;
+        skippedNodes = [];
+    }
+
+    return connections;
+}

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphModel.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphModel.jsx
@@ -1,0 +1,83 @@
+// @flow
+
+import type { Result } from '../status/StatusIndicator';
+
+// Dimensions used for layout, px
+export const defaultLayout = {
+    nodeSpacingH: 120,
+    nodeSpacingV: 70,
+    nodeRadius: 12,
+    terminalRadius: 7,
+    curveRadius: 12,
+    connectorStrokeWidth: 3.5,
+    labelOffsetV: 20,
+    smallLabelOffsetV: 15,
+    ypStart: 55,
+};
+
+// Typedefs
+
+export type StageInfo = {
+    name: string,
+    title: string,
+    state: Result,
+    completePercent: number,
+    id: number,
+    children: Array<StageInfo>
+};
+
+export type StageNodeInfo = {
+    // -- Shared with PlaceholderNodeInfo
+    key: string,
+    x: number,
+    y: number,
+    id: number,
+    name: string,
+
+    // -- Marker
+    isPlaceholder: false,
+
+    // -- Unique
+    stage: StageInfo
+};
+
+export type PlaceholderNodeInfo = {
+    // -- Shared with StageNodeInfo
+    key: string,
+    x: number,
+    y: number,
+    id: number,
+    name: string,
+
+    // -- Marker
+    isPlaceholder: true,
+
+    // -- Unique
+    type: 'start' | 'end'
+}
+
+// TODO: Attempt to extract a "common" node type with intersection operator to remove duplication
+
+export type NodeInfo = StageNodeInfo | PlaceholderNodeInfo;
+
+export type NodeColumn = {
+    topStage?: StageInfo,
+    nodes: Array<NodeInfo>,
+}
+
+export type CompositeConnection = {
+    sourceNodes: Array<NodeInfo>,
+    destinationNodes: Array<NodeInfo>,
+    skippedNodes: Array<NodeInfo>
+};
+
+export type LabelInfo = {
+    x: number,
+    y: number,
+    text: string,
+    key: string,
+    stage?: StageInfo,
+    node: NodeInfo
+};
+
+export type LayoutInfo = typeof defaultLayout;

--- a/jenkins-design-language/src/js/stories/PipelineGraphStories.jsx
+++ b/jenkins-design-language/src/js/stories/PipelineGraphStories.jsx
@@ -1,6 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React from 'react';
 import { storiesOf } from '@kadira/storybook';
-import {PipelineGraph, defaultLayout} from '../components/PipelineGraph';
+import {PipelineGraph} from '../components/pipeline/PipelineGraph';
 
 import { StatusIndicator } from '../components';
 const validResultValues = StatusIndicator.validResultValues;
@@ -12,7 +12,6 @@ storiesOf('PipelineGraph', module)
     .add('Duplicate Names', renderWithDuplicateNames)
     .add('Fat', renderFlatPipelineFat)
     .add('Legend', renderFlatPipeline)
-    .add('Constructor', renderConstructomatic)
     .add('Listeners', renderListenersPipeline)
     .add('Parallel', renderParallelPipeline)
     .add('Parallel (Deep)', renderParallelPipelineDeep);
@@ -94,32 +93,6 @@ function renderFlatPipelineFat() {
             <PipelineGraph stages={stages} layout={layout}/>
         </div>
     );
-}
-
-
-function renderConstructomatic() {
-
-    const stages = [
-        makeNode("Success", [], validResultValues.success),
-        makeNode("Failure", [], validResultValues.failure),
-        makeNode("Running", [
-            makeNode("Job 1", [], validResultValues.running),
-            makeNode("Job 2", [], validResultValues.running),
-            makeNode("Job 3", [], validResultValues.running)
-        ]),
-        makeNode("Skipped", [], validResultValues.skipped),
-        makeNode("Queued", [
-            makeNode("Job 4", [], validResultValues.queued),
-            makeNode("This is Job number 5", [], validResultValues.queued),
-            makeNode("Job 6", [], validResultValues.queued),
-            makeNode("Job 7", [], validResultValues.queued),
-            makeNode("Job 8", [], validResultValues.queued)
-        ]),
-        makeNode("Not Built", [], validResultValues.not_built),
-        makeNode("Bad data", [], "this is not my office")
-    ];
-
-    return <PipelineGraphConstructionKit stages={stages}/>;
 }
 
 function renderListenersPipeline() {
@@ -290,83 +263,3 @@ function makeNode(name, children = [], state = validResultValues.not_built, comp
     return {name, children, state, completePercent, id};
 }
 
-/// Wrap a PipelineGraph with some controls to tweak the layout properties
-class PipelineGraphConstructionKit extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {layout: defaultLayout};
-    }
-
-    control(label, property, min, max) {
-        const value = this.state.layout[property];
-
-        const changed = (e) => {
-            const value = e.target.value;
-
-            const layout = Object.assign({}, this.state.layout);
-            layout[property] = parseInt(value);
-
-            this.setState({layout});
-        };
-
-        return (
-            <tr>
-                <td>{label}</td>
-                <td><input type="range" min={min} max={max} defaultValue={value} onChange={changed}/></td>
-                <td>{value}</td>
-            </tr>
-        );
-    }
-
-    render() {
-
-        const wrapperStyle = {
-            margin: "5px",
-            padding: "10px",
-            border: "dashed 1px #ccc",
-            borderRadius: "10px"
-        };
-
-        const tableStyle = {
-            width: "auto",
-            borderSpacing: "5px",
-            borderCollapse: "separate"
-        };
-
-        const controlDivStyle = {
-            display: "flex",
-            justifyContent: "center"
-        };
-
-        return (
-            <div style={wrapperStyle}>
-                <h1>PipelineGraph Construct-o-matic&trade;</h1>
-                <div style={controlDivStyle}>
-                    <table style={tableStyle}>
-                        <tbody>
-                        {this.control("Line Thickness", "connectorStrokeWidth", 1, 20)}
-                        {this.control("Curve Radius", "curveRadius", 0, 50)}
-                        {this.control("H Spacing", "nodeSpacingH", 10, 200)}
-                        {this.control("V Spacing", "nodeSpacingV", 10, 200)}
-                        </tbody>
-                    </table>
-                    <table style={tableStyle}>
-                        <tbody>
-                        {this.control("Node radius", "nodeRadius", 5, 40)}
-                        {this.control("Big Label offset", "labelOffsetV", 0, 100)}
-                        {this.control("Small Label offset", "smallLabelOffsetV", 0, 100)}
-                        </tbody>
-                    </table>
-                </div>
-                <PipelineGraph stages={this.props.stages}
-                               layout={this.state.layout}
-                               onNodeClick={this.props.onNodeClick}/>
-            </div>
-        );
-    }
-}
-
-PipelineGraphConstructionKit.propTypes = {
-    stages: PropTypes.array,
-    onNodeClick: PropTypes.func
-};

--- a/jenkins-design-language/test/js/components/PipelineGraph-spec.js
+++ b/jenkins-design-language/test/js/components/PipelineGraph-spec.js
@@ -1,16 +1,245 @@
 import { assert } from 'chai';
 
 import { PipelineGraph } from '../../../src/js/components';
+import { layoutGraph } from '../../../src/js/components/pipeline/PipelineGraphLayout';
+import { defaultLayout } from '../../../src/js/components/pipeline/PipelineGraphModel';
 
-describe("PipelineGraph", () => {
-    describe("createNodeColumns", () => {
-        it("gracefully handles a Stage with null children", () => {
+import { StatusIndicator } from '../../../src/js/components/status/StatusIndicator';
+
+const validResultValues = StatusIndicator.validResultValues;
+
+// Data creation helper Lifted from stories
+let __id = 1111;
+
+function makeNode(name, children = [], state = validResultValues.not_built, completePercent) {
+    completePercent = completePercent || ((state == validResultValues.running) ? Math.floor(Math.random() * 60 + 20) : 50);
+    const id = __id++;
+    return { name, children, state, completePercent, id };
+}
+
+// Assertion helpers
+function assertNode(node, text, x, y) {
+    assert.ok(node, `node ${text} exists`);
+    assert.equal(node.name, text, `node ${text} name`);
+    assert.equal(node.x, x, `node ${text} x`);
+    assert.equal(node.y, y, `node ${text} y`);
+}
+
+function assertLabel(labels, text, x,y) {
+    const label = labels.find(label => label.text === text);
+    assert.ok(label, `label ${text} exists`);
+    assert.equal(label.x, x, `label ${text} x`);
+    assert.equal(label.y, y, `label ${text} y`);
+}
+
+function assertConnection(connections, sourceName, destinationName) {
+    for (const compositeConnection of connections) {
+        const sourceMatch = compositeConnection.sourceNodes.find(node => node.name === sourceName);
+        const destinationMatch = compositeConnection.destinationNodes.find(node => node.name === destinationName);
+
+        if (sourceMatch && destinationMatch) {
+            return; // Connection found
+        }
+    }
+
+    assert.fail(`could not find ${leftText} --> ${rightText} connection`);
+}
+
+describe('PipelineGraph', () => {
+    describe('layoutGraph', () => {
+
+        it('gracefully handles a Stage with null children', () => {
             const stagesNullChildren = require('../data/pipeline-graph/stages-with-null-children.json');
-            const graph = new PipelineGraph({});
-            const columns = graph.createNodeColumns(stagesNullChildren);
-            assert.isOk(columns);
-            assert.equal(columns.length, 5);
+            const { nodeColumns } = layoutGraph(stagesNullChildren, defaultLayout);
+            assert.isOk(nodeColumns);
+            assert.equal(nodeColumns.length, 7);
+        });
 
+        it('lays out a mixed graph', () => {
+            const stages = [
+                makeNode('Build', [], validResultValues.success),
+                makeNode('Test', [
+                    makeNode('JUnit', [], validResultValues.success),
+                    makeNode('DBUnit', [], validResultValues.success),
+                    makeNode('Jasmine', [], validResultValues.success),
+                ]),
+                makeNode('Browser Tests', [
+                    makeNode('Firefox', [], validResultValues.success),
+                    makeNode('Edge', [], validResultValues.failure),
+                    makeNode('Safari', [], validResultValues.running, 60),
+                    makeNode('Chrome', [], validResultValues.running, 120),
+                ]),
+                makeNode('Skizzled', [], validResultValues.skipped),
+                makeNode('Foshizzle', [], validResultValues.skipped),
+                makeNode('Dev', [
+                    makeNode('US-East', [], validResultValues.success),
+                    makeNode('US-West', [], validResultValues.success),
+                    makeNode('APAC', [], validResultValues.success),
+                ], validResultValues.success),
+                makeNode('Staging', [], validResultValues.skipped),
+                makeNode('Production'),
+            ];
+
+            const {
+                nodeColumns,
+                connections,
+                bigLabels,
+                smallLabels,
+                measuredWidth,
+                measuredHeight,
+            } = layoutGraph(stages, defaultLayout);
+
+            // Basic stuff
+
+            assert.equal(nodeColumns.length, 10, 'column count');
+            assert.equal(measuredWidth, 1128, 'measuredWidth');
+            assert.equal(measuredHeight, 320, 'measuredHeight');
+            assert.equal(smallLabels.length, 10, 'small label count');
+            assert.equal(bigLabels.length, 10, 'big label count');
+
+            // Start col
+            let col = nodeColumns[0];
+            assert.equal(undefined, col.topStage, 'topStage');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Start', 60, 55);
+
+            // End col
+            col = nodeColumns[9];
+            assert.equal(undefined, col.topStage, 'topStage');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'End', 1068, 55);
+
+            // Col 1
+            col = nodeColumns[1];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Build', 'top stage name');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Build', 144, 55);
+
+            // Col 2
+            col = nodeColumns[2];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Test', 'top stage name');
+            assert.equal(3, col.nodes.length);
+            assertNode(col.nodes[0], 'JUnit', 264, 55);
+            assertNode(col.nodes[1], 'DBUnit', 264, 125);
+            assertNode(col.nodes[2], 'Jasmine', 264, 195);
+
+            // Col 3
+            col = nodeColumns[3];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Browser Tests', 'top stage name');
+            assert.equal(4, col.nodes.length);
+            assertNode(col.nodes[0], 'Firefox', 384, 55);
+            assertNode(col.nodes[1], 'Edge', 384, 125);
+            assertNode(col.nodes[2], 'Safari', 384, 195);
+            assertNode(col.nodes[3], 'Chrome', 384, 265);
+
+            // Col 4
+            col = nodeColumns[4];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Skizzled', 'top stage name');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Skizzled', 504, 55);
+
+            // Col 5
+            col = nodeColumns[5];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Foshizzle', 'top stage name');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Foshizzle', 624, 55);
+
+            // Col 6
+            col = nodeColumns[6];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Dev', 'top stage name');
+            assert.equal(3, col.nodes.length);
+            assertNode(col.nodes[0], 'US-East', 744, 55);
+            assertNode(col.nodes[1], 'US-West', 744, 125);
+            assertNode(col.nodes[2], 'APAC', 744, 195);
+
+            // Col 7
+            col = nodeColumns[7];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Staging', 'top stage name');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Staging', 864, 55);
+
+            // Col 8
+            col = nodeColumns[8];
+            assert.ok(col.topStage, 'topStage');
+            assert.equal(col.topStage.name, 'Production', 'top stage name');
+            assert.equal(1, col.nodes.length);
+            assertNode(col.nodes[0], 'Production', 984, 55);
+
+            // Big Labels
+            assertLabel(bigLabels, 'Start', 60, 55);
+            assertLabel(bigLabels, 'Build', 144, 55);
+            assertLabel(bigLabels, 'Test', 264, 55);
+            assertLabel(bigLabels, 'Browser Tests', 384, 55);
+            assertLabel(bigLabels, 'Skizzled', 504, 55);
+            assertLabel(bigLabels, 'Foshizzle', 624, 55);
+            assertLabel(bigLabels, 'Dev', 744, 55);
+            assertLabel(bigLabels, 'Staging', 864, 55);
+            assertLabel(bigLabels, 'Production', 984, 55);
+            assertLabel(bigLabels, 'End', 1068, 55);
+
+            // Small Labels - Test
+            assertLabel(smallLabels, 'JUnit', 264, 55);
+            assertLabel(smallLabels, 'DBUnit', 264, 125);
+            assertLabel(smallLabels, 'Jasmine', 264, 195);
+
+            // Small Labels - Browser Tests
+            assertLabel(smallLabels, 'Firefox', 384, 55);
+            assertLabel(smallLabels, 'Edge', 384, 125);
+            assertLabel(smallLabels, 'Safari', 384, 195);
+            assertLabel(smallLabels, 'Chrome', 384, 265);
+
+            // Small Labels - Dev
+            assertLabel(smallLabels, 'US-East', 744, 55);
+            assertLabel(smallLabels, 'US-West', 744, 125);
+            assertLabel(smallLabels, 'APAC', 744, 195);
+
+            // Connections
+            assertConnection(connections, 'Start', 'Build');
+
+            assertConnection(connections, 'Build', 'JUnit');
+            assertConnection(connections, 'Build', 'DBUnit');
+            assertConnection(connections, 'Build', 'Jasmine');
+
+            assertConnection(connections, 'JUnit', 'Firefox');
+            assertConnection(connections, 'JUnit', 'Edge');
+            assertConnection(connections, 'JUnit', 'Safari');
+            assertConnection(connections, 'JUnit', 'Chrome');
+            assertConnection(connections, 'DBUnit', 'Firefox');
+            assertConnection(connections, 'DBUnit', 'Edge');
+            assertConnection(connections, 'DBUnit', 'Safari');
+            assertConnection(connections, 'DBUnit', 'Chrome');
+            assertConnection(connections, 'Jasmine', 'Firefox');
+            assertConnection(connections, 'Jasmine', 'Edge');
+            assertConnection(connections, 'Jasmine', 'Safari');
+            assertConnection(connections, 'Jasmine', 'Chrome');
+
+            assertConnection(connections, 'Firefox', 'US-East');
+            assertConnection(connections, 'Firefox', 'US-West');
+            assertConnection(connections, 'Firefox', 'APAC');
+            assertConnection(connections, 'Edge', 'US-East');
+            assertConnection(connections, 'Edge', 'US-West');
+            assertConnection(connections, 'Edge', 'APAC');
+            assertConnection(connections, 'Safari', 'US-East');
+            assertConnection(connections, 'Safari', 'US-West');
+            assertConnection(connections, 'Safari', 'APAC');
+            assertConnection(connections, 'Chrome', 'US-East');
+            assertConnection(connections, 'Chrome', 'US-West');
+            assertConnection(connections, 'Chrome', 'APAC');
+
+            assertConnection(connections, 'US-East', 'Production');
+            assertConnection(connections, 'US-West', 'Production');
+            assertConnection(connections, 'APAC', 'Production');
+
+            assertConnection(connections, 'Production', 'End');
+
+            assert.equal(connections.length, 6, 'Total composite connections');
         });
     });
 });


### PR DESCRIPTION
Squashed commit of the following:

    hackweek/complex-graphs * Add a comprehensive test-case for the layout algorithm to ensure we don't break it during modifications
    hackweek/complex-graphs * Update existing test to use new interface to layout
    hackweek/complex-graphs * Flow and eslint fixes
    hackweek/complex-graphs * Move ypStart into the Layout object and remove the old busted constructor usecase from storybooks
    hackweek/complex-graphs * Extract layout into a single-entry function in separate file for reuse
    hackweek/complex-graphs * Move pipeline graph components into their own subdir, extract types into a model file

# Description

See [JENKINS-38442](https://issues.jenkins-ci.org/browse/JENKINS-38442).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

