### PR TITLE
avoid second scrollbar in pipeline graph

### DIFF
--- a/blueocean-dashboard/src/main/less/pipeline-run-graph.less
+++ b/blueocean-dashboard/src/main/less/pipeline-run-graph.less
@@ -2,10 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    overflow: auto;
+    overflow-x: auto;
     margin-bottom: 16px;
-    max-height: ~"calc(70vh - 120px)"; // Leave room for header (120px) and log (30vh)
-    // NB: ^^ Needs to be escaped or LESS silently ruins it
 
     .PipelineGraph {
         margin-left: auto;


### PR DESCRIPTION
- was not necessary to fix JENKINS-43201 which was a bug report about
  missing x scrolling
- chances of getting lost just because the stage labels are scrolled
  out of view seem rather small (some visual cues on the left/right
  side of the container could help)
- fixed PgUp/PgDown for default focus (nested scrollbar needs to be clicked first)

# Description

See [JENKINS-43201](https://issues.jenkins-ci.org/browse/JENKINS-43201).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests

Seems like there are not frontend style tests.
Example page https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fci/detail/PR-76/1/pipeline/190/. You can use the browser inspector to see the effect of this change.

- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
