### PR TITLE
Tasks/jenkins 36641 delete favorites rest api

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -9,7 +9,11 @@ import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteContainer;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.verb.DELETE;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -57,5 +61,16 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
     @Override
     public Link getLink() {
         return self;
+    }
+
+    /**
+     * Delete all of the user's favorites.
+     */
+    @WebMethod(name = "") @DELETE
+    public void doDelete(StaplerResponse resp) throws Favorites.FavoriteException {
+        for (final Item favorite: Favorites.getFavorites(user.user)) {
+            Favorites.removeFavorite(user.user, favorite);
+        }
+        resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/FavoritesApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/FavoritesApiTest.java
@@ -1,0 +1,86 @@
+package io.jenkins.blueocean.service.embedded;
+
+import com.google.common.collect.ImmutableMap;
+import hudson.model.Project;
+import hudson.model.User;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author cliffmeyers
+ */
+public class FavoritesApiTest extends BaseTest {
+
+    private Project createAndFavorite(String jobName, String username, String password) throws IOException {
+        Project project = j.createFreeStyleProject(jobName);
+
+        new RequestBuilder(baseUrl)
+            .put("/organizations/jenkins/pipelines/"+jobName+"/favorite/")
+            .auth(username, password)
+            .data(ImmutableMap.of("favorite", true))
+            .build(Map.class);
+
+        return project;
+    }
+
+
+    @Test
+    public void deleteUserFavoritesUnauthenticatedTest() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        hudson.model.User user = User.get("alice");
+
+        new RequestBuilder(baseUrl)
+            .delete("/users/"+user.getId()+"/favorites/")
+            .status(403)
+            .build(Map.class);
+    }
+
+    @Test
+    public void deleteUserFavoritesUnauthorizedTest() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        hudson.model.User user = User.get("alice");
+
+        new RequestBuilder(baseUrl)
+            .delete("/users/"+user.getId()+"/favorites/")
+            .auth("bob", "bob")
+            .status(403)
+            .build(Map.class);
+    }
+
+    @Test
+    public void deleteUserFavoritesSuccessfulTest() throws IOException {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+        String username = "alice";
+        String password = "alice";
+
+        createAndFavorite("pipeline1", username, password);
+        createAndFavorite("pipeline2", username, password);
+
+        List favorites = new RequestBuilder(baseUrl)
+            .get("/users/"+username+"/favorites/")
+            .auth(username, password)
+            .build(List.class);
+
+        assertEquals(2, favorites.size());
+
+        new RequestBuilder(baseUrl)
+            .delete("/users/"+username+"/favorites/")
+            .auth(username, password)
+            .status(204)
+            .build(Map.class);
+
+        favorites = new RequestBuilder(baseUrl)
+            .get("/users/"+username+"/favorites/")
+            .auth(username, password)
+            .build(List.class);
+
+        assertEquals("all favorites must be deleted",0, favorites.size());
+    }
+
+}

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ProfileApiTest.java
@@ -193,6 +193,7 @@ public class ProfileApiTest extends BaseTest{
         assertEquals("alice@jenkins-ci.org",r.get("email"));
     }
 
+    // TODO: migrate to FavoritesApiTest after PR receives initial approval (trying to cut down on PR noise)
     @Test
     public void createUserFavouriteTest() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -244,6 +245,7 @@ public class ProfileApiTest extends BaseTest{
 
     }
 
+    // TODO: migrate to FavoritesApiTest after PR receives initial approval (trying to cut down on PR noise)
     @Test
     public void createUserFavouriteFolderTest() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());


### PR DESCRIPTION
# Description
- To ensure that we can run ATH covering favorites in a clean state, we needed an API to delete all of the user's favorites.
- See [JENKINS-36641](https://issues.jenkins-ci.org/browse/JENKINS-36641).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

