### PR TITLE
JENKINS-46879# Pipeline could be an org folder, handle it accordingly

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/ScmResourceImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/ScmResourceImpl.java
@@ -8,6 +8,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipelineScm;
+import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.StaplerRequest;
@@ -59,7 +60,12 @@ public class ScmResourceImpl extends BluePipelineScm {
     }
 
     private @Nonnull User checkPermission(){
-        ACL acl = item.getACL();
+        ACL acl;
+        if(item.getParent() != null && item.getParent() instanceof OrganizationFolder){
+            acl = ((OrganizationFolder) item.getParent()).getACL();
+        }else{
+            acl = item.getACL();
+        }
         Authentication a = Jenkins.getAuthentication();
         User user = User.get(a);
         if(user == null){


### PR DESCRIPTION
# Description

Ported handling of permission check for org folder during loading content. 1.3 doesn't support creation of org folder pipeline but we  need this fix for backward compatibility.

See [JENKINS-46879](https://issues.jenkins-ci.org/browse/JENKINS-46879).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

