### PR TITLE
JENKINS-47749 Add editor test for creating a parallelized pipeline

### DIFF
--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -270,7 +270,7 @@ Any new Page Object classes need to be bound in `ATHModule#configure` to be able
 
 #### Pipeline Helper
 
-These are a series of helpers to deal with pipelines. The started life to deal with pipelines being in folders. It offes a way 
+These are a series of helpers to deal with pipelines. They started life to deal with pipelines being in folders. It offes a way 
 to give PageObjects more contextual information about what they are operating on without having to be explicit about it in every method call.
 
 ```java

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -271,7 +271,7 @@ Any new Page Object classes need to be bound in `ATHModule#configure` to be able
 
 #### Pipeline Helper
 
-These are a series or helpers to deal with pipelines. The started life to deal with pieplines being in folders. It offes a way 
+These are a series of helpers to deal with pipelines. The started life to deal with pipelines being in folders. It offes a way 
 to give PageOjects more contextual information about what they are operating on without having to be explicit about it in every method call.
 
 ```java

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -23,9 +23,9 @@ mvn clean install -DskipTests -DcleanNode
 ### Areas covered
 
 * Karaoke parallel: ParallelNavigationTest. This checks that users can navigate between concurrently executing parallel branches, including steps waiting for input.
-* Commit Messages: CommitMessagesTest checks to see that commit messsages of git commits are shown on a run
-* Folder Names: FoldersTest checks that folders with sperial characters work correctly in blueoean
-* Github integration: GithubCreationTests cover github integration testing of buth the creation flow and also simple editor round tripping.
+* Commit Messages: CommitMessagesTest checks to see that commit messages of git commits are shown on a run
+* Folder Names: FoldersTest checks that folders with special characters work correctly in Blue Ocean
+* Github integration: GithubCreationTests cover github integration testing of both the creation flow and also simple editor round tripping.
 
 ### Run all tests (in one command)
  ```bash
@@ -52,7 +52,7 @@ adminPassword=admin
 ### Run tests in DEV mode
 
 DEV mode starts Jenkins and the selenium docker container running in a standalone mode.
-This allows for individual tests to be run against the server multple times, which makes
+This allows for individual tests to be run against the server multiple times, which makes
 writing ATH tests much easier.
 
 First, start the server:
@@ -77,7 +77,7 @@ mvn clean test -Dprofile=all
 mvn clean test -Dprofile=all -Dtest=FavoritesTest
 ```
 
-Note to run the live tests there needs to be a `live.properties` file in the acceptance-tests directory.
+Note: to run the live tests, there needs to be a `live.properties` file in the acceptance-tests directory.
 
 ```properties
 github.repo=<name of repository to be created
@@ -87,7 +87,7 @@ github.deleteRepo=<true/false should the code delete repo once test is done>
 github.randomSuffix=<true/false - add a random suffix to repo name (ie must have for CI> 
 ```
 
-#### Java Webdriver Tests via Intellij (and probably other ides)
+#### Java Webdriver Tests via Intellij (and probably other IDEs)
 
 Running tests via the IDE works as expected as long as the standalone part of the ATH is running.
 
@@ -105,7 +105,6 @@ nightwatch src/test/js/
 nightwatch src/test/js/edgeCases/
 nightwatch src/test/js/edgeCases/folder.js
 ```
-
 
 When running in `--dev` mode, it can be useful to turn on client code log output. To do this, simply set
 the `LOG_CONFIG` env variable e.g. to turn on SSE logging:
@@ -158,7 +157,7 @@ public class LoginTest implements WebDriverMixin {
 
 #### JUnit4 Tests
 
-All test code is uses Guice to do dependency injection.
+All test code uses Guice to do dependency injection.
 
 ```java
 //Makes the browser login at the start of every test in this class.
@@ -168,7 +167,7 @@ All test code is uses Guice to do dependency injection.
 @UseModules(AthModule.class)
 public class MyFirstATHTest{
     
-    // Base url for the browser to naviate to. e.g driver.get(baseUrl + "/blue/")
+    // Base url for the browser to navigate to. e.g driver.get(baseUrl + "/blue/")
     @Inject @BaseUrl
     String baseUrl;
     
@@ -207,7 +206,7 @@ public class MyFirstATHTest{
 it connects to the Jenkins server want waits for job events. Events are saved into a list as they happen.
 
 Once a test is ready to check for events, `untilEvent()` can be used. `clear()` can be invoked at any time to clear out any 
-messages recieved until that point in time.
+messages received until that point in time.
 
 ```java
 @Login
@@ -272,7 +271,7 @@ Any new Page Object classes need to be bound in `ATHModule#configure` to be able
 #### Pipeline Helper
 
 These are a series of helpers to deal with pipelines. The started life to deal with pipelines being in folders. It offes a way 
-to give PageOjects more contextual information about what they are operating on without having to be explicit about it in every method call.
+to give PageObjects more contextual information about what they are operating on without having to be explicit about it in every method call.
 
 ```java
 

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -83,20 +83,21 @@ public class EditorPage {
         // Now let's create the next one.
         logger.info("Create our second parallel stage");
         wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
-        logger.info("\n--> KS NAME PARALLEL 2 --> click cssSelector input.stage-name-edit\n");
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-2");
         wait.until(By.cssSelector("button.btn-primary.add")).click();
         wait.until(By.xpath("//*[text()='Shell Script']")).click();
         wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("whoami");
         wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
-
-        // Here's where we save the pipeline. This comes later.
+        // Now we need to name the "wrapper" stage to something other than what
+        // got automatically put in.
+        wait.click(By.cssSelector("div.pipeline-big-label.top-level-parallel"));
+        // Need to clear it first.
+        wait.until(By.cssSelector("input.stage-name-edit")).clear();
+        wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Top Level Parallel Wrapper Stage");
+        // Here's where we save the pipeline.
         wait.until(By.xpath("//*[text()='Save']")).click();
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
-            // This isn't working. It's not finding the Commit to new branch thing to click on.
-            // wait.until(By.xpath("//span[@text='Commit to new branch'")).click();
-            // mine
             wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
@@ -104,11 +105,13 @@ public class EditorPage {
             // Maybe we should click on the Commit to new branch button first, then
             // have the automation 'change its mind' so to speak, just to make
             // sure that works.
-
+            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys("i-am-changing-my-mind");
+            wait.until(By.xpath("//*[text()='Commit to master']")).click();
             logger.info("Using branch master");
         }
         wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
-        logger.info("Simple pipeline saved");
+        logger.info("Parallel pipeline saved");
     }
 
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -34,7 +34,7 @@ public class EditorPage {
     public void saveBranch(String branch) {
         logger.info("Editing pipeline - saving now");
         wait.until(By.xpath("//*[text()='Save']")).click();
-        wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Simple pipeline");
+        wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("We changed some things.");
         if(!Strings.isNullOrEmpty(branch)) {
             wait.until(By.xpath("//span[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(branch);
@@ -59,7 +59,7 @@ public class EditorPage {
         wait.until(By.xpath("//*[text()='Save']")).click();
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Simple pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
-            wait.until(By.xpath("//span[@text='Commit to new branch'")).click();
+            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
         } else {
@@ -69,7 +69,7 @@ public class EditorPage {
         logger.info("Simple pipeline saved");
     }
 
-    // Creates a parallel pipeline
+    // Creates a pipeline with parallel stages in it.
     public void parallelPipeline(String newBranch, int numberOfParallels) {
         logger.info("Editing a parallel pipeline");
         /*
@@ -92,7 +92,6 @@ public class EditorPage {
         wait.click(By.cssSelector("div.pipeline-big-label.top-level-parallel"));
         wait.until(By.cssSelector("input.stage-name-edit")).clear();
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Top Level Parallel Wrapper Stage");
-        // Here's where we save the pipeline.
         wait.until(By.xpath("//*[text()='Save']")).click();
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
@@ -101,9 +100,8 @@ public class EditorPage {
             logger.info("Using branch " + newBranch);
         } else {
             /*
-            I don't know that this particular code path ever gets executed, TBH.
-            But if it does, we now click the "Commit to new branch" option, and
-            then change our minds to "Commit to master."
+            This mimics the user changing picking a new branch, and then
+            changing their mind and committing to master after all.
             */
             wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys("i-am-changing-my-mind");

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -70,28 +70,26 @@ public class EditorPage {
     }
 
     // Creates a parallel pipeline
-    public void parallelPipeline(String newBranch) {
+    public void parallelPipeline(String newBranch, int numberOfParallels) {
         logger.info("Editing a parallel pipeline");
-        // Creating first parallel stage
-        logger.info("Create our first parallel stage");
-        wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
-        wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-1");
-        wait.until(By.cssSelector("button.btn-primary.add")).click();
-        wait.until(By.xpath("//*[text()='Shell Script']")).click();
-        wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("netstat -a");
-        wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
-        // Now let's create the next one.
-        logger.info("Create our second parallel stage");
-        wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
-        wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-2");
-        wait.until(By.cssSelector("button.btn-primary.add")).click();
-        wait.until(By.xpath("//*[text()='Shell Script']")).click();
-        wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("whoami");
-        wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
-        // Now we need to name the "wrapper" stage to something other than what
-        // got automatically put in.
+        /*
+        We'll create as many parallel stages as we were told to
+        via int numberOfParallels when we were called.
+        */
+        for (int i = 0; i < numberOfParallels; i++) {
+            logger.info("Create stage Parallel-" + i);
+            wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+            wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-" + i);
+            wait.until(By.cssSelector("button.btn-primary.add")).click();
+            wait.until(By.xpath("//*[text()='Shell Script']")).click();
+            wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("netstat -a");
+            wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
+        }
+        /*
+        Now we need to name the "wrapper" stage to something other than what
+        got automatically put in.
+        */
         wait.click(By.cssSelector("div.pipeline-big-label.top-level-parallel"));
-        // Need to clear it first.
         wait.until(By.cssSelector("input.stage-name-edit")).clear();
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Top Level Parallel Wrapper Stage");
         // Here's where we save the pipeline.
@@ -102,9 +100,11 @@ public class EditorPage {
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
         } else {
-            // Maybe we should click on the Commit to new branch button first, then
-            // have the automation 'change its mind' so to speak, just to make
-            // sure that works.
+            /*
+            I don't know that this particular code path ever gets executed, TBH.
+            But if it does, we now click the "Commit to new branch" option, and
+            then change our minds to "Commit to master."
+            */
             wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys("i-am-changing-my-mind");
             wait.until(By.xpath("//*[text()='Commit to master']")).click();

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -68,4 +68,45 @@ public class EditorPage {
         wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
         logger.info("Simple pipeline saved");
     }
+
+    // Creates a parallel pipeline
+    public void parallelPipeline(String newBranch) {
+        logger.info("Editing a parallel pipeline");
+        // Creating first parallel stage
+        logger.info("Create our first parallel stage");
+        wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+        wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-1");
+        wait.until(By.cssSelector("button.btn-primary.add")).click();
+        wait.until(By.xpath("//*[text()='Shell Script']")).click();
+        wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("netstat -a");
+        wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
+        // Now let's create the next one.
+        logger.info("Create our second parallel stage");
+        wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+        logger.info("\n--> KS NAME PARALLEL 2 --> click cssSelector input.stage-name-edit\n");
+        wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-2");
+        wait.until(By.cssSelector("button.btn-primary.add")).click();
+        wait.until(By.xpath("//*[text()='Shell Script']")).click();
+        wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("whoami");
+        wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
+
+        // Here's where we save the pipeline. This comes later.
+        wait.until(By.xpath("//*[text()='Save']")).click();
+        wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
+        if(!Strings.isNullOrEmpty(newBranch)) {
+            // This isn't working. It's not finding the Commit to new branch thing to click on.
+            wait.until(By.xpath("//span[@text='Commit to new branch'")).click();
+            wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
+            logger.info("Using branch " + newBranch);
+        } else {
+            // Maybe we should click on the Commit to new branch button first, then
+            // have the automation 'change its mind' so to speak, just to make
+            // sure that works.
+
+            logger.info("Using branch master");
+        }
+        wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
+        logger.info("Simple pipeline saved");
+    }
+
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -95,7 +95,9 @@ public class EditorPage {
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
             // This isn't working. It's not finding the Commit to new branch thing to click on.
-            wait.until(By.xpath("//span[@text='Commit to new branch'")).click();
+            // wait.until(By.xpath("//span[@text='Commit to new branch'")).click();
+            // mine
+            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
         } else {

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -145,7 +145,7 @@ public class GithubEditorTest {
     public void testEditorParallel() throws IOException {
         creationPage.createPipeline(token, organization, repo, true);
         MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
-        editorPage.parallelPipeline("branch-with-parallels");
+        editorPage.parallelPipeline("branch-with-parallels", 3);
         ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
         driver.navigate().refresh();
         sseClient.untilEvents(pipeline.buildsFinished);

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -135,4 +135,27 @@ public class GithubEditorTest {
 
         sseClient.untilEvents(pipeline.buildsFinished);
     }
+
+    /**
+     * This test covers e2e usage of the editor. Does so with a parallel pipeline.
+     *
+     * Creates a blank github repo, and then uses editor to create a parallel pipeline.
+     */
+    @Test
+    public void testEditorParallel() throws IOException {
+        creationPage.createPipeline(token, organization, repo, true);
+        MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
+        editorPage.parallelPipeline("branch-with-parallels");
+        ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
+        driver.navigate().refresh();
+        sseClient.untilEvents(pipeline.buildsFinished);
+        sseClient.clear();
+        BranchPage branchPage = activityPage.clickBranchTab();
+        branchPage.openEditor("master");
+        editorPage.saveBranch("new - branch");
+        activityPage.checkUrl();
+        activityPage.getRunRowForBranch("branch-with-parallels");
+
+        sseClient.untilEvents(pipeline.buildsFinished);
+    }
 }

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -132,7 +132,6 @@ public class GithubEditorTest {
         editorPage.saveBranch("new - branch");
         activityPage.checkUrl();
         activityPage.getRunRowForBranch("new-branch");
-
         sseClient.untilEvents(pipeline.buildsFinished);
     }
 
@@ -151,12 +150,10 @@ public class GithubEditorTest {
         sseClient.untilEvents(pipeline.buildsFinished);
         sseClient.clear();
         BranchPage branchPage = activityPage.clickBranchTab();
-        // We need to open editor on our branch
         branchPage.openEditor("branch-with-parallels");
         editorPage.saveBranch("new - branch");
         activityPage.checkUrl();
         activityPage.getRunRowForBranch("branch-with-parallels");
-
         sseClient.untilEvents(pipeline.buildsFinished);
     }
 }

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -151,7 +151,8 @@ public class GithubEditorTest {
         sseClient.untilEvents(pipeline.buildsFinished);
         sseClient.clear();
         BranchPage branchPage = activityPage.clickBranchTab();
-        branchPage.openEditor("master");
+        // We need to open editor on our branch
+        branchPage.openEditor("branch-with-parallels");
         editorPage.saveBranch("new - branch");
         activityPage.checkUrl();
         activityPage.getRunRowForBranch("branch-with-parallels");

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 @Login
 @RunWith(ATHJUnitRunner.class)
-public class GitCreationTest extends BlueOceanAcceptanceTest {
+public class    GitCreationTest extends BlueOceanAcceptanceTest {
     private Logger logger = Logger.getLogger(GitCreationTest.class);
 
     @Inject @Named("live")

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 @Login
 @RunWith(ATHJUnitRunner.class)
-public class    GitCreationTest extends BlueOceanAcceptanceTest {
+public class GitCreationTest extends BlueOceanAcceptanceTest {
     private Logger logger = Logger.getLogger(GitCreationTest.class);
 
     @Inject @Named("live")


### PR DESCRIPTION
# Description

See [JENKINS-47749](https://issues.jenkins-ci.org/browse/JENKINS-47749). This PR is for the addition of a Pipeline Editor test which creates a Parallel pipeline, in support of the parallel syntax introduced with [Declarative 1.2](https://wiki.jenkins.io/display/JENKINS/Pipeline+Model+Definition+Plugin). This PR also includes some small README edits.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: this is an acceptabce test addition. Unit and acceptance tests not applicable
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# To run:

1. Follow the instructions provided in [the acceptance tests' README](https://github.com/kshultzCB/blueocean-plugin/tree/add-parallel-editor-test/acceptance-tests) for setting up the "live" acceptance tests
2. Invoke `mvn test -Dprofile=live -Dtest=GithubEditorTest#testEditorParallel`

@kzantow , @imeredith , a review would be most appreciated.