### PR TITLE
fs-extra

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -48,6 +48,10 @@ ENV MAVEN_HOME /usr/share/maven
 RUN wget --no-verbose https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz -O /opt/nodejs.tar.xz
 RUN tar -C /usr/local --strip-components 1 -xJf /opt/nodejs.tar.xz
 RUN mkdir /.npm && chmod 777 /.npm
+# Fix bug https://github.com/npm/npm/issues/9863
+RUN cd $(npm root -g)/npm \
+  && npm install fs-extra \
+  && sed -i -e s/graceful-fs/fs-extra/ -e s/fs\.rename/fs.move/ ./lib/utils/rename.js
 # Update to latest version so optional dependancies + shrinkwrap work
 RUN npm install -g npm@3.10.3
 


### PR DESCRIPTION
Without this,

```sh
docker build -t blueocean_build_env --build-arg GID=$(id -g ${USER}) --build-arg UID=$(id -u ${USER}) - < Dockerfile.build
```

fails for me on Ubuntu Zesty w/ Docker 17.09.0-ce:

```
Step 18/26 : RUN npm install -g npm@3.10.3
 ---> Running in e889b4076a6f
npm ERR! Linux 4.10.0-37-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "-g" "npm@3.10.3"
npm ERR! node v6.4.0
npm ERR! npm  v3.10.3
npm ERR! path /usr/local/lib/node_modules/npm
npm ERR! code EXDEV
npm ERR! errno -18
npm ERR! syscall rename

npm ERR! EXDEV: cross-device link not permitted, rename '/usr/local/lib/node_modules/npm' -> '/usr/local/lib/node_modules/.npm.DELETE'
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /npm-debug.log
The command '/bin/sh -c npm install -g npm@3.10.3' returned a non-zero code: 238
```

So I applied a fix: https://github.com/npm/npm/issues/9863#issuecomment-254080385

![Googling the error message](https://pbs.twimg.com/media/CfEhcE3VIAE5ePS.jpg)

@reviewbybees