### PR TITLE
[JENKINS-47339] Switch to ReplayAction.isRebuildEnabled()

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -172,7 +172,7 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
     }
 
     private boolean isReplayable(ReplayAction replayAction) {
-        return replayAction != null && replayAction.isEnabled();
+        return replayAction != null && replayAction.isRebuildEnabled();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.42-20171107.182521-1</version> <!-- TODO: Switch to release once https://github.com/jenkinsci/workflow-cps-plugin/pull/187 is merged and released -->
+            <version>2.42</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.39</version>
+            <version>2.42-20171107.182521-1</version> <!-- TODO: Switch to release once https://github.com/jenkinsci/workflow-cps-plugin/pull/187 is merged and released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
# Description

See [JENKINS-47339](https://issues.jenkins-ci.org/browse/JENKINS-47339).

Downstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/187

This allows Item.BUILD or the new ReplayAction.REBUILD permission to
be used for determining whether rebuilding a build with the exact same
script is allowed.

To test, create a Pipeline job and run it. Then, login as a user with `Item.BUILD` permission but *not* `Item.CONFIGURE`. Replaying should be possible from Blue Ocean.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

