### PR TITLE
<html> element must have a lang attribute

### DIFF
--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -7,7 +7,7 @@
       <st:include it="${pd}" page="httpHeaders.jelly" optional="true"/>
     </j:forEach>
     <x:doctype name="html"/>
-    <html>
+    <html lang="${it.lang}">
 
         <!-- HACK that need to be cleaned up -->
         <j:new var="h" className="hudson.Functions"/><!-- instead of JSP functions -->


### PR DESCRIPTION
See: https://issues.jenkins-ci.org/browse/JENKINS-47080

https://dequeuniversity.com/rules/axe/2.4/html-has-lang?application=AxeChrome

> The HTML document must contain a valid lang attribute or must correspond to a valid lang code for multilingual screen reader users who may prefer a language other than the default.

# Description

I did run an analysis with https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd and our `lang` needs to appear in the parent `html`tag.

![screenshot_2017-09-23_11-23-18](https://user-images.githubusercontent.com/596701/30771962-190c71e6-a053-11e7-8f92-8f78123e6aa6.png)

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

