### PR TITLE
Add log message to help debug flakiness

### DIFF
--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubCreationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubCreationTest.java
@@ -119,6 +119,8 @@ public class GithubCreationTest{
     @Test
     @Retry(3)
     public void testCreatePipelineFull() throws IOException {
+        // Log SSE events to help debug flakiness
+        sseClient.setLogEvents(true);
         URL jenkinsFileUrl = Resources.getResource(this.getClass(), "Jenkinsfile");
         byte[] content = Resources.toByteArray(jenkinsFileUrl);
         GHContentUpdateResponse updateResponse = ghRepository.createContent(content, "Jenkinsfile", "Jenkinsfile", "master");


### PR DESCRIPTION
# Description

ATH test `GithubCreationTest.testCreatePipelineFull()` has been failing:
https://ci.blueocean.io/blue/organizations/jenkins/blueocean/detail/master/1372/tests

On completion of successful pipeline creation creation page redirects to activity page. The test is failing timing out waiting to get to activity page.

Github pipeline creation code waits for certain sse events to arrive to get hint that pipeline was created and is running before transferring to activity page: see: https://github.com/jenkinsci/blueocean-plugin/blob/76af0a305b454fba4bff4bb687d2b26614b87496/blueocean-dashboard/src/main/js/creation/github/GithubFlowManager.js#L389 and https://github.com/jenkinsci/blueocean-plugin/blob/76af0a305b454fba4bff4bb687d2b26614b87496/blueocean-dashboard/src/main/js/creation/github/steps/GithubCompleteStep.jsx#L77.

Enabling logging of sse events to help debug cause of failure. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
