### PR TITLE
Properies object not being passed when track() sent

### DIFF
--- a/blueocean-core-js/src/js/analytics/AnalyticsService.js
+++ b/blueocean-core-js/src/js/analytics/AnalyticsService.js
@@ -18,7 +18,7 @@ export class AnalyticsService {
             },
             body: JSON.stringify({
                 name: eventName,
-                properties: { properties },
+                properties: properties,
             }),
         };
         return Fetch.fetch(url, { fetchOptions });


### PR DESCRIPTION
# Description

Erroneously sending the properties parameter as a string.
`{"name":"pageview","properties":{"properties":{"mode":"blueocean"}}}`

Should now be:
`{"name":"pageview","properties":{"mode":"blueocean"}}`

See [JENKINS-47735](https://issues.jenkins-ci.org/browse/JENKINS-47735).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

