### PR TITLE
Display all pipeline nodes when there are many

### DIFF
--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -41,6 +41,7 @@
     "gulp-mocha": "3.0.1",
     "mocha": "3.1.0",
     "nock": "8.0.0",
+    "parse-link-header": "1.0.1",
     "react-addons-test-utils": "15.4.2",
     "react-router": "2.8.1",
     "reactify": "1.1.1",

--- a/blueocean-dashboard/src/main/js/components/karaoke/rest/KaraokeApi.js
+++ b/blueocean-dashboard/src/main/js/components/karaoke/rest/KaraokeApi.js
@@ -1,4 +1,4 @@
-import { capabilityAugmenter, Fetch, FetchFunctions, logging } from '@jenkins-cd/blueocean-core-js';
+import { capabilityAugmenter, Fetch, logging } from '@jenkins-cd/blueocean-core-js';
 import debounce from 'lodash.debounce';
 import { generateDetailUrl } from '../urls/detailUrl';
 import { getNodesInformation } from '../../../util/logDisplayHelper';
@@ -63,7 +63,6 @@ export class KaraokeApi {
         const href = generateDetailUrl(pipeline, branch, runId);
         logger.debug('Fetching href', href);
         return Fetch.fetchJSON(href, { fetchOptions })
-            .then(FetchFunctions.checkStatus)
             .then(data => capabilityAugmenter.augmentCapabilities(data));
     }
 
@@ -84,7 +83,6 @@ export class KaraokeApi {
                     resolve();
                 }
                 resolve(Fetch.fetch(finalHref, { fetchOptions })
-                    .then(FetchFunctions.checkStatus)
                     .then(parseMoreDataHeader)
                     .then(parseNewStart));
             }, 200)();
@@ -103,7 +101,6 @@ export class KaraokeApi {
                     resolve();
                 }
                 resolve(Fetch.fetchJSON(href, { fetchOptions })
-                    .then(FetchFunctions.checkStatus)
                     .then(data => capabilityAugmenter.augmentCapabilities(data))
                     .then(getNodesInformation));
             }, 200)();

--- a/blueocean-dashboard/src/main/js/components/karaoke/rest/KaraokeApi.js
+++ b/blueocean-dashboard/src/main/js/components/karaoke/rest/KaraokeApi.js
@@ -62,8 +62,7 @@ export class KaraokeApi {
         const fetchOptions = prepareOptions();
         const href = generateDetailUrl(pipeline, branch, runId);
         logger.debug('Fetching href', href);
-        return Fetch.fetchJSON(href, { fetchOptions })
-            .then(data => capabilityAugmenter.augmentCapabilities(data));
+        return Fetch.fetchJSON(href, { fetchOptions });
     }
 
     /**
@@ -101,7 +100,6 @@ export class KaraokeApi {
                     resolve();
                 }
                 resolve(Fetch.fetchJSON(href, { fetchOptions })
-                    .then(data => capabilityAugmenter.augmentCapabilities(data))
                     .then(getNodesInformation));
             }, 200)();
         });

--- a/blueocean-dashboard/src/main/js/components/karaoke/services/pagers/PipelinePager.js
+++ b/blueocean-dashboard/src/main/js/components/karaoke/services/pagers/PipelinePager.js
@@ -79,7 +79,7 @@ export class PipelinePager {
             },
         };
         // get api data and further process it
-        return KaraokeApi.getNodes(this.augmenter.nodesUrl)
+        return KaraokeApi.getAllNodes(this.augmenter.nodesUrl)
             .then(action('Process node data', result => {
                 if (result.model.length === 0) {
                     logger.debug('Seems we do not have any nodes for this run.');


### PR DESCRIPTION
# Description

The BlueOcean nodes API is paginated, returning results in pages of (by default) 100 items. For large pipelines with more nodes than this, the UI would display only the first 100, making no attempt to fetch further pages.

I'm not aware of any tests for the existing functionality which I could have extended to demonstrate the issue, and so I also did not add any new tests for this.

In order to manually test this, I used [a pipeline with > 300 items](https://github.com/benlangfeld/jenkins-test/blob/master/Jenkinsfile). On the blueocean-plugin master branch, only the first 100 will be displayed. On this branch, all nodes will be displayed.

While a build is in progress, I do encounter several errors in the browser console:

```
blueocean-core-js.js:3184 [ERROR - io.jenkins.blueocean.dashboard.karaoke.Pager.Pipeline] Error fetching page TypeError: Already read
```

I believe this is to do with overlapping fetches because we do not wait for all pages to be fetched before making another attempt, but I am unsure of the best approach to fix this. It has no negative impact on the user experience, however.

See [JENKINS-41205](https://issues.jenkins-ci.org/browse/JENKINS-41205).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

