### PR TITLE
[FIX JENKINS-47249] Remove name parallel group dialog (1.3 branch)

### DIFF
--- a/blueocean-pipeline-editor/src/main/js/components/editor/EditorMain.jsx
+++ b/blueocean-pipeline-editor/src/main/js/components/editor/EditorMain.jsx
@@ -17,7 +17,6 @@ import pipelineValidator from '../../services/PipelineValidator';
 import { ValidationMessageList } from './ValidationMessageList';
 import focusOnElement from './focusOnElement';
 import debounce from 'lodash.debounce';
-import { Dialog, TextInput, FormElement } from '@jenkins-cd/design-language';
 
 type Props = {
 };
@@ -116,29 +115,10 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
         }
     }
 
-    promptForParallelName(parentStage:StageInfo) {
-        let val = '';
-        const createStage = () => {
-            this.setState({ dialog: null }, () => this.createStage(parentStage, val));
-        };
-        this.setState({ dialog: (
-            <Dialog className="name-new-parallel" onDismiss={() => this.setState({dialog: null})}
-                    title="Name Parallel Group"
-                    buttons={<div><button onClick={() => createStage()}>Create</button></div>}>
-                <FormElement title="Group Name">
-                    <TextInput isRequired
-                               defaultValue={val}
-                               onChange={v => val = v}
-                               onEnterPressed={() => createStage()}/>
-                </FormElement>
-            </Dialog>
-        )}, () => document.querySelector('.name-new-parallel input').focus());
-    }
-
     createStage(parentStage:StageInfo, parallelGroupName:string) {
         if (parentStage && !parallelGroupName) {
             if (!parentStage.children || !parentStage.children.length) {
-                this.promptForParallelName(parentStage);
+                this.createStage(parentStage, parentStage.name);
                 return;
             }
         }

--- a/blueocean-pipeline-editor/src/main/js/services/PipelineStore.js
+++ b/blueocean-pipeline-editor/src/main/js/services/PipelineStore.js
@@ -251,6 +251,7 @@ class PipelineStore {
             let onlyChild = newChildren[0];
             newChildren = [];
             moveStageProperties(onlyChild, parentStage);
+            parentStage.name = onlyChild.name;
         }
 
         // Update the parent with new children list


### PR DESCRIPTION
# Description

Removes "Name Parallel Group" dialog. To test: create a parallel group. Needs more tests in this area.

See [JENKINS-47249](https://issues.jenkins-ci.org/browse/JENKINS-47249).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

