### PR TITLE
[JENKINS-47146,JENKINS-45589] Remove expensive fallback path for expected build number and NPE

### DIFF
--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -96,16 +96,13 @@ public class BlueMessageEnricher extends MessageEnricher {
             if (message.containsKey("job_run_queueId") && jobChannelItem instanceof hudson.model.Job) {
                 final long queueId = Long.parseLong(message.get("job_run_queueId"));
                 Queue.Item queueItem = Jenkins.getInstance().getQueue().getItem(queueId);
+                if (queueItem == null) {
+                    return;
+                }
                 hudson.model.Job job = (hudson.model.Job) jobChannelItem;
                 BlueQueueItem blueQueueItem = QueueUtil.getQueuedItem(null, queueItem, job);
                 if (blueQueueItem != null) {
                     jobChannelMessage.set(BlueEventProps.blueocean_queue_item_expected_build_number, Integer.toString(blueQueueItem.getExpectedBuildNumber()));
-                } else {
-                    Run run = QueueUtil.getRun(job, queueId);
-                    if (run == null) {
-                        return;
-                    }
-                    jobChannelMessage.set(BlueEventProps.blueocean_queue_item_expected_build_number, Integer.toString(run.getNumber()));
                 }
             }
         }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -27,7 +27,6 @@ import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Queue;
-import hudson.model.Run;
 import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.hal.LinkResolver;
@@ -36,6 +35,7 @@ import io.jenkins.blueocean.rest.model.BlueQueueItem;
 import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
 import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pubsub.EventProps;
 import org.jenkinsci.plugins.pubsub.Events;
 import org.jenkinsci.plugins.pubsub.JobChannelMessage;
@@ -107,8 +107,17 @@ public class BlueMessageEnricher extends MessageEnricher {
                 BlueQueueItem blueQueueItem = QueueUtil.getQueuedItem(null, queueItem, job);
                 if (blueQueueItem != null) {
                     jobChannelMessage.set(BlueEventProps.blueocean_queue_item_expected_build_number, Integer.toString(blueQueueItem.getExpectedBuildNumber()));
+                } else {
+                    // If build is already running, we simply take the run id and pass it on
+                    if(message.get("job_run_status") != null){
+                        String buildNumberStr = message.get("jenkins_object_id");
+                        if(StringUtils.isNotBlank(buildNumberStr)) {
+                            jobChannelMessage.set(BlueEventProps.blueocean_queue_item_expected_build_number, message.get("jenkins_object_id"));
+                        }
+                    }
                 }
             }
+
         }
     }
 }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -94,7 +94,11 @@ public class BlueMessageEnricher extends MessageEnricher {
             }
 
             if (message.containsKey("job_run_queueId") && jobChannelItem instanceof hudson.model.Job) {
-                final long queueId = Long.parseLong(message.get("job_run_queueId"));
+                String queueIdStr = message.get("job_run_queueId");
+                if (queueIdStr == null) {
+                    return;
+                }
+                final long queueId = Long.parseLong(queueIdStr);
                 Queue.Item queueItem = Jenkins.getInstance().getQueue().getItem(queueId);
                 if (queueItem == null) {
                     return;


### PR DESCRIPTION
This changes fixes an issue I've seen come up:
    - When large numbers of triggers are run at once, the getBuilds call in getRun is extremely expensive.  It effectively ends up loading all the builds for a certain job.
    - This causes delays of sometimes several hours in scheduling jobs when load is high.
    - NPE when queued items can't be found in the queue.  This tends to happen more on startup.  It may simply be a race between the lookup code and the scheduling code.
The reason for removing this code is basically like this.  When a queue item that is blocked, waiting, etc. passes through here, the codepath appears to always return null.  This is becuase the queue item has not yet become a build and thus there is no entry in the job's build list.  The one I've found case where this does work is when the queue item leaves the queue (becomes a LeftItem).  At that point, it has been assigned a run number, and this code does work.  However, logically at that point this is no longer an expected build number.  It's an actual build number.  The regular build id logic in the blue ocean UI should take over at that point.

Now, it's entirely possible that I missed a crucial case here.  However, the getRun code is undoubtedly incorrect as it is extremely inefficient.

See [JENKINS-47146](https://issues.jenkins-ci.org/browse/JENKINS-47146) and [JENKINS-45589](https://issues.jenkins-ci.org/browse/JENKINS-45589)