### PR TITLE
[JENKINS-41205] Return 10,000 pipeline nodes by default

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
@@ -22,7 +22,7 @@ import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainSpecifi
 import io.jenkins.blueocean.rest.impl.pipeline.scm.AbstractScm;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmOrganization;
 import io.jenkins.blueocean.rest.model.Container;
-import io.jenkins.blueocean.rest.pageable.PagedResponse;
+import io.jenkins.blueocean.rest.pageable.Pageable;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
@@ -161,7 +161,7 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
                 @Override
                 public Iterator<ScmOrganization> iterator(int start, int limit) {
                     if(limit <= 0){
-                        limit = PagedResponse.DEFAULT_LIMIT;
+                        limit = Pageable.DEFAULT_LIMIT;
                     }
                     if(start <0){
                         start = 0;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
@@ -19,7 +19,7 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbRepo;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbSaveContentResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbUser;
 import io.jenkins.blueocean.commons.ServiceException;
-import io.jenkins.blueocean.rest.pageable.PagedResponse;
+import io.jenkins.blueocean.rest.pageable.Pageable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.http.HttpEntity;
@@ -86,7 +86,7 @@ public class BitbucketCloudApi extends BitbucketApi {
             }
 
             if(pageSize <=0){
-                pageSize = PagedResponse.DEFAULT_LIMIT;
+                pageSize = Pageable.DEFAULT_LIMIT;
             }
             InputStream inputStream = request.get(String.format("%s&page=%s&pagelen=%s",baseUrl+"teams/?role=contributor",
                     pageNumber,pageSize)).getContent();

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -24,7 +24,7 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerRe
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerSaveContentResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.model.BbServerUser;
 import io.jenkins.blueocean.commons.ServiceException;
-import io.jenkins.blueocean.rest.pageable.PagedResponse;
+import io.jenkins.blueocean.rest.pageable.Pageable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.utils.URIBuilder;
@@ -103,7 +103,7 @@ public class BitbucketServerApi extends BitbucketApi {
             }
 
             if(pageSize <=0){
-                pageSize = PagedResponse.DEFAULT_LIMIT;
+                pageSize = Pageable.DEFAULT_LIMIT;
             }
             InputStream inputStream = request.get(String.format("%s?start=%s&limit=%s",baseUrl+"projects/",
                     toStart(pageNumber, pageSize), pageSize))

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/BranchContainerImpl.java
@@ -158,7 +158,7 @@ public class BranchContainerImpl extends BluePipelineContainer {
 
     @Override
     public Iterator<BluePipeline> iterator() {
-        return iterator(0, PagedResponse.DEFAULT_LIMIT);
+        return iterator(0, defaultLimit());
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeContainerImpl.java
@@ -46,6 +46,10 @@ public class PipelineNodeContainerImpl extends BluePipelineNodeContainer {
         }
     }
 
+    public int defaultLimit() {
+      return 10000;
+    }
+
     @Override
     public BluePipelineNode get(String name) {
         if(nodeMap.get(name) != null){

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/Pageable.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/Pageable.java
@@ -6,6 +6,12 @@ import java.util.Iterator;
  * @author Kohsuke Kawaguchi
  */
 public interface Pageable<T> extends Iterable<T> {
+    public static final int DEFAULT_LIMIT=100;
+
+    default public int defaultLimit() {
+      return DEFAULT_LIMIT;
+    }
+
     /**
      * Returns a iterator that visits a subset, which is used by the HTTP layer to do the pagenation.
      * @param start starting index requested from collection

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/pageable/PagedResponse.java
@@ -29,7 +29,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @InterceptorAnnotation(PagedResponse.Processor.class)
 public @interface PagedResponse {
-    public static final int DEFAULT_LIMIT=100;
     class Processor extends Interceptor {
         @Override
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
@@ -45,14 +44,14 @@ public @interface PagedResponse {
                 @Override
                 public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
                     int start = (req.getParameter("start") != null) ? Integer.parseInt(req.getParameter("start")) : 0;
-                    int limit = (req.getParameter("limit") != null) ? Integer.parseInt(req.getParameter("limit")) : DEFAULT_LIMIT;
+                    int limit = (req.getParameter("limit") != null) ? Integer.parseInt(req.getParameter("limit")) : resp.defaultLimit();
 
                     if(start < 0){
                         start = 0;
                     }
 
                     if(limit < 0){
-                        limit = DEFAULT_LIMIT;
+                        limit = resp.defaultLimit();
                     }
                     Object[] page = Iterators.toArray(resp.iterator(start, limit), Object.class);
                     String url = req.getOriginalRequestURI();


### PR DESCRIPTION
# Description

See [JENKINS-41205](https://issues.jenkins-ci.org/browse/JENKINS-41205). Second attempt at https://github.com/jenkinsci/blueocean-plugin/pull/1517#issuecomment-341285188.

No tests included because there aren't any existing tests for this functionality.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

