### PR TITLE
JIRA and Github issues not showing up in REST

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssue.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssue.java
@@ -1,9 +1,7 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import com.google.common.base.Function;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -17,9 +15,7 @@ import jenkins.scm.api.SCMSource;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.github_branch_source.HttpsRepositoryUriResolver;
-import org.kohsuke.github.GitHub;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssue.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssue.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
@@ -65,7 +66,7 @@ public class GithubIssue extends BlueIssue {
                 return null;
             }
             GitHubSCMSource gitHubSource = (GitHubSCMSource)source;
-            String apiUri = MoreObjects.firstNonNull(gitHubSource.getApiUri(), GitHubServerConfig.GITHUB_URL);
+            String apiUri = Objects.firstNonNull(gitHubSource.getApiUri(), GitHubServerConfig.GITHUB_URL);
             final String repositoryUri = new HttpsRepositoryUriResolver().getRepositoryUri(apiUri, gitHubSource.getRepoOwner(), gitHubSource.getRepository());
             return Collections2.transform(findIssueKeys(changeSetEntry.getMsg()), new Function<String, BlueIssue>() {
                 @Override


### PR DESCRIPTION
# Description

JIRA and Github issues were not loading via REST. On further inspection of the logs, it looks like there was a classloading error for Guava's `MoreObjects.firstNotNull`.  This switches it to use the old API and now it all works.

@vivek potential class loading problem - Guava :'(

See [JENKINS-46017](https://issues.jenkins-ci.org/browse/JENKINS-46017).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

