### PR TITLE
[FIX JENKINS-44390] Support reading nested stages within parallel, generate new syntax

### DIFF
--- a/blueocean-pipeline-editor/pom.xml
+++ b/blueocean-pipeline-editor/pom.xml
@@ -17,10 +17,6 @@
     <artifactId>blueocean-pipeline-editor</artifactId>
     <packaging>hpi</packaging>
 
-    <properties>
-        <declarative.version>1.0</declarative.version>
-    </properties>
-
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
 
     <licenses>
@@ -47,7 +43,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.jenkins.blueocean</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-rest</artifactId>
         </dependency>
         <dependency>
@@ -55,17 +51,16 @@
             <artifactId>blueocean-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.blueocean</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-commons</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.blueocean</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-pipeline-api-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>${declarative.version}</version>
         </dependency>
     </dependencies>
 

--- a/blueocean-pipeline-editor/src/main/js/components/editor/EditorMain.jsx
+++ b/blueocean-pipeline-editor/src/main/js/components/editor/EditorMain.jsx
@@ -105,7 +105,7 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
             }, 200);
         });
     }
-    
+
     graphSelectedStageChanged(newSelectedStage:?StageInfo) {
         this.setState({
             selectedStage: newSelectedStage,
@@ -171,11 +171,11 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
 
     render() {
         const {selectedStage, selectedSteps, stepMetadata} = this.state;
-        
+
         if (!stepMetadata) {
             return null;
         }
-        
+
         const sheets = [];
         const steps = selectedStage ? selectedStage.steps : [];
 
@@ -200,10 +200,10 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
         if (globalConfigPanel) sheets.push(globalConfigPanel);
 
         const stageConfigPanel = selectedStage && (<ConfigPanel className="editor-config-panel stage" key={'stageConfig'+selectedStage.id}
-            onClose={e => pipelineValidator.validate() || this.graphSelectedStageChanged(null)}
+            onClose={e => cleanPristine(selectedStage) || pipelineValidator.validate() || this.graphSelectedStageChanged(null)}
             title={
                 <div>
-                    <input className="stage-name-edit" placeholder="Name your stage" defaultValue={title} 
+                    <input className="stage-name-edit" placeholder="Name your stage" defaultValue={title}
                         onChange={e => (selectedStage.name = e.target.value) && this.pipelineUpdated()} />
                     <MoreMenu>
                         <a onClick={e => this.deleteStageClicked(e)}>Delete</a>
@@ -251,7 +251,7 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
 
         return (
             <div className="editor-main" key={pipelineStore.pipeline && pipelineStore.pipeline.id}>
-                <div className="editor-main-graph" onClick={e => pipelineValidator.validate() || this.setState({selectedStage: null, selectedSteps: []})}>
+                <div className="editor-main-graph" onClick={e => cleanPristine(pipelineStore.pipeline) || pipelineValidator.validate() || this.setState({selectedStage: null, selectedSteps: []})}>
                     {pipelineStore.pipeline &&
                     <EditorPipelineGraph stages={pipelineStore.pipeline.children}
                                          selectedStage={selectedStage}

--- a/blueocean-pipeline-editor/src/main/js/services/PipelineValidator.js
+++ b/blueocean-pipeline-editor/src/main/js/services/PipelineValidator.js
@@ -72,7 +72,7 @@ export class PipelineValidator {
      */
     getNodeValidationErrors(node: Object, visited: any[] = []): Object[] {
         const validationErrors = node.validationErrors ? [ ...node.validationErrors ] : [];
-        
+
         // if this is a parallel, check the parent stage for errors
         const parent = pipelineStore.findParentStage(node);
         if (parent && pipelineStore.pipeline !== parent && parent.validationErrors) {
@@ -132,6 +132,11 @@ export class PipelineValidator {
                     }
                     break;
                 }
+                case 'parallel': {
+                    const idx = parseInt(path[++i]);
+                    node = node.children[idx];
+                    break;
+                }
                 case 'steps': {
                     const idx = parseInt(path[++i]);
                     if (!isNaN(idx)) { // it is actually the steps array, so just target the node
@@ -157,6 +162,7 @@ export class PipelineValidator {
         }
         if (!node) {
             if (window.isDevelopmentMode) console.error('unable to find node for', path, 'in', pipeline);
+            return pipeline;
         }
         return node;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
     <jenkins-test-harness.version>2.23</jenkins-test-harness.version>
-    <scm-api.version>2.2.0</scm-api.version>
+    <scm-api.version>2.2.1</scm-api.version>
     <git.version>3.5.1</git.version>
     <git-client.version>2.5.0</git-client.version>
   </properties>
@@ -312,7 +312,7 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.1.9</version>
+            <version>1.2-beta-4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
# Description

Use some [new-style nested parallel stages](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-definition/src/test/resources/nestedParallelStages.groovy) - e.g. Cmd/Ctrl-S and paste [examples](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-definition/src/test/resources/) in, see what the editor generates. Validate it is using the [new style nested stage parallel syntax](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-definition/src/test/resources/nestedParallelStages.groovy).

See [JENKINS-44390](https://issues.jenkins-ci.org/browse/JENKINS-44390).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

Esp: @abayer @michaelneale 