### PR TITLE
JENKINS-46704# Fix for save content to new branch on github

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/HttpRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/HttpRequest.java
@@ -97,7 +97,7 @@ class HttpRequest {
                     try {
                         return GithubScm.om.readValue(data, type);
                     } catch (JsonMappingException e) {
-                        throw new IOException("Failed to deserialize " + data, e);
+                        throw new IOException("Failed to deserialize: "+e.getMessage()+"\n" + data, e);
                     }
                 }
             }

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
@@ -387,7 +387,9 @@ public class GithubScmContentProviderTest extends GithubMockBase{
 
         when(staplerRequest.bindJSON(Mockito.eq(GithubScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new GithubScmSaveFileRequest(content));
 
-        MultiBranchProject mbp = mockMbp(credentialId, user, GithubScm.DOMAIN_NAME);
+        OrganizationFolder orgFolder = mockOrgFolder(user, credentialId);
+
+        MultiBranchProject mbp = mockMbp(orgFolder, credentialId);
 
         String request = "{\n" +
                 "  \"content\" : {\n" +

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
@@ -377,6 +377,40 @@ public class GithubScmContentProviderTest extends GithubMockBase{
     }
 
     @Test
+    public void saveContentNewBranchToMbp() throws UnirestException, IOException {
+        String credentialId = createGithubCredential(user);
+
+        StaplerRequest staplerRequest = mockStapler();
+
+        GitContent content = new GitContent.Builder().autoCreateBranch(true).base64Data("c2xlZXAgMTUKbm9kZSB7CiAgY2hlY2tvdXQgc2NtCiAgc2ggJ2xzIC1sJwp9\\nCnNsZWVwIDE1Cg==\\n")
+                .branch("test2").message("another commit").sourceBranch("master").owner("cloudbeers").path("Jankinsfile").repo("PR-demo").sha("e23b8ef5c2c4244889bf94db6c05cc08ea138aef").build();
+
+        when(staplerRequest.bindJSON(Mockito.eq(GithubScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new GithubScmSaveFileRequest(content));
+
+        MultiBranchProject mbp = mockMbp(credentialId, user, GithubScm.DOMAIN_NAME);
+
+        String request = "{\n" +
+                "  \"content\" : {\n" +
+                "    \"message\" : \"first commit\",\n" +
+                "    \"path\" : \"Jenkinsfile\",\n" +
+                "    \"branch\" : \"test2\",\n" +
+                "    \"sourceBranch\" : \"master\",\n" +
+                "    \"repo\" : \"PR-demo\",\n" +
+                "    \"sha\" : \"e23b8ef5c2c4244889bf94db6c05cc08ea138aef\",\n" +
+                "    \"base64Data\" : "+"\"c2xlZXAgMTUKbm9kZSB7CiAgY2hlY2tvdXQgc2NtCiAgc2ggJ2xzIC1sJwp9\\nCnNsZWVwIDE1Cg==\\n\""+
+                "  }\n" +
+                "}";
+
+        when(staplerRequest.getReader()).thenReturn(new BufferedReader(new StringReader(request), request.length()));
+
+        GithubFile file = (GithubFile) new GithubScmContentProvider().saveContent(staplerRequest, mbp);
+        assertEquals("Jenkinsfile", file.getContent().getName());
+        assertEquals("e23b8ef5c2c4244889bf94db6c05cc08ea138aef", file.getContent().getSha());
+        assertEquals("PR-demo", file.getContent().getRepo());
+        assertEquals("cloudbeers", file.getContent().getOwner());
+    }
+
+    @Test
     public void saveContentToMbpGHE() throws UnirestException, IOException {
         String credentialId = createGithubEnterpriseCredential();
 

--- a/blueocean-github-pipeline/src/test/resources/api/__files/body-branches-master-BELLU.json
+++ b/blueocean-github-pipeline/src/test/resources/api/__files/body-branches-master-BELLU.json
@@ -78,5 +78,14 @@
   "_links": {
     "self": "https://api.github.com/repos/cloudbeers/PR-demo/branches/master",
     "html": "https://github.com/cloudbeers/PR-demo/tree/master"
-  }
+  },
+  "protected": false,
+  "protection": {
+    "enabled": false,
+    "required_status_checks": {
+      "enforcement_level": "off",
+      "contexts": []
+    }
+  },
+  "protection_url": "https://api.github.com/repos/cloudbeers/PR-demo/branches/master/protection"
 }


### PR DESCRIPTION
# Description

>Cherry picked from master, https://github.com/jenkinsci/blueocean-plugin/pull/1381. Compared to the changes on master for this issue, this PR has minor adjustment in test as release/1.2 branch supports org folder for GitHub.

See [JENKINS-46704](https://issues.jenkins-ci.org/browse/JENKINS-46704).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

