### PR TITLE
[FIX JENKINS-47887] unable to use pipeline editor with GitHub on IE 11

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
@@ -82,13 +82,16 @@ public class GithubScmContentProvider extends AbstractScmContentProvider {
                 throw new ServiceException.UnexpectedErrorException("Failed to load file: "+request.getPath());
             }
 
+            String base64Data = (String)ghContent.get("content");
+            // JENKINS-47887 - this content contains \n which breaks IE11
+            base64Data = base64Data == null ? null : base64Data.replace("\n", "");
             return new GithubFile(new GitContent.Builder()
                     .sha((String)ghContent.get("sha"))
                     .name((String)ghContent.get("name"))
                     .repo(request.getRepo())
                     .owner(request.getOwner())
                     .path(request.getPath())
-                    .base64Data((String)ghContent.get("content"))
+                    .base64Data(base64Data)
                     .build());
         } catch (IOException e) {
             throw new ServiceException.UnexpectedErrorException(String.format("Failed to load file %s: %s", request.getPath(),e.getMessage()), e);


### PR DESCRIPTION
# Description

Trying to use the editor with GitHub on IE11 gave an _InvalidCharacterError_. BitBucket and Git were unaffected by this. Test is covered sufficiently by standard ATH pipeline editor tests.

See [JENKINS-47887](https://issues.jenkins-ci.org/browse/JENKINS-47887).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

