### PR TITLE
[FIX JENKINS-47357] release/1.3: bitbucket unable to save

### DIFF
--- a/blueocean-bitbucket-pipeline/pom.xml
+++ b/blueocean-bitbucket-pipeline/pom.xml
@@ -43,9 +43,16 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    <dependency> <!-- need to use this instead of the plugin due to a classloader issue -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+
+    <dependency> <!-- need to use this instead of the plugin due to a classloader issue -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Description

Unable to save to bitbucket due to a classloader issue with the `apache-httpcomponents-4-api` plugin. Need ATH tests for this!!

See [JENKINS-47357](https://issues.jenkins-ci.org/browse/JENKINS-47357).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

