### PR TITLE
Remove the metrics dependency

### DIFF
--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -22,10 +22,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>metrics</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>variant</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -514,17 +514,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>metrics</artifactId>
-            <version>3.1.2.10</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>jackson2-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>variant</artifactId>
             <version>1.1</version>
         </dependency>


### PR DESCRIPTION
There was a metrics dependency that @rsandell complained about. Turns out its not needed.

PTAL