### PR TITLE
JENKINS-46335 Pipeline graph flickers

### DIFF
--- a/blueocean-dashboard/src/main/js/components/karaoke/components/FreeStyle.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/FreeStyle.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { logging } from '@jenkins-cd/blueocean-core-js';
 import { observer } from 'mobx-react';
 import { KaraokeService } from '../index';
+import { QueuedState } from './QueuedState';
 import LogConsole from './LogConsole';
 import LogToolbar from './LogToolbar';
 
@@ -50,6 +51,18 @@ export default class FreeStyle extends Component {
         this.pager = KaraokeService.generalLogPager(augmenter, location);
     }
     render() {
+        const run = this.props.run;
+        const isPipelineQueued = run && run.isQueued();
+        if (isPipelineQueued) { // if queued we are saying that we are waiting to start
+            logger.debug('EarlyOut - abort due to run queued.');
+            return (<QueuedState
+                translation={this.props.t}
+                titleKey="rundetail.pipeline.waiting.message.title"
+                messageKey="rundetail.pipeline.waiting.message.description"
+                message={run.causeOfBlockage}
+            />);
+        }
+
         if (this.pager.pending) {
             logger.debug('abort due to pager pending');
             return null;

--- a/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
@@ -168,15 +168,6 @@ export default class Pipeline extends Component {
         // Queue magic since a pipeline is only showing queued state a short time even if still waiting for executors
         const isPipelineQueued = (run.isQueued() || run.isRunning()) && noResultsToDisplay;
         logger.debug('isQueued', run.isQueued(), 'noResultsToDisplay', noResultsToDisplay, 'isPipelineQueued', isPipelineQueued);
-        if (isPipelineQueued) { // if queued we are saying that we are waiting to start
-            logger.debug('EarlyOut - abort due to run queued.');
-            return (<QueuedState
-                translation={t}
-                titleKey="rundetail.pipeline.waiting.message.title"
-                messageKey="rundetail.pipeline.waiting.message.description"
-                message={run.causeOfBlockage}
-            />);
-        }
         const supportsNodes = this.pager.nodes === undefined;
         if (!this.pager.pending && (this.classicLog || (noResultsToDisplay && supportsNodes))) { // no information? fallback to freeStyle
             logger.debug('EarlyOut - We do not have any information we can display or we opt-out by preference, falling back to freeStyle rendering');

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStylePipeline.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStylePipeline.java
@@ -1,0 +1,41 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import hudson.Extension;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Job;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.annotation.Capability;
+import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.rest.model.BluePipeline;
+import io.jenkins.blueocean.rest.model.Resource;
+
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_FREESTYLE_PROJECT;
+
+@Capability(JENKINS_FREESTYLE_PROJECT)
+public class FreeStylePipeline extends AbstractPipelineImpl {
+    private FreeStylePipeline(BlueOrganization organization, Job job) {
+        super(organization, job);
+    }
+
+    @Extension(ordinal = 1)
+    public static class FactoryImpl extends BluePipelineFactory {
+        @Override
+        public BluePipeline getPipeline(Item item, Reachable parent, BlueOrganization organization) {
+            if (item instanceof FreeStyleProject) {
+                FreeStyleProject job = (FreeStyleProject)item;
+                return new FreeStylePipeline(organization, job);
+            }
+            return null;
+        }
+
+        @Override
+        public Resource resolve(Item context, Reachable parent, Item target, BlueOrganization organization) {
+            if(context == target && target instanceof FreeStyleProject) {
+                return getPipeline(target, parent, organization);
+            }
+            return null;
+        }
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueUtil.java
@@ -7,9 +7,10 @@ import hudson.model.BuildableItem;
 import hudson.model.Job;
 import hudson.model.Run;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
 import io.jenkins.blueocean.rest.hal.Link;
-import io.jenkins.blueocean.rest.hal.LinkResolver;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BlueQueueItem;
 import jenkins.model.Jenkins;
 
@@ -55,18 +56,18 @@ public class QueueUtil {
      * @return List of items newest first
      */
     public static List<BlueQueueItem> getQueuedItems(BlueOrganization organization, Job job) {
-        Link pipelineLink = LinkResolver.resolveLink(job);
-        if(job instanceof BuildableItem) {
+        BluePipeline pipeline = (BluePipeline) BluePipelineFactory.resolve(job);
+        if(job instanceof BuildableItem && pipeline != null) {
             BuildableItem task = (BuildableItem)job;
             List<hudson.model.Queue.Item> items = Jenkins.getInstance().getQueue().getItems(task);
             List<BlueQueueItem> items2 = Lists.newArrayList();
             for (int i = 0; i < items.size(); i++) {
-                Link self = pipelineLink.rel("queue").rel(Long.toString(items.get(i).getId()));
+                Link self = pipeline.getLink().rel("queue").rel(Long.toString(items.get(i).getId()));
                 items2.add(0, new QueueItemImpl(
                     organization,
                     items.get(i),
-                    job.getName(),
-                    (items.size() == 1 ? job.getNextBuildNumber() : job.getNextBuildNumber() + i), self, pipelineLink));
+                    pipeline,
+                    (items.size() == 1 ? job.getNextBuildNumber() : job.getNextBuildNumber() + i), self, pipeline.getLink()));
             }
 
             return items2;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueuedFreeStyleRun.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueuedFreeStyleRun.java
@@ -1,0 +1,13 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import io.jenkins.blueocean.rest.annotation.Capability;
+import io.jenkins.blueocean.rest.hal.Link;
+
+import static io.jenkins.blueocean.rest.model.KnownCapabilities.JENKINS_FREE_STYLE_BUILD;
+
+@Capability(JENKINS_FREE_STYLE_BUILD)
+public class QueuedFreeStyleRun extends QueuedBlueRun {
+    public QueuedFreeStyleRun(BlueRunState runState, BlueRunResult runResult, QueueItemImpl item, Link parent) {
+        super(runState, runResult, item, parent);
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
@@ -140,7 +140,7 @@ public class RunContainerImpl extends BlueRunContainer {
                 return new QueueItemImpl(
                     pipeline.getOrganization(),
                     item,
-                    job.getName(),
+                    pipeline,
                     expectedBuildNumber, pipeline.getLink().rel("queue").rel(Long.toString(item.getId())),
                     pipeline.getLink()
                 ).toRun();

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/KnownCapabilities.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/KnownCapabilities.java
@@ -27,6 +27,7 @@ public class KnownCapabilities {
     public static final String JENKINS_ABSTRACT_FOLDER ="com.cloudbees.hudson.plugins.folder.AbstractFolder";
     public static final String JENKINS_JOB ="hudson.model.Job";
     public static final String JENKINS_MATRIX_PROJECT="hudson.matrix.MatrixProject";
+    public static final String JENKINS_FREESTYLE_PROJECT="hudson.model.FreeStyleProject";
     public static final String JENKINS_MULTI_BRANCH_PROJECT="jenkins.branch.MultiBranchProject";
     public static final String JENKINS_FREE_STYLE_BUILD="hudson.model.FreeStyleBuild";
     public static final String JENKINS_ORGANIZATION_FOLDER = "jenkins.branch.OrganizationFolder";


### PR DESCRIPTION
# Description
* Pipeline.jsx should never shortcut to the QueuedState message when the run is queued. This should only happen for freestyle jobs. This is why the Pipeline graph would flicker as the Pipeline changed nodes. 
* QueuedRun needs to smell like a FreeStyleBuild when its parent is FreeStyleProject otherwise Pipeline.jsx will be used instead of FreeStyle.jsx. This leads to the Queued freestyle run occasionally having a blank screen.

See [JENKINS-46335](https://issues.jenkins-ci.org/browse/JENKINS-46335).

# Testing scenarios
## Pipeline

### No flickering

1. Run the app store demo project
2. Notice how there is no flickering of the pipeline visualization

### Queued message

1. Disable all executors
2. Run the app store demo project
3. You should see the graph and the queued message where the steps should be
4. Enable all executors
5. The pipeline should finish

## Freestyle

1. Disable all executors 
2. Run a freestyle project
3. You should see the queued message
4. Enable all executors
5. The freestyle job should finish

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

