### PR TITLE
JENKINS-47357# Fix for linkage error during bitbucket pipeline save

### DIFF
--- a/blueocean-bitbucket-pipeline/pom.xml
+++ b/blueocean-bitbucket-pipeline/pom.xml
@@ -44,11 +44,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
-    </dependency>
-
-    <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pubsub-light</artifactId>
     </dependency>
@@ -56,6 +51,15 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -50,10 +50,9 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pubsub-light</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/blueocean-jira/pom.xml
+++ b/blueocean-jira/pom.xml
@@ -39,8 +39,12 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
         </dependency>
     </dependencies>
 

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -50,6 +50,11 @@
 
         <!-- Test plugins -->
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <scope>test</scope>

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -114,11 +114,6 @@
             <artifactId>pipeline-milestone-step</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-        </dependency>
-
         <!-- Test deps -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,11 +174,6 @@
 
       <!-- Needed for unirest -->
       <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>apache-httpcomponents-client-4-api</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
           <groupId>org.powermock</groupId>
           <artifactId>powermock-module-junit4-common</artifactId>
           <scope>test</scope>
@@ -464,13 +459,6 @@
                     <artifactId>asm</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!--Used from blueocean-github-pipeline and blueocean-bitbucket-pipeline modules as well as by tests using unirest -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.3-2.0</version>
         </dependency>
 
         <!-- Bitbucket dependencies -->
@@ -764,7 +752,6 @@
             <version>1.4.9</version>
             <scope>test</scope>
             <exclusions>
-                <!--Exclude httpcomponents libraries, these are loaded from apache-httpcomponents-client-4-api plugin -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
@@ -919,6 +906,21 @@
             <version>${scm-api.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.5.3</version>
         </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Description

See [JENKINS-47357](https://issues.jenkins-ci.org/browse/JENKINS-47357).

This regression happened when we started depending on `apache-httpcomponents-client-4-api`. Main purpose of this was to load one set of httpcomponents library that all plugins use. Unfortunately upsrtream plugins (git, git-client, jira, blueocean-display-url etc.) depend directly on httpcomponents libs and this causes classes from it to be loaded anyways causing linkage error. To fix it I tried excluding httpcompoents libraries from different components but it simply doesn't work. These gets sucked in anyways.

For now, I am reverting dependence on `apache-httpcomponents-client-4-api` till all upstream libs are fixed to use it. Until then we are depending on httpcomponents directly. Lets see our tests pass and I will run PCT over this branch to ensure there is no side effect of this change.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

