### PR TITLE
[FIX JENKINS-47248] Add warning / message that saving Jenkinsfiles without SSH is unsupported (1.3 branch)

### DIFF
--- a/blueocean-dashboard/src/main/js/creation/git/GitConnectStep.jsx
+++ b/blueocean-dashboard/src/main/js/creation/git/GitConnectStep.jsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import debounce from 'lodash.debounce';
 import Extensions from '@jenkins-cd/js-extensions';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import { Dropdown, FormElement, TextInput } from '@jenkins-cd/design-language';
+import { Alerts, Dropdown, FormElement, TextInput } from '@jenkins-cd/design-language';
 
 import FlowStep from '../flow2/FlowStep';
 
@@ -23,11 +23,11 @@ function isSshRepositoryUrl(url) {
         return false;
     }
 
-    if (/ssh:\/\/.*/.test(url)) {
+    if (/^ssh:\/\/.*/.test(url)) {
         return true;
     }
 
-    if (/[^@:]+@.*/.test(url)) {
+    if (/^[^@:]+@.*/.test(url)) {
         return true;
     }
 
@@ -197,23 +197,30 @@ export default class GitConnectStep extends React.Component {
                 }
 
                 {isNonSshRepositoryUrl(this.state.repositoryUrl) &&
-                <FormElement title={t('creation.git.step1.credentials')} errorMessage={credentialErrorMsg}>
-                    <Dropdown
-                        ref={dropdown => this._bindDropdown(dropdown)}
-                        className="dropdown-credentials"
-                        options={flowManager.credentials}
-                        defaultOption={noCredentialsOption}
-                        labelField="displayName"
-                        onChange={opt => this._selectedCredentialChange(opt)}
-                    />
+                <div>
+                    <div style={{marginTop: 16, marginBottom: 10}}>
+                        <Alerts type="Warning"
+                            message={<div style={{marginTop: 6, marginBottom: 6}}>
+                                Saving Pipelines is unsupported using http/https repositories. Please use SSH instead.</div>} />
+                    </div>
+                    <FormElement title={t('creation.git.step1.credentials')} errorMessage={credentialErrorMsg}>
+                        <Dropdown
+                            ref={dropdown => this._bindDropdown(dropdown)}
+                            className="dropdown-credentials"
+                            options={flowManager.credentials}
+                            defaultOption={noCredentialsOption}
+                            labelField="displayName"
+                            onChange={opt => this._selectedCredentialChange(opt)}
+                        />
 
-                    <button
-                        className="button-create-credential btn-secondary"
-                        onClick={() => this._onCreateCredentialClick()}
-                    >
-                        {t('creation.git.step1.create_credential_button')}
-                    </button>
-                </FormElement>
+                        <button
+                            className="button-create-credential btn-secondary"
+                            onClick={() => this._onCreateCredentialClick()}
+                        >
+                            {t('creation.git.step1.create_credential_button')}
+                        </button>
+                    </FormElement>
+                </div>
                 }
                 </ReactCSSTransitionGroup>
 

--- a/blueocean-dashboard/src/main/js/creation/git/GitConnectStep.jsx
+++ b/blueocean-dashboard/src/main/js/creation/git/GitConnectStep.jsx
@@ -198,10 +198,14 @@ export default class GitConnectStep extends React.Component {
 
                 {isNonSshRepositoryUrl(this.state.repositoryUrl) &&
                 <div>
-                    <div style={{marginTop: 16, marginBottom: 10}}>
+                    <div style={{ marginTop: 16, marginBottom: 10 }}>
                         <Alerts type="Warning"
-                            message={<div style={{marginTop: 6, marginBottom: 6}}>
-                                Saving Pipelines is unsupported using http/https repositories. Please use SSH instead.</div>} />
+                            message={
+                                <div style={{ marginTop: 6, marginBottom: 6 }}>
+                                    Saving Pipelines is unsupported using http/https repositories. Please use SSH instead.
+                                </div>
+                            }
+                        />
                     </div>
                     <FormElement title={t('creation.git.step1.credentials')} errorMessage={credentialErrorMsg}>
                         <Dropdown

--- a/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
+++ b/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
@@ -407,7 +407,7 @@ class PipelineLoader extends React.Component {
         const { scmSource } = pipeline;
 
         if (!scmSource || !scmSource.id || (scmSource.id === 'git' && !isSshRepositoryUrl(scmSource.apiUrl))) {
-            this.showLoadingError('', 'This repository does not support saving');
+            this.showLoadingError('', 'Saving Pipelines is unsupported using http/https repositories. Please use SSH instead.');
             return;
         }
 

--- a/blueocean-pipeline-editor/src/main/js/GitUtils.js
+++ b/blueocean-pipeline-editor/src/main/js/GitUtils.js
@@ -8,11 +8,11 @@ export function isSshRepositoryUrl(url) {
         return false;
     }
 
-    if (/ssh:\/\/.*/.test(url)) {
+    if (/^ssh:\/\/.*/.test(url)) {
         return true;
     }
 
-    if (/[^@:]+@.*/.test(url)) {
+    if (/^[^@:]+@.*/.test(url)) {
         return true;
     }
 

--- a/blueocean-pipeline-editor/src/main/js/PipelineEditorLink.jsx
+++ b/blueocean-pipeline-editor/src/main/js/PipelineEditorLink.jsx
@@ -54,7 +54,7 @@ class PipelineEditorLink extends React.Component {
 
     _canSavePipeline(pipeline) {
         if (pipeline.scmSource && pipeline.scmSource.id === 'git') {
-            return isSshRepositoryUrl(pipeline.scmSource.apiUrl);
+            return true;
         }
         if (pipeline._capabilities && pipeline._capabilities
                 .find(capability => capability === 'io.jenkins.blueocean.rest.model.BluePipelineScm')) {


### PR DESCRIPTION
# Description

Tweak to add text indicating saving using non-SSH is not supported. Needs more tests in this area.

![image](https://user-images.githubusercontent.com/3009477/31112282-cccd35a0-a7e0-11e7-8575-0be9ae3092aa.png)

![image](https://user-images.githubusercontent.com/3009477/31112288-d61e1bd8-a7e0-11e7-8cba-e2ffe4a073f0.png)

See [JENKINS-47248](https://issues.jenkins-ci.org/browse/JENKINS-47248).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

