### PR TITLE
 [FIX JENKINS-47032] IE will give focus to StatusIndicator in creation flow

### DIFF
--- a/jenkins-design-language/src/js/components/status/StatusIndicator.jsx
+++ b/jenkins-design-language/src/js/components/status/StatusIndicator.jsx
@@ -66,7 +66,6 @@ class StatusIndicator extends Component {
             width = '24px',
             height = '24px',
             noBackground,
-            focusable = false,
         } = this.props;
 
         const groupClasses = [
@@ -91,7 +90,7 @@ class StatusIndicator extends Component {
         return (
             <svg className={groupClasses.join(' ')} xmlns="http://www.w3.org/2000/svg"
               viewBox={`0 0 ${2 * radius} ${2 * radius}`} width={width} height={height}
-              focusable={focusable}
+              focusable={false}
             >
                 <title>{resultClean}</title>
                 <g transform={transforms.join(' ')}>
@@ -108,7 +107,6 @@ StatusIndicator.propTypes = {
     width: PropTypes.string,
     height: PropTypes.string,
     noBackground: PropTypes.bool,
-    focusable: PropTypes.bool,
 };
 
 export {StatusIndicator, SvgSpinner, SvgStatus};

--- a/jenkins-design-language/src/js/components/status/StatusIndicator.jsx
+++ b/jenkins-design-language/src/js/components/status/StatusIndicator.jsx
@@ -66,6 +66,7 @@ class StatusIndicator extends Component {
             width = '24px',
             height = '24px',
             noBackground,
+            focusable = false,
         } = this.props;
 
         const groupClasses = [
@@ -90,6 +91,7 @@ class StatusIndicator extends Component {
         return (
             <svg className={groupClasses.join(' ')} xmlns="http://www.w3.org/2000/svg"
               viewBox={`0 0 ${2 * radius} ${2 * radius}`} width={width} height={height}
+              focusable={focusable}
             >
                 <title>{resultClean}</title>
                 <g transform={transforms.join(' ')}>
@@ -106,6 +108,7 @@ StatusIndicator.propTypes = {
     width: PropTypes.string,
     height: PropTypes.string,
     noBackground: PropTypes.bool,
+    focusable: PropTypes.bool,
 };
 
 export {StatusIndicator, SvgSpinner, SvgStatus};


### PR DESCRIPTION
# Description 

Can be seen in any creation flow. When using the keybaord to navigate in the create flow if you tab from an input field you get nothing and then tab again and you get the next element in the focus.

Basically you need to shift-tab or tab twice to move between the control elements when a statusIndicator is in between since it will "steal" the focus due the the svg not having focusable="false".

Happens in IE only, Edge is correct as is Chrome.

Testing needs to be done manually in an IE.

See [JENKINS-47032](https://issues.jenkins-ci.org/browse/JENKINS-47032).

# Note on IE

All SVG need to have focusable="false" otherwise IE may give them focus even if they are not anymore in the DOM and your document.activeElement becomes null and TAB_INDEX starts at top level (either document or browser(!)).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

