### PR TITLE
Hotfix/GitHub editor ath deflake 2

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/AcceptanceTestException.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/AcceptanceTestException.java
@@ -1,7 +1,15 @@
 package io.blueocean.ath;
 
 public class AcceptanceTestException extends RuntimeException {
+
     public AcceptanceTestException(String message, Throwable cause) {
-        super(message, cause);
+        super(message);
+
+        if (cause instanceof AcceptanceTestException) {
+            initCause(cause.getCause());
+        } else {
+            initCause(cause);
+        }
     }
+
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
@@ -109,4 +109,30 @@ public class WaitUtil {
         }
     }
 
+    /**
+     * Try to perform the specified function up to the specified count.
+     *
+     * @param desc textual description of action
+     * @param tryCount number of times to try
+     * @param function action to perform
+     * @return result of action
+     */
+    public <T> T retryAction(String desc, int tryCount, Function<WebDriver, T> function) {
+        for (int i = 1; i <= tryCount; i++) {
+            try {
+                T result = until(function);
+                if (i > 1) {
+                    logger.info(String.format("retry was successful for action '%s' ", desc));
+                }
+                return result;
+            } catch (Exception ex) {
+                if (i < tryCount) {
+                    logger.warn(String.format("action failed for %s; will retry again", desc));
+                } else {
+                    throw ex;
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
@@ -105,7 +105,7 @@ public class GithubCreationPage implements WebDriverMixin {
     public void clickCreatePipelineButton() {
         wait.retryAction("click create pipeline button", 3, driver -> {
             wait.click(By.cssSelector(".button-create"));
-            return wait.until(By.cssSelector(".all-i-do-is-fail-fail-fail"), 5000);
+            return wait.until(By.cssSelector(".github-complete-step"), 5000);
         });
     }
 

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
@@ -103,10 +103,11 @@ public class GithubCreationPage implements WebDriverMixin {
     }
 
     public void clickCreatePipelineButton() {
-        wait.click(By.cssSelector(".button-create"));
+        wait.retryAction("click create pipeline button", 3, driver -> {
+            wait.click(By.cssSelector(".button-create"));
+            return wait.until(By.cssSelector(".github-complete-step"), 5000);
+        });
     }
-
-    public By emptyRepositoryCreateButton = By.cssSelector(".jenkins-pipeline-create-missing-jenkinsfile > div > button");
 
     public void createPipeline(String apikey, String org, String pipeline) throws IOException {
         createPipeline(apikey, org, pipeline, false);

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/GithubCreationPage.java
@@ -105,7 +105,7 @@ public class GithubCreationPage implements WebDriverMixin {
     public void clickCreatePipelineButton() {
         wait.retryAction("click create pipeline button", 3, driver -> {
             wait.click(By.cssSelector(".button-create"));
-            return wait.until(By.cssSelector(".github-complete-step"), 5000);
+            return wait.until(By.cssSelector(".all-i-do-is-fail-fail-fail"), 5000);
         });
     }
 


### PR DESCRIPTION
# Description
Continued quest to deflake the `GithubEditorTest` which seems to hang (still) after selecting repo and trying to click on "Create Pipeline" button.

- Introduces a general purpose `retryAction` method that allows a Function to be called n times.
- We now try to 1. click on "Create Pipeline" button, and 2. wait for the "completed' step to appear. If it hangs the first time, it will attempt it two more times.
- I haven't been able to get the test to flake in CI and actually attempt the retry, although the branch has passed 5 times. I introduced an intentional failure in 2nd run to ensure retry logic fires when the Function doesn't match as expected. see:  https://ci.blueocean.io/blue/organizations/jenkins/blueocean/activity?branch=hotfix%2Fgithub-editor-ath-deflake-2

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

