### PR TITLE
JENKINS-47509# Initialize mapped URL lazily

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
@@ -11,9 +11,43 @@ import javax.annotation.Nonnull;
  */
 public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
 
-    private final String mappedUrl;
+    private volatile String mappedUrl;
+    private final ModelObject modelObject;
 
     public BlueOceanUrlObjectImpl(ModelObject modelObject) {
+        this.modelObject = modelObject;
+    }
+
+    @Override
+    public @Nonnull String getDisplayName() {
+        return Messages.BlueOceanUrlAction_DisplayName();
+    }
+
+    @Override
+    public @Nonnull String getUrl() {
+        setUrlIfNeeded();
+        return mappedUrl;
+    }
+
+    @Override
+    public @Nonnull String getIconUrl() {
+        return "/plugin/blueocean-rest-impl/images/48x48/blueocean.png";
+    }
+
+    private void setUrlIfNeeded(){
+        String url = mappedUrl;
+        if(url == null){
+            synchronized (this){
+                url = mappedUrl;
+                if(url == null){
+                    url = computeUrl();
+                    this.mappedUrl = url;
+                }
+            }
+        }
+    }
+
+    private String computeUrl(){
         String url = null;
         for(BlueOceanUrlMapper mapper: BlueOceanUrlMapper.all()){
             url = mapper.getUrl(modelObject);
@@ -24,21 +58,6 @@ public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
         if(url == null){
             url = BlueOceanUrlMapperImpl.getLandingPagePath();
         }
-        this.mappedUrl = url;
-    }
-
-    @Override
-    public @Nonnull String getDisplayName() {
-        return Messages.BlueOceanUrlAction_DisplayName();
-    }
-
-    @Override
-    public @Nonnull String getUrl() {
-        return mappedUrl;
-    }
-
-    @Override
-    public @Nonnull String getIconUrl() {
-        return "/plugin/blueocean-rest-impl/images/48x48/blueocean.png";
+        return url;
     }
 }


### PR DESCRIPTION
# Description

Computation of mapped url involves creating blueocean pipeline object graph (Note: the object graph gets created lazily as well). It can potential cause performance issues as access to transient actions resulting in calling `TryBlueOceanMenu.createFor(ModelOjbect target)` and that computes url eagerly. See See [JENKINS-47509](https://issues.jenkins-ci.org/browse/JENKINS-47509) for details.

Fix is made to initialize mapped url lazily. That is only when `BlueOceanUrlAction.getUrlName()` is called. It happens during rendering and to avoid duplicates.

cc: @svanoort 

See [JENKINS-47509](https://issues.jenkins-ci.org/browse/JENKINS-47509).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given