### PR TITLE
JENKINS-46490# Fix graph visualization for single parallel branch

### DIFF
--- a/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
+++ b/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
@@ -49,9 +49,10 @@ export const getNodesInformation = (nodes) => {
         /*
          * are we in a node that indicates that we have parallel nodes?
          */
-        if (item.edges && item.edges.length >= 2) {
-            parallelNodes = item.edges.map((itemParallel) => itemParallel.id);
+        if (item.edges) {
+            parallelNodes = item.edges.filter((edge) => edge.type === 'PARALLEL');
         }
+
         // in case we had been in a parallel node before, we will indicate it and remove the id of the parallel array
         const indexParallel = parallelNodes.indexOf(item.id);
         const isParallel = indexParallel !== -1;
@@ -72,6 +73,7 @@ export const getNodesInformation = (nodes) => {
             key: key || undefined,
             id: item.id,
             edges: item.edges,
+            type: item.type,
             displayName: item.displayName,
             displayDescription: item.displayDescription,
             title: title || `runId: ${item.id}`,

--- a/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
+++ b/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
@@ -50,7 +50,7 @@ export const getNodesInformation = (nodes) => {
          * are we in a node that indicates that we have parallel nodes?
          */
         if (item.edges) {
-            parallelNodes = item.edges.filter((edge) => edge.type === 'PARALLEL');
+            parallelNodes = item.edges.filter((edge) => edge.type === 'PARALLEL').map((edge) => edge.id);
         }
 
         // in case we had been in a parallel node before, we will indicate it and remove the id of the parallel array

--- a/blueocean-dashboard/src/test/js/pipeline-graph-converter-spec.js
+++ b/blueocean-dashboard/src/test/js/pipeline-graph-converter-spec.js
@@ -26,12 +26,13 @@ function jenkinsNode(name) {
         input: null,
         causeOfBlockage: null,
         result: 'SUCCESS',
+        type: 'STAGE',
         startTime: new Date(2017, 8, 3, 12, 0, 0, 0).toISOString(),
         state: 'FINISHED',
     };
 }
 
-function connect(left, right) {
+function connect(left, right, type='STAGE') {
     const ms = left.durationInMillis;
     const d1 = new Date(left.startTime);
     const d2 = new Date(right.startTime);
@@ -41,6 +42,7 @@ function connect(left, right) {
     right.startTime = d3.toISOString();
     left.edges.push({
         id: right.id,
+        type: type
     });
 }
 
@@ -405,17 +407,17 @@ describe('pipeline graph data converter /', () => {
             connect(alpha, bravo);
 
             // Split into parallels
-            connect(bravo, delta);
-            connect(bravo, echo);
-            connect(bravo, foxtrot);
-            connect(bravo, hotel);
+            connect(bravo, delta, 'PARALLEL');
+            connect(bravo, echo, 'PARALLEL');
+            connect(bravo, foxtrot, 'PARALLEL');
+            connect(bravo, hotel, 'PARALLEL');
 
             // Two stages in foxtrot row
-            connect(foxtrot, golf);
+            connect(foxtrot, golf, 'PARALLEL');
 
             // Three stages in hotel row
-            connect(hotel, india);
-            connect(india, juliett);
+            connect(hotel, india,'PARALLEL');
+            connect(india, juliett,'PARALLEL');
 
             // Collapse parallel branches to final stage
             connect(delta, charlie);

--- a/blueocean-dashboard/src/test/json/pipeline-graph-converter/ends-with-parallel.json
+++ b/blueocean-dashboard/src/test/json/pipeline-graph-converter/ends-with-parallel.json
@@ -4,12 +4,14 @@
         "edges": [
             {
                 "durationInMillis": 694,
-                "id": "9"
+                "id": "9",
+                "type": "STAGE"
             }
         ],
         "id": "3",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:28.639+1000",
+        "type": "STAGE",
         "state": "FINISHED"
     },
     {
@@ -17,16 +19,19 @@
         "edges": [
             {
                 "durationInMillis": 2,
-                "id": "12"
+                "id": "12",
+                "type": "PARALLEL"
             },
             {
                 "durationInMillis": 3,
-                "id": "13"
+                "id": "13",
+                "type": "PARALLEL"
             }
         ],
         "id": "9",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.333+1000",
+        "type": "STAGE",
         "state": "FINISHED"
     },
     {
@@ -35,6 +40,7 @@
         "id": "12",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.335+1000",
+        "type": "PARALLEL",
         "state": "FINISHED"
     },
     {
@@ -43,6 +49,7 @@
         "id": "13",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.336+1000",
+        "type": "PARALLEL",
         "state": "FINISHED"
     }
 ]

--- a/blueocean-dashboard/src/test/json/pipeline-graph-converter/pipeline-nodes-example.json
+++ b/blueocean-dashboard/src/test/json/pipeline-graph-converter/pipeline-nodes-example.json
@@ -4,12 +4,14 @@
         "edges": [
             {
                 "durationInMillis": 694,
-                "id": "9"
+                "id": "9",
+                "type": "STAGE"
             }
         ],
         "id": "3",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:28.639+1000",
+        "type": "STAGE",
         "state": "FINISHED"
     },
     {
@@ -17,16 +19,19 @@
         "edges": [
             {
                 "durationInMillis": 2,
-                "id": "12"
+                "id": "12",
+                "type": "PARALLEL"
             },
             {
                 "durationInMillis": 3,
-                "id": "13"
+                "id": "13",
+                "type": "PARALLEL"
             }
         ],
         "id": "9",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.333+1000",
+        "type": "STAGE",
         "state": "FINISHED"
     },
     {
@@ -34,12 +39,14 @@
         "edges": [
             {
                 "durationInMillis": 607,
-                "id": "27"
+                "id": "27",
+                "type": "STAGE"
             }
         ],
         "id": "12",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.335+1000",
+        "type": "PARALLEL",
         "state": "FINISHED"
     },
     {
@@ -47,12 +54,14 @@
         "edges": [
             {
                 "durationInMillis": 606,
-                "id": "27"
+                "id": "27",
+                "type": "STAGE"
             }
         ],
         "id": "13",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.336+1000",
+        "type": "PARALLEL",
         "state": "FINISHED"
     },
     {
@@ -61,6 +70,7 @@
         "id": "27",
         "result": "SUCCESS",
         "startTime": "2016-05-02T16:06:29.942+1000",
+        "type": "STAGE",
         "state": "FINISHED"
     }
 ]

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
@@ -27,7 +27,7 @@ public class FlowNodeWrapper {
     private final FlowNode node;
     private final NodeRunStatus status;
     private final TimingInfo timingInfo;
-    public final List<String> edges = new ArrayList<>();
+    public final List<FlowNodeWrapper> edges = new ArrayList<>();
     public final NodeType type;
     private final String displayName;
     private final InputStep inputStep;
@@ -104,11 +104,15 @@ public class FlowNodeWrapper {
         return node;
     }
 
-    public void addEdge(String id){
-        this.edges.add(id);
+    public NodeType getType() {
+        return type;
     }
 
-    public void addEdges(List<String> edges){
+    public void addEdge(FlowNodeWrapper edge){
+        this.edges.add(edge);
+    }
+
+    public void addEdges(List<FlowNodeWrapper> edges){
         this.edges.addAll(edges);
     }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -215,12 +215,12 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             while(branches.hasNext()){
                 FlowNodeWrapper p = branches.next();
                 p.addParent(stage);
-                stage.addEdge(p.getId());
+                stage.addEdge(p);
             }
         }else{
             if(nextStage != null) {
                 nextStage.addParent(stage);
-                stage.addEdge(nextStage.getId());
+                stage.addEdge(nextStage);
             }
         }
         parallelBranches.clear();
@@ -286,7 +286,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             FlowNodeWrapper branch = new FlowNodeWrapper(branchStartNode, status, times, run);
 
             if(nextStage!=null) {
-                branch.addEdge(nextStage.getId());
+                branch.addEdge(nextStage);
             }
             parallelBranches.push(branch);
         }
@@ -465,11 +465,11 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                     FlowNodeWrapper latestNode = currentNodes.get(i-1);
                     if(latestNode.type == FlowNodeWrapper.NodeType.STAGE){
                         if(futureNode.type == FlowNodeWrapper.NodeType.STAGE){
-                            latestNode.addEdge(futureNode.getId());
+                            latestNode.addEdge(futureNode);
                         }else if(futureNode.type == FlowNodeWrapper.NodeType.PARALLEL){
                             FlowNodeWrapper thatStage = futureNode.getFirstParent();
                             if(thatStage != null && thatStage.equals(latestNode)){
-                                for(String edge:thatStage.edges){
+                                for(FlowNodeWrapper edge:thatStage.edges){
                                     if(!latestNode.edges.contains(edge)){
                                         latestNode.addEdge(edge);
                                     }
@@ -477,33 +477,33 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                             }
                         }
                     }else if(latestNode.type == FlowNodeWrapper.NodeType.PARALLEL){
-                        String futureNodeId = null;
+                        FlowNodeWrapper futureStage = null;
                         FlowNodeWrapper thatStage = null;
                         FlowNodeWrapper futureNodeParent = futureNode.getFirstParent();
                         if(futureNode.type == FlowNodeWrapper.NodeType.STAGE){
                             thatStage = futureNode;
-                            futureNodeId = futureNode.getId();
+                            futureStage = futureNode;
                         }else if(futureNode.type == FlowNodeWrapper.NodeType.PARALLEL &&
                                 futureNodeParent != null &&
                                 futureNodeParent.equals(latestNode.getFirstParent())){
                             thatStage = futureNode.getFirstParent();
                             if(futureNode.edges.size() > 0){
-                                futureNodeId = futureNode.edges.get(0);
+                                futureStage = futureNode.edges.get(0);
                             }
                         }
                         FlowNodeWrapper stage = latestNode.getFirstParent();
                         if(stage != null){
                             //Add future node as edge to all edges of last stage
-                            for(String id:stage.edges){
-                                FlowNodeWrapper node = nodeMap.get(id);
-                                if(node != null && futureNodeId != null) {
-                                    node.addEdge(futureNodeId);
+                            for(FlowNodeWrapper edge:stage.edges){
+                                FlowNodeWrapper node = nodeMap.get(edge.getId());
+                                if(node != null && futureStage != null) {
+                                    node.addEdge(futureStage);
                                 }
                             }
 
                             //now patch edges in case its partial
                             if(thatStage != null && futureNode.type == FlowNodeWrapper.NodeType.PARALLEL) {
-                                for (String edge : thatStage.edges) {
+                                for (FlowNodeWrapper edge : thatStage.edges) {
                                     if (!stage.edges.contains(edge)) {
                                         stage.addEdge(edge);
                                     }
@@ -607,7 +607,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         while(sortedBranches.hasNext()){
             FlowNodeWrapper p = sortedBranches.next();
             p.addParent(synStage);
-            synStage.addEdge(p.getId());
+            synStage.addEdge(p);
         }
         return synStage;
     }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeImpl.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * Implementation of {@link BluePipelineNode}.
@@ -108,6 +109,11 @@ public class PipelineNodeImpl extends BluePipelineNode {
     }
 
     @Override
+    public String getType(){
+        return node.getType().name();
+    }
+
+    @Override
     public String getCauseOfBlockage() {
         return node.getCauseOfFailure();
     }
@@ -144,22 +150,29 @@ public class PipelineNodeImpl extends BluePipelineNode {
 
     public static class EdgeImpl extends Edge{
         private final String id;
+        private final String type;
 
-        public EdgeImpl(String id) {
-            this.id = id;
+        public EdgeImpl(FlowNodeWrapper edge) {
+            this.id = edge.getId();
+            this.type = edge.getType().name();
         }
 
         @Override
         public String getId() {
             return id;
         }
+
+        @Exported
+        public String getType() {
+            return type;
+        }
     }
 
-    private List<Edge> buildEdges(List<String> nodes){
+    private List<Edge> buildEdges(List<FlowNodeWrapper> nodes){
         List<Edge> edges  = new ArrayList<>();
         if(!nodes.isEmpty()) {
-            for (String id:nodes) {
-                edges.add(new EdgeImpl(id));
+            for (FlowNodeWrapper edge:nodes) {
+                edges.add(new EdgeImpl(edge));
             }
         }
         return edges;

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -85,6 +85,11 @@ public class PipelineStepImpl extends BluePipelineStep {
     }
 
     @Override
+    public String getType() {
+        return node.getType().name();
+    }
+
+    @Override
     public BlueRun.BlueRunResult getResult() {
         return node.getStatus().getResult();
     }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -2435,6 +2435,24 @@ public class PipelineNodeTest extends PipelineBaseTest {
         assertEquals("echo \"\u001B[32m some text \u001B[0m\"", resp.get(1).get("displayDescription"));
     }
 
+    @Test
+    public void testDynamicInnerStage() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "p");
+        URL resource = Resources.getResource(getClass(), "testDynamicInnerStage.jenkinsfile");
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+        job.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+
+        WorkflowRun build = job.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.SUCCESS, build);
+
+        List<Map> nodes = get("/organizations/jenkins/pipelines/p/runs/1/nodes/", List.class);
+        assertEquals(4, nodes.size());
+        assertEquals(FlowNodeWrapper.NodeType.STAGE.name(),nodes.get(0).get("type"));
+        assertEquals(FlowNodeWrapper.NodeType.STAGE.name(),nodes.get(1).get("type"));
+        assertEquals(FlowNodeWrapper.NodeType.PARALLEL.name(),nodes.get(2).get("type"));
+        assertEquals(FlowNodeWrapper.NodeType.STAGE.name(),nodes.get(3).get("type"));
+    }
+
     private void setupScm(String script) throws Exception {
         // create git repo
         sampleRepo.init();

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/testDynamicInnerStage.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/testDynamicInnerStage.jenkinsfile
@@ -1,0 +1,24 @@
+node {
+    stage('test') {
+        println('pre parallel step')
+    }
+    stage('parallel stage') {
+        def array = ["a_1"]
+        def builds = [:]
+        array.each {
+            test = it
+            builds[it] = {
+                node {
+                    stage(it) {
+                        println(it)
+                        sh 'date'
+                    }
+                }
+            }
+        }
+        parallel builds
+    }
+    stage('test2') {
+        println('post parallel step')
+    }
+}

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineNode.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineNode.java
@@ -69,12 +69,31 @@ public abstract class BluePipelineNode extends BluePipelineStep{
     @Navigable
     public abstract BluePipelineStepContainer getSteps();
 
+    /**
+     * Represents edge of pipeline flow graph
+     */
     @ExportedBean
     public abstract static class Edge{
+        /**
+         * Id of {@link BluePipelineNode#getId()} destination node
+         * @return node id
+         */
         @Exported
         public abstract String getId();
+
+        /**
+         * Type of {@link BluePipelineNode#getType()} destination node
+         * @return type
+         */
+        @Exported
+        public abstract String getType();
+
     }
 
+    /**
+     * All the outgoing edges from this node
+     * @return edges
+     */
     @Exported(name = EDGES, inline = true)
     public abstract List<Edge> getEdges();
 

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineStep.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BluePipelineStep.java
@@ -2,16 +2,13 @@ package io.jenkins.blueocean.rest.model;
 
 import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.annotation.Capability;
+import java.util.Collection;
+import java.util.Date;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.verb.POST;
-
-import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Date;
-
 import static io.jenkins.blueocean.rest.model.BlueRun.STATE;
 import static io.jenkins.blueocean.rest.model.KnownCapabilities.BLUE_PIPELINE_STEP;
 
@@ -30,27 +27,67 @@ public abstract class BluePipelineStep extends Resource{
     public static final String EDGES = "edges";
     public static final String DURATION_IN_MILLIS="durationInMillis";
     public static final String ACTIONS = "actions";
+    public static final String TYPE = "type";
 
+    /**
+     * id of step.
+     * @return node id
+     */
     @Exported(name = ID)
     public abstract String getId();
 
+    /**
+     * Step display name.
+     * @return display name
+     */
     @Exported(name = DISPLAY_NAME)
     public abstract String getDisplayName();
 
+    /**
+     * Step display description.
+     * @return display description
+     */
     @Exported(name = DISPLAY_DESCRIPTION)
     public abstract String getDisplayDescription();
 
+    /**
+     * Type of step.
+     * @return step type
+     */
+    @Exported(name = TYPE)
+    public abstract String getType();
+
+    /**
+     * Step execution result
+     * @return {@link io.jenkins.blueocean.rest.model.BlueRun.BlueRunResult} instance
+     */
     @Exported(name = RESULT)
     public abstract BlueRun.BlueRunResult getResult();
 
+    /**
+     * Step execution state
+     * @return execution state {@link io.jenkins.blueocean.rest.model.BlueRun.BlueRunState}
+     */
     @Exported(name=STATE)
     public abstract BlueRun.BlueRunState getStateObj();
 
+    /**
+     * Start time of execution
+     * @return start time of execution
+     */
     public abstract Date getStartTime();
 
+    /**
+     * Start time string representation
+     * @return start time of execution
+     */
     @Exported(name = START_TIME)
     public abstract String getStartTimeString();
 
+    /**
+     * Execution duration
+     * @return execution duration in milli seconds
+     */
     @Exported(name= DURATION_IN_MILLIS)
     public abstract Long getDurationInMillis();
 
@@ -67,9 +104,18 @@ public abstract class BluePipelineStep extends Resource{
     @Exported(name = ACTIONS, inline = true)
     public abstract Collection<BlueActionProxy> getActions();
 
+    /**
+     * Input step associated with this step
+     * @return input step
+     */
     @Exported(name="input", inline = true)
     public abstract BlueInputStep getInputStep();
 
+    /**
+     * Processes submitted input step via POST request
+     * @param request stapler request
+     * @return http response
+     */
     @POST
     @WebMethod(name = "")
     public abstract HttpResponse submitInputStep(StaplerRequest request);

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
@@ -231,11 +231,12 @@ function createSmallLabels(columns: Array<NodeColumn>) {
     const labels = [];
 
     for (const column of columns) {
-        if (column.rows.length === 1) {
-            continue; // No small labels for single-row (single node) columns
-        }
         for (const row of column.rows) {
             for (const node of row) {
+                // We add small labels to parallel nodes only so skip others
+                if (!node.stage || node.stage.type !== 'PARALLEL'){
+                    continue;
+                }
                 const label: LabelInfo = {
                     x: node.x,
                     y: node.y,


### PR DESCRIPTION
# Description
Existing karaoke/JDL(PipelineGraph) treats parallel branches if number of edges > 1. Visualization breaks down if there is just one parallel branch.

To fix it, I am introducing new element type to `BluePipelineStep` and `BluePipelineNode.Edge`. Front end uses type to detect whether a node is stage or parallel.

For given pipeline script:
```
node {
    
    stage('test' ) {
        println('pre parallel step')
    }
    
    
    stage('parallel stage') { 
        
        def array = ["a_1"]
    
        def builds = [:]
    
        array.each {
        
            test = it
            builds[it] = {
                
                node {
                    stage (it) {
                        println(it)   
                        sh 'date'
                    }
                }
            }
            
            
        }
        parallel builds
    
    }    
    
    stage('test2') {
        println('post parallel step')
    }
}
```

##Existing rendering

![image](https://user-images.githubusercontent.com/38139/32102010-260df8a6-bb38-11e7-98c4-d79161d09b41.png)

## Rendering after fix

![image](https://user-images.githubusercontent.com/38139/32102019-392e28ac-bb38-11e7-9282-9ac4aed03040.png)

See [JENKINS-46490](https://issues.jenkins-ci.org/browse/JENKINS-46490).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

