### PR TITLE
hotfix/javadoc error

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -173,7 +173,6 @@ public class UserImpl extends BlueUser {
      * Gets or creates the user's private Jenkins-managed key and returns the
      * public key to the user
      * @return JSON response
-     * @throws IOException
      */
     @GET
     @WebMethod(name="publickey")
@@ -196,7 +195,6 @@ public class UserImpl extends BlueUser {
     /**
      * Deletes the user's private Jenkins-managed key
      * @return
-     * @throws IOException
      */
     @DELETE
     @WebMethod(name="publickey")


### PR DESCRIPTION
# Description

In my local environment, when building master, blueocean-rest-impl would fail on Javadoc. I am not sure why this isn't showing up in CI for master (JDK version discrepancy perhaps?) but seems worth fixing.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

