### PR TITLE
defensive code - for issue trackers that like to blow up with NPEs

### DIFF
--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BlueIssueFactory.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BlueIssueFactory.java
@@ -14,9 +14,13 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public abstract class BlueIssueFactory implements ExtensionPoint {
 
+
+    private static final Logger LOGGER = Logger.getLogger(BlueIssueFactory.class.getName());
     /**
      * @see #resolve(Job)
      * @param job job
@@ -41,13 +45,18 @@ public abstract class BlueIssueFactory implements ExtensionPoint {
      */
     public static Collection<BlueIssue> resolve(Job job) {
         LinkedHashSet<BlueIssue> allIssues = Sets.newLinkedHashSet();
-        for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
+        try {
+            for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
             Collection<BlueIssue> issues = factory.getIssues(job);
             if (issues == null) {
                 continue;
             }
             allIssues.addAll(issues);
         }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING,"Unable to fetch issues for job " + e.getMessage(), e);
+        }
+
         return allIssues;
     }
 
@@ -59,12 +68,17 @@ public abstract class BlueIssueFactory implements ExtensionPoint {
      */
     public static Collection<BlueIssue> resolve(ChangeLogSet.Entry changeSetEntry) {
         LinkedHashSet<BlueIssue> allIssues = Sets.newLinkedHashSet();
-        for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
-            Collection<BlueIssue> issues = factory.getIssues(changeSetEntry);
-            if (issues == null) {
-                continue;
+        try {
+            for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
+
+                    Collection<BlueIssue> issues = factory.getIssues(changeSetEntry);
+                    if (issues == null) {
+                        continue;
+                    }
+                    allIssues.addAll(issues);
             }
-            allIssues.addAll(issues);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING,"Unable to fetch issues for changeSetEntry " + e.getMessage(), e);
         }
         return allIssues;
     }

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BlueIssueFactory.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/factory/BlueIssueFactory.java
@@ -45,40 +45,38 @@ public abstract class BlueIssueFactory implements ExtensionPoint {
      */
     public static Collection<BlueIssue> resolve(Job job) {
         LinkedHashSet<BlueIssue> allIssues = Sets.newLinkedHashSet();
-        try {
-            for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
-            Collection<BlueIssue> issues = factory.getIssues(job);
-            if (issues == null) {
-                continue;
+        for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
+            try {
+                Collection<BlueIssue> issues = factory.getIssues(job);
+                if (issues == null) {
+                    continue;
+                }
+                allIssues.addAll(issues);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING,"Unable to fetch issues for job " + e.getMessage(), e);
             }
-            allIssues.addAll(issues);
         }
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING,"Unable to fetch issues for job " + e.getMessage(), e);
-        }
-
         return allIssues;
     }
 
     /**
-     * Finds any JIRA tickets associated with the changeset
+     * Finds any issues associated with the changeset
      * e.g. a commit message could be "TICKET-123 fix all the things" and be associated with TICKET-123 in JIRA
      * @param changeSetEntry entry
      * @return issues representing the change
      */
     public static Collection<BlueIssue> resolve(ChangeLogSet.Entry changeSetEntry) {
         LinkedHashSet<BlueIssue> allIssues = Sets.newLinkedHashSet();
-        try {
-            for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
-
-                    Collection<BlueIssue> issues = factory.getIssues(changeSetEntry);
-                    if (issues == null) {
-                        continue;
-                    }
-                    allIssues.addAll(issues);
+        for (BlueIssueFactory factory : ExtensionList.lookup(BlueIssueFactory.class)) {
+            try {
+                Collection<BlueIssue> issues = factory.getIssues(changeSetEntry);
+                if (issues == null) {
+                    continue;
+                }
+                allIssues.addAll(issues);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING,"Unable to fetch issues for changeSetEntry " + e.getMessage(), e);
             }
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING,"Unable to fetch issues for changeSetEntry " + e.getMessage(), e);
         }
         return allIssues;
     }


### PR DESCRIPTION
# Description

See https://issues.jenkins-ci.org/browse/JENKINS-46778

There have been issues since JIRA has been bundled. This is an attempt to be generically defensive against issue tracking plugins that may poop on things. 

please consider @vivek @kzantow 

