### PR TITLE
[JENKINS-45947] Show Open BlueOcean to everyone

### DIFF
--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction/action.jelly
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction/action.jelly
@@ -2,6 +2,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
             href="${rootURL}/${action.urlName}"
-            permission="${app.READ}"
     />
 </j:jelly>


### PR DESCRIPTION
# Description

This PR removes the permissions check for the Open BlueOcean link on the side bar. The rational is that if you can see the sidebar at all, then you should be able to see the link. 

See [JENKINS-45947](https://issues.jenkins-ci.org/browse/JENKINS-45947).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

