### PR TITLE
Performance improvements for LogConsole component

### DIFF
--- a/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component, PureComponent, PropTypes } from 'react';
 import { Progress, Linkify } from '@jenkins-cd/design-language';
 import { logging } from '@jenkins-cd/blueocean-core-js';
 
@@ -13,34 +13,39 @@ const RERENDER_DELAY = 17;
 
 const logger = logging.logger('io.jenkins.blueocean.dashboard.karaoke.LogConsole');
 
-const LogLine = ({ prefix, line, index, router, location }) => {
-    const tokenized = tokenizeANSIString(line);
-    const lineChunks = makeReactChildren(tokenized);
+class LogLine extends PureComponent {
+    onClick = () => {
+        const { prefix, index, router, location } = this.props;
 
-    const onClick = () => {
         const loc2 = location; // For eslint 🙄
         loc2.hash = `#${prefix || ''}log-${index + 1}`;
         router.push(loc2);
     };
 
-    return (
-        <p key={index + 1} id={`${prefix}log-${index + 1}`}>
-            <div className="log-boxes">
-                <a
-                    className="linenumber"
-                    key={index + 1}
-                    href={`#${prefix || ''}log-${index + 1}`}
-                    name={`${prefix}log-${index + 1}`}
-                    onClick={onClick}
-                >
-                </a>
-                {
-                    React.createElement(Linkify, { className: 'line ansi-color' }, ...lineChunks)
-                }
-            </div>
-        </p>
-    );
-};
+    render() {
+        const { prefix, line, index } = this.props;
+        const tokenized = tokenizeANSIString(line);
+        const lineChunks = makeReactChildren(tokenized);
+
+        return (
+            <p id={`${prefix}log-${index + 1}`}>
+                <div className="log-boxes">
+                    <a
+                        className="linenumber"
+                        key={index + 1}
+                        href={`#${prefix || ''}log-${index + 1}`}
+                        name={`${prefix}log-${index + 1}`}
+                        onClick={this.onClick}
+                    >
+                    </a>
+                    {
+                        React.createElement(Linkify, { className: 'line ansi-color' }, ...lineChunks)
+                    }
+                </div>
+            </p>
+        );
+    }
+}
 
 LogLine.propTypes = {
     prefix: PropTypes.string,
@@ -170,7 +175,7 @@ export class LogConsole extends Component {
             </div>}
 
             {!isLoading && <div className="log-body"><pre>
-                {hasMore && <div key={0} id={`${prefix}log-${0}`} className="fullLog">
+                {hasMore && <div id={`${prefix}log-${0}`} className="fullLog">
                     <a className="btn-link inverse"
                        key={0}
                        target="_blank"
@@ -180,7 +185,8 @@ export class LogConsole extends Component {
                     </a>
                 </div>}
                 {!isLoading && lines.map((line, index) => (
-                    <LogLine prefix={prefix}
+                    <LogLine key={index}
+                             prefix={prefix}
                              index={index}
                              line={line}
                              router={router}


### PR DESCRIPTION
# Description

Note: This PR is best viewed with [?w=1](https://github.com/jenkinsci/blueocean-plugin/pull/1521/files?w=1)

When the following component receives new log rows: 

![image](https://user-images.githubusercontent.com/1271782/32150281-bb4204f4-bd08-11e7-8cf4-07fc10fabd54.png)

Currently when new logs are received for a given step, it forces an entire re-render of the LogConsole component's children. Unfortunately on a rather large build, this becomes quite laggy.

This PR updates the LogLine to be a PureComponent to avoid un-needed re-renders of previously rendered console lines.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate:
    - No ticket was created for this, let me know if this is an issue
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests:
    - This is a performance tweak, all functionality should remain the same
- [x] Reviewer's manual test instructions provided in PR description:
    - Ensure that the pipeline detail view renders as before. Note, I tested this commit on top of  the 1.3 release branch, and it worked as expected. I have rebased this PR onto of master now, so it should still work if master is stable :+1:

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given