### PR TITLE
JENKINS-47054# Bitbucket api access via http proxy

### DIFF
--- a/blueocean-bitbucket-pipeline/pom.xml
+++ b/blueocean-bitbucket-pipeline/pom.xml
@@ -46,8 +46,9 @@
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>fluent-hc</artifactId>
+      <artifactId>httpclient</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
@@ -9,7 +9,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.User;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbOrg;
 import io.jenkins.blueocean.commons.ErrorMessage;
@@ -136,7 +135,7 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
             throw new ServiceException.BadRequestException(new ErrorMessage(400, "Failed to return Bitbucket organizations").addAll(errors));
         }else {
             apiUrl = normalizeApiUrl(apiUrl);
-            BitbucketApiFactory apiFactory = BitbucketApiFactory.resolve(apiUrl);
+            BitbucketApiFactory apiFactory = BitbucketApiFactory.resolve(this.getId());
             if (apiFactory == null) {
                 throw new ServiceException.UnexpectedErrorException("BitbucketApiFactory to handle apiUrl " + apiUrl + " not found");
             }
@@ -210,7 +209,7 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         final StandardUsernamePasswordCredentials credential = new UsernamePasswordCredentialsImpl(CredentialsScope.USER,
                 createCredentialId(apiUrl), "Bitbucket server credentials", userName, password);
 
-        BitbucketApi api = getApi(apiUrl, credential);
+        BitbucketApi api = getApi(apiUrl, this.getId(), credential);
         api.getUser(); //if credentials are wrong, this call will fail with 403 error
 
         StandardUsernamePasswordCredentials bbCredentials = CredentialsUtils.findCredential(createCredentialId(apiUrl),
@@ -264,8 +263,8 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         }
     }
 
-    public static BitbucketApi getApi(String apiUrl, StandardUsernamePasswordCredentials credentials){
-        BitbucketApiFactory apiFactory = BitbucketApiFactory.resolve(apiUrl);
+    public static BitbucketApi getApi(String apiUrl, String scmId, StandardUsernamePasswordCredentials credentials){
+        BitbucketApiFactory apiFactory = BitbucketApiFactory.resolve(scmId);
         if(apiFactory == null){
             throw new ServiceException.UnexpectedErrorException("BitbucketApiFactory to handle apiUrl "+apiUrl+" not found");
         }

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScmContentProvider.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScmContentProvider.java
@@ -43,7 +43,7 @@ public abstract class AbstractBitbucketScmContentProvider extends AbstractScmCon
 
     @Override
     protected Object getContent(ScmGetRequest request) {
-        BitbucketApi api = BitbucketServerScm.getApi(request.getApiUrl(), request.getCredentials());
+        BitbucketApi api = BitbucketServerScm.getApi(request.getApiUrl(), this.getScmId(), request.getCredentials());
         BbBranch branch=null;
         String branchName = request.getBranch();
 
@@ -110,7 +110,7 @@ public abstract class AbstractBitbucketScmContentProvider extends AbstractScmCon
         String owner = scmParamsFromItem.getOwner();
         String repo = scmParamsFromItem.getRepo();
         String commitId = StringUtils.isNotBlank(gitContent.getCommitId()) ? gitContent.getCommitId() : gitContent.getSha();
-        BitbucketApi api = BitbucketServerScm.getApi(scmParamsFromItem.getApiUrl(), scmParamsFromItem.getCredentials());
+        BitbucketApi api = BitbucketServerScm.getApi(scmParamsFromItem.getApiUrl(), this.getScmId(), scmParamsFromItem.getCredentials());
 
         String content;
         try {

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApi.java
@@ -1,7 +1,6 @@
 package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import hudson.util.Secret;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbBranch;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbOrg;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbPage;
@@ -9,7 +8,6 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbRepo;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbSaveContentResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbUser;
 import io.jenkins.blueocean.commons.ServiceException;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.client.HttpResponseException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -17,7 +15,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 /**
@@ -27,10 +24,10 @@ import java.util.Map;
  */
 @Restricted(NoExternalUse.class)
 public abstract class BitbucketApi {
+
     protected final String apiUrl;
-    protected final StandardUsernamePasswordCredentials credentials;
     protected final String userName;
-    protected final String basicAuthHeaderValue;
+    protected final HttpRequest request;
 
     //XXX: To be used for testing to resolve correct factory
     public static final String X_BB_API_TEST_MODE_HEADER="X_BB_API_TEST_MODE_HEADER";
@@ -38,15 +35,8 @@ public abstract class BitbucketApi {
 
     protected BitbucketApi(@Nonnull String apiUrl, @Nonnull StandardUsernamePasswordCredentials credentials) {
         this.apiUrl = ensureTrailingSlash(apiUrl);
-        this.credentials = credentials;
-        try {
-            this.basicAuthHeaderValue = String.format("Basic %s",
-                    Base64.encodeBase64String(String.format("%s:%s", credentials.getUsername(),
-                            Secret.toString(credentials.getPassword())).getBytes("UTF-8")));
-            this.userName = credentials.getUsername();
-        } catch (UnsupportedEncodingException e) {
-            throw new ServiceException.UnexpectedErrorException("Failed to create basic auth header: "+e.getMessage(), e);
-        }
+        this.request = new HttpRequest.HttpRequestBuilder(apiUrl).credentials(credentials).build();
+        this.userName = credentials.getUsername();
     }
 
     /**

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApi.java
@@ -29,10 +29,6 @@ public abstract class BitbucketApi {
     protected final String userName;
     protected final HttpRequest request;
 
-    //XXX: To be used for testing to resolve correct factory
-    public static final String X_BB_API_TEST_MODE_HEADER="X_BB_API_TEST_MODE_HEADER";
-
-
     protected BitbucketApi(@Nonnull String apiUrl, @Nonnull StandardUsernamePasswordCredentials credentials) {
         this.apiUrl = ensureTrailingSlash(apiUrl);
         this.request = new HttpRequest.HttpRequestBuilder(apiUrl).credentials(credentials).build();

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApiFactory.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketApiFactory.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.ExtensionList;
+import io.jenkins.blueocean.rest.impl.pipeline.scm.Scm;
 import org.apache.tools.ant.ExtensionPoint;
 
 import javax.annotation.CheckForNull;
@@ -15,9 +16,9 @@ import javax.annotation.Nonnull;
  */
 public abstract class BitbucketApiFactory extends ExtensionPoint{
     /**
-     * @return true if this factory can handle this API url
+     * @return true if this factory can handle this scmId
      */
-    public abstract boolean handles(@Nonnull String apiUrl);
+    public abstract boolean handles(@Nonnull String scmId);
 
     /**
      * Create {@link BitbucketApi} instance.
@@ -30,9 +31,14 @@ public abstract class BitbucketApiFactory extends ExtensionPoint{
      */
     public abstract @Nonnull BitbucketApi create(@Nonnull String apiUrl, @Nonnull StandardUsernamePasswordCredentials credentials);
 
-    public static @CheckForNull BitbucketApiFactory resolve(@Nonnull String apiUrl){
+    /**
+     * Resolves a {@link BitbucketApiFactory}
+     * @param scmId id {@link Scm#getId()} of Bitbucket SCM provider
+     * @return {@link BitbucketApiFactory} instance, could be null
+     */
+    public static @CheckForNull BitbucketApiFactory resolve(@Nonnull String scmId){
         for(BitbucketApiFactory api: ExtensionList.lookup(BitbucketApiFactory.class)){
-            if(api.handles(apiUrl)){
+            if(api.handles(scmId)){
                 return api;
             }
         }

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
@@ -1,0 +1,154 @@
+package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.ProxyConfiguration;
+import hudson.util.Secret;
+import io.jenkins.blueocean.commons.ServiceException;
+import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+
+/**
+ * @author Vivek Pandey
+ */
+@Restricted(NoExternalUse.class)
+public class HttpRequest {
+    private final HttpClient client;
+    private final String authorizationHeader;
+
+    private HttpRequest(@Nonnull String apiUrl, @Nullable StandardUsernamePasswordCredentials credentials, @Nullable String authHeader) {
+        this.client = getHttpClient(apiUrl);
+        try {
+            if(StringUtils.isBlank(authHeader) && credentials != null) {
+                this.authorizationHeader = String.format("Basic %s",
+                        Base64.encodeBase64String(String.format("%s:%s", credentials.getUsername(),
+                                Secret.toString(credentials.getPassword())).getBytes("UTF-8")));
+            }else{
+                this.authorizationHeader = authHeader;
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new ServiceException.UnexpectedErrorException("Failed to create basic auth header: "+e.getMessage(), e);
+        }
+    }
+
+    public HttpResponse head(String url) {
+        try {
+            return new HttpResponse(client.execute(setAuthorizationHeader(new HttpHead(url))));
+        } catch (IOException e) {
+            throw handleException(e);
+        }
+    }
+
+    public HttpResponse get(String url) {
+        try {
+            return new HttpResponse(client.execute(setAuthorizationHeader(new HttpGet(url))));
+        } catch (IOException e) {
+            throw handleException(e);
+        }
+    }
+
+    public HttpResponse put(String url, HttpEntity body) {
+        try {
+            HttpPut httpPut = new HttpPut(url);
+            httpPut.setEntity(body);
+            return new HttpResponse(client.execute(setAuthorizationHeader(httpPut)));
+        } catch (IOException e) {
+            throw handleException(e);
+        }
+    }
+
+    public HttpResponse post(String url, HttpEntity body) {
+        try {
+            HttpPost post = new HttpPost(url);
+            post.setEntity(body);
+            return new HttpResponse(client.execute(setAuthorizationHeader(post)));
+        } catch (IOException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Converts thrown exception during BB HTTP call in to JSON serializable {@link ServiceException}
+     *
+     * @param e exception
+     * @return {@link ServiceException} instance
+     */
+    private ServiceException handleException(Exception e){
+        if(e instanceof HttpResponseException){
+            return new ServiceException(((HttpResponseException) e).getStatusCode(), e.getMessage(), e);
+        }
+        return new ServiceException.UnexpectedErrorException(e.getMessage(), e);
+    }
+
+
+    private  HttpClient getHttpClient(@Nonnull String apiUrl) {
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create().disableAutomaticRetries();
+        setClientProxyParams(apiUrl, clientBuilder);
+        return clientBuilder.build();
+    }
+
+    private void setClientProxyParams(String apiUrl, HttpClientBuilder clientBuilder) {
+        try {
+            URL url = new URL(apiUrl);
+            ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+            Proxy proxy = proxyConfig != null ? proxyConfig.createProxy(url.getHost()) : Proxy.NO_PROXY;
+            if (!proxy.equals(Proxy.NO_PROXY) && proxyConfig != null) {
+                clientBuilder.setProxy(new HttpHost(proxyConfig.name, proxyConfig.port));
+            }
+        } catch (MalformedURLException e) {
+            throw new ServiceException.UnexpectedErrorException("Invalid apiUrl: "+apiUrl, e);
+        }
+    }
+
+    private HttpUriRequest setAuthorizationHeader(HttpUriRequest request){
+        if(StringUtils.isNotBlank(authorizationHeader)) {
+            request.addHeader("Authorization", authorizationHeader);
+        }
+        return request;
+    }
+
+    public static class HttpRequestBuilder {
+        private final String url;
+        private String authHeader;
+        private StandardUsernamePasswordCredentials credentials;
+
+        public HttpRequestBuilder(@Nonnull String apiUrl) {
+            this.url = apiUrl;
+        }
+
+        public HttpRequestBuilder credentials(StandardUsernamePasswordCredentials credentials){
+            this.credentials = credentials;
+            return this;
+        }
+
+        public HttpRequestBuilder authenticationHeader(String authenticationHeader) {
+            this.authHeader = authenticationHeader;
+            return this;
+        }
+
+        public HttpRequest build() {
+            return new HttpRequest(url, credentials, authHeader);
+        }
+    }
+
+}

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -1,0 +1,49 @@
+package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
+
+import io.jenkins.blueocean.commons.ServiceException;
+import org.apache.http.HttpEntity;
+import org.apache.http.util.EntityUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author Vivek Pandey
+ */
+@Restricted(NoExternalUse.class)
+public class HttpResponse {
+    private final org.apache.http.HttpResponse response;
+
+    public HttpResponse(org.apache.http.HttpResponse response) {
+        this.response = response;
+    }
+
+    public @CheckForNull InputStream getContent() {
+        try {
+            HttpEntity entity = response.getEntity();
+            if(getStatus() >= 300){
+                EntityUtils.consume(entity);
+                throw new ServiceException(getStatus(), getStatusLine());
+            }
+            return entity == null ? null :entity.getContent();
+        } catch (IOException e) {
+            throw new ServiceException.UnexpectedErrorException(e.getMessage(), e);
+        }
+    }
+
+    public int getStatus() {
+        return response.getStatusLine().getStatusCode();
+    }
+
+    public @Nonnull String getStatusLine() {
+        return response.getStatusLine().getReasonPhrase();
+    }
+
+    public @CheckForNull String getHeader(String name) {
+        return response.getFirstHeader(name).getValue();
+    }
+}

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
@@ -2,7 +2,6 @@ package io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Preconditions;
 import hudson.Extension;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApiFactory;
@@ -23,11 +22,8 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -253,16 +249,8 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Extension
     public static class BitbucketCloudApiFactory extends BitbucketApiFactory {
         @Override
-        public boolean handles(@Nonnull String apiUrl) {
-            //We test using wiremock, where api url is always localhost:PORT, so we want to check for
-            // X_BB_API_MODE parameter during test.
-            //X_BB_API_MODE == "cloud" then its cloud  api mode otherwise its server
-
-            StaplerRequest request = Stapler.getCurrentRequest();
-            Preconditions.checkNotNull(request);
-            String mode=request.getHeader(X_BB_API_TEST_MODE_HEADER);
-            boolean isCloudMode =  StringUtils.isNotBlank(mode) && mode.equals("cloud");
-            return isCloudMode || apiUrl.startsWith("https://bitbucket.org") || apiUrl.startsWith("https://api.bitbucket.org");
+        public boolean handles(@Nonnull String scmId) {
+            return scmId.equals(BitbucketCloudScm.ID);
         }
 
         @Nonnull

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import hudson.Extension;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApiFactory;
+import io.jenkins.blueocean.blueocean_bitbucket_pipeline.HttpResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.model.BbCloudBranch;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.model.BbCloudPage;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.model.BbCloudRepo;
@@ -24,10 +25,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.fluent.Request;
-import org.apache.http.client.fluent.Response;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -58,9 +55,7 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbUser getUser() {
         try {
-            InputStream inputStream = Request.Get(baseUrl+"user")
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(baseUrl+"user").getContent();
             return om.readValue(inputStream, BbCloudUser.class);
         } catch (IOException e) {
             throw handleException(e);
@@ -71,9 +66,7 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbUser getUser(@Nonnull String userName) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s/%s",baseUrl+"users", userName))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"users", userName)).getContent();
             return om.readValue(inputStream, BbCloudUser.class);
         } catch (IOException e) {
             throw handleException(e);
@@ -99,9 +92,8 @@ public class BitbucketCloudApi extends BitbucketApi {
             if(pageSize <=0){
                 pageSize = PagedResponse.DEFAULT_LIMIT;
             }
-            InputStream inputStream = Request.Get(String.format("%s&page=%s&pagelen=%s",baseUrl+"teams/?role=contributor", pageNumber,pageSize))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s&page=%s&pagelen=%s",baseUrl+"teams/?role=contributor",
+                    pageNumber,pageSize)).getContent();
             BbPage<BbOrg> page =  om.readValue(inputStream, new TypeReference<BbCloudPage<BbCloudTeam>>(){});
             if(pageNumber == 1){ //add user org as the first org on first page
                 BbUser user = getUser();
@@ -132,9 +124,7 @@ public class BitbucketCloudApi extends BitbucketApi {
             if(orgName.equalsIgnoreCase(user.getSlug())){
                 return new BbCloudTeam(user.getSlug(), user.getDisplayName(), user.getAvatar());
             }
-            InputStream inputStream = Request.Get(String.format("%s/%s",baseUrl+"teams", orgName))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"teams", orgName)).getContent();
             return om.readValue(inputStream, BbCloudTeam.class);
         } catch (IOException e) {
             throw handleException(e);
@@ -145,9 +135,8 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbRepo getRepo(@Nonnull String orgId, String repoSlug) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s/%s",baseUrl+"repositories/"+orgId, repoSlug))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"repositories/"+orgId, repoSlug))
+                    .getContent();
             return om.readValue(inputStream, BbCloudRepo.class);
         } catch (IOException e) {
             throw handleException(e);
@@ -158,9 +147,8 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbPage<BbRepo> getRepos(@Nonnull String orgId, int pageNumber, int pageSize) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s?page=%s&limit=%s",baseUrl+"repositories/"+orgId, pageNumber, pageSize))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s?page=%s&limit=%s",baseUrl+"repositories/"+orgId,
+                    pageNumber, pageSize)).getContent();
             return om.readValue(inputStream, new TypeReference<BbCloudPage<BbCloudRepo>>(){});
         } catch (IOException e) {
             throw handleException(e);
@@ -171,10 +159,8 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public String getContent(@Nonnull String orgId, @Nonnull String repoSlug, @Nonnull String path, @Nonnull String commitId) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s/%s/%s/src/%s/%s",baseUrl+"repositories",orgId,
-                    repoSlug, commitId, path))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+            InputStream inputStream = request.get(String.format("%s/%s/%s/src/%s/%s",baseUrl+"repositories",orgId,
+                    repoSlug, commitId, path)).getContent();
             return IOUtils.toString(inputStream);
         } catch (IOException e) {
             throw handleException(e);
@@ -191,34 +177,29 @@ public class BitbucketCloudApi extends BitbucketApi {
                                              @Nullable String branch,
                                              @Nullable String sourceBranch,
                                              @Nullable String commitId) {
-        try {
-            MultipartEntityBuilder builder = MultipartEntityBuilder.create()
-                        .addTextBody(path, content)
-                    .addTextBody("message", commitMessage);
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create()
+                    .addTextBody(path, content)
+                .addTextBody("message", commitMessage);
 
-            if(isNotBlank(branch)){
-                builder.addTextBody("branch", branch);
-            }
+        if(isNotBlank(branch)){
+            builder.addTextBody("branch", branch);
+        }
 
-            if(isNotBlank(commitId)){
-                builder.addTextBody("parents", commitId);
+        if(isNotBlank(commitId)){
+            builder.addTextBody("parents", commitId);
+        }
+        HttpEntity entity = builder.build();
+        HttpResponse response = request.post(String.format("%s/%s/%s/src",baseUrl+"repositories",orgId,repoSlug), entity);
+        int status = response.getStatus();
+        if(status == 201){
+            String location = response.getHeader("Location");
+            if(location == null){
+                throw new ServiceException.UnexpectedErrorException("Location header is missing on save content response");
             }
-            HttpEntity entity = builder.build();
-            Response response = Request.Post(String.format("%s/%s/%s/src",baseUrl+"repositories",orgId,repoSlug))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .body(entity)
-                    .execute();
-            HttpResponse resp = response.returnResponse();
-            int status = resp.getStatusLine().getStatusCode();
-            if(status == 201){
-                String location = resp.getFirstHeader("Location").getValue();
-                String cid = location.substring(location.lastIndexOf("/")+1);
-                return new BbCloudSaveContentResponse(cid);
-            }else{
-                throw new ServiceException.UnexpectedErrorException("Failed to save file: "+path+" server returned status: "+status);
-            }
-        } catch (IOException e) {
-            throw handleException(e);
+            String cid = location.substring(location.lastIndexOf("/") + 1);
+            return new BbCloudSaveContentResponse(cid);
+        }else{
+            throw new ServiceException.UnexpectedErrorException("Failed to save file: "+path+" server returned status: "+status);
         }
     }
 
@@ -230,17 +211,15 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbBranch getBranch(@Nonnull String orgId, @Nonnull String repoSlug, @Nonnull String branch) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s/%s/refs/branches/%s?fields=target.hash,target.repository.mainbranch.name,target.repository.*,target.repository.owner.*,target.repository.owner.links.avatar.href,name",
+            HttpResponse response = request.get(String.format("%s/%s/refs/branches/%s?fields=target.hash,target.repository.mainbranch.name,target.repository.*,target.repository.owner.*,target.repository.owner.links.avatar.href,name",
                     baseUrl+"repositories/"+orgId,
                     repoSlug,
-                    branch))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
-            return om.readValue(inputStream, BbCloudBranch.class);
-        } catch (IOException e) {
-            if (e instanceof HttpResponseException && ((HttpResponseException) e).getStatusCode() == 404) {
+                    branch));
+            if(response.getStatus() == 404){
                 return null;
             }
+            return om.readValue(response.getContent(), BbCloudBranch.class);
+        } catch (Exception e) {
             throw handleException(e);
         }
     }
@@ -254,11 +233,10 @@ public class BitbucketCloudApi extends BitbucketApi {
     @Override
     public BbBranch getDefaultBranch(@Nonnull String orgId, @Nonnull String repoSlug) {
         try {
-            InputStream inputStream = Request.Get(String.format("%s/%s/?fields=mainbranch.*,mainbranch.target.*,mainbranch.target.repository.*,mainbranch.target.repository.mainbranch.name,mainbranch.target.repository.owner.*,mainbranch.target.repository.owner.links.avatar.*",
+            InputStream inputStream = request.get(String.format("%s/%s/?fields=mainbranch.*,mainbranch.target.*,mainbranch.target.repository.*,mainbranch.target.repository.mainbranch.name,mainbranch.target.repository.owner.*,mainbranch.target.repository.owner.links.avatar.*",
                     baseUrl+"repositories/"+orgId,
                     repoSlug))
-                    .addHeader("Authorization", basicAuthHeaderValue)
-                    .execute().returnContent().asStream();
+                    .getContent();
             Map<String, BbCloudBranch> resp = om.readValue(inputStream, new TypeReference<Map<String, BbCloudBranch>>() {});
             return resp.get("mainbranch");
         } catch (IOException e) {

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import hudson.Extension;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi;
@@ -33,8 +32,6 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -359,12 +356,8 @@ public class BitbucketServerApi extends BitbucketApi {
     @Extension
     public static class BitbucketServerApiFactory extends BitbucketApiFactory{
         @Override
-        public boolean handles(@Nonnull String apiUrl) {
-            StaplerRequest request = Stapler.getCurrentRequest();
-            Preconditions.checkNotNull(request);
-            String mode=request.getHeader(X_BB_API_TEST_MODE_HEADER);
-            boolean isCloudMode =  StringUtils.isNotBlank(mode) && mode.equals("cloud"); //used for testing
-            return !isCloudMode && !apiUrl.startsWith("https://bitbucket.org") && !apiUrl.startsWith("https://api.bitbucket.org");
+        public boolean handles(@Nonnull String scmId) {
+            return scmId.equals(BitbucketServerScm.ID);
         }
 
         @Nonnull

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketWireMockBase.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketWireMockBase.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi.X_BB_API_TEST_MODE_HEADER;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -66,9 +65,6 @@ public abstract class BitbucketWireMockBase extends PipelineBaseTest{
                 .put("/organizations/jenkins/scm/"+ scmId+"/validate/")
                 .data(ImmutableMap.of("apiUrl",apiUrl, "userName", getUserName(), "password",getPassword()));
 
-        if(apiMode.equals("cloud")){
-            builder.header(X_BB_API_TEST_MODE_HEADER, apiMode);
-        }
         Map r = builder.build(Map.class);
 
         assertNotNull(r);

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BbCloudPipelineCreateRequestTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BbCloudPipelineCreateRequestTest.java
@@ -17,11 +17,10 @@ import static org.junit.Assert.assertNotNull;
 public class BbCloudPipelineCreateRequestTest extends BbCloudWireMock {
     @Test
     public void createPipeline() throws UnirestException, IOException {
-        String credentialId = createCredential(BitbucketCloudScm.ID);
+        createCredential(BitbucketCloudScm.ID);
         Map r = new PipelineBaseTest.RequestBuilder(baseUrl)
                 .status(201)
                 .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
-                .header(io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi.X_BB_API_TEST_MODE_HEADER, "cloud")
                 .post("/organizations/jenkins/pipelines/")
                 .data(ImmutableMap.of("name", "pipeline1", "$class", "io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketPipelineCreateRequest",
                         "scmConfig", ImmutableMap.of("id", BitbucketCloudScm.ID, "uri", apiUrl,

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmContentProviderTest.java
@@ -9,7 +9,6 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.model.User;
 import hudson.tasks.Mailer;
 import hudson.util.DescribableList;
-import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketScmSaveFileRequest;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.BitbucketServerScmContentProvider;
 import io.jenkins.blueocean.commons.ServiceException;
@@ -170,7 +169,6 @@ public class BitbucketCloudScmContentProviderTest extends BbCloudWireMock{
         when(staplerRequest.getParameter("path")).thenReturn("Jenkinsfile");
         when(staplerRequest.getParameter("repo")).thenReturn("demo1");
         when(staplerRequest.getParameter("scmId")).thenReturn(BitbucketCloudScm.ID);
-        when(staplerRequest.getHeader(BitbucketApi.X_BB_API_TEST_MODE_HEADER)).thenReturn("cloud");
         return staplerRequest;
     }
 

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmTest.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi.X_BB_API_TEST_MODE_HEADER;
 import static org.junit.Assert.*;
 
 /**
@@ -35,7 +34,6 @@ public class BitbucketCloudScmTest extends BbCloudWireMock {
                 .status(200)
                 .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
                 .get("/organizations/jenkins/scm/"+BitbucketCloudScm.ID+"/organizations/"+getApiUrlParam()+"&credentialId="+credentialId)
-                .header(X_BB_API_TEST_MODE_HEADER, "cloud")
                 .build(List.class);
         assertEquals(2, orgs.size());
         assertEquals("vivekp7", ((Map)orgs.get(0)).get("key"));
@@ -51,7 +49,6 @@ public class BitbucketCloudScmTest extends BbCloudWireMock {
             .status(200)
             .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
             .get("/organizations/jenkins/scm/"+BitbucketCloudScm.ID+"/organizations/"+getApiUrlParam())
-            .header(X_BB_API_TEST_MODE_HEADER, "cloud")
             .build(List.class);
         assertEquals(2, orgs.size());
         assertEquals("vivekp7", ((Map)orgs.get(0)).get("key"));
@@ -75,7 +72,6 @@ public class BitbucketCloudScmTest extends BbCloudWireMock {
         Map repoResp = new RequestBuilder(baseUrl)
                 .status(200)
                 .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
-                .header(X_BB_API_TEST_MODE_HEADER, "cloud")
                 .get("/organizations/jenkins/scm/"+BitbucketCloudScm.ID+"/organizations/vivektestteam/repositories/"+getApiUrlParam()+"&credentialId="+credentialId)
                 .build(Map.class);
         List repos = (List) ((Map)repoResp.get("repositories")).get("items");
@@ -97,7 +93,6 @@ public class BitbucketCloudScmTest extends BbCloudWireMock {
         Map repoResp = new RequestBuilder(baseUrl)
             .status(200)
             .jwtToken(getJwtToken(j.jenkins, authenticatedUser.getId(), authenticatedUser.getId()))
-            .header(X_BB_API_TEST_MODE_HEADER, "cloud")
             .get("/organizations/jenkins/scm/"+BitbucketCloudScm.ID+"/organizations/vivektestteam/repositories/"+getApiUrlParam())
             .build(Map.class);
         List repos = (List) ((Map)repoResp.get("repositories")).get("items");


### PR DESCRIPTION
# Description

Adds HTTP proxy support. To simplify code, moved away from fluent http library.

I have tested bitbucket pipeline creation and editing for both bitbucket cloud and server.

See [JENKINS-47054](https://issues.jenkins-ci.org/browse/JENKINS-47054).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

