### PR TITLE
[FIX JENKINS-47774] Re-enable activity-spec test

### DIFF
--- a/blueocean-dashboard/src/test/js/activity-spec.js
+++ b/blueocean-dashboard/src/test/js/activity-spec.js
@@ -195,7 +195,7 @@ describe('Pipeline -> Activity List', () => {
     beforeAll(() => mockExtensionsForI18n());
 
     // TODO: renable this test once problem is diagnosed. TypeError: _moment2.default.duration(...).format is not a function
-    xit('should contain cause', () => {
+    it('should contain cause', () => {
         const wrapper = shallow(<Activity t={t} runs={data} pipeline={pipeline} capabilities={capabilities} />, { context });
         assert.isNotNull(wrapper);
         const runs = wrapper.find('NewComponent');

--- a/blueocean-dashboard/src/test/js/activity-spec.js
+++ b/blueocean-dashboard/src/test/js/activity-spec.js
@@ -194,7 +194,6 @@ describe('Activity', () => {
 describe('Pipeline -> Activity List', () => {
     beforeAll(() => mockExtensionsForI18n());
 
-    // TODO: renable this test once problem is diagnosed. TypeError: _moment2.default.duration(...).format is not a function
     it('should contain cause', () => {
         const wrapper = shallow(<Activity t={t} runs={data} pipeline={pipeline} capabilities={capabilities} />, { context });
         assert.isNotNull(wrapper);


### PR DESCRIPTION
# Description

This is just fixing a test that was failing for an unknown reason (which should be fixed now).

See [JENKINS-47774](https://issues.jenkins-ci.org/browse/JENKINS-47774).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

