### PR TITLE
JENKINS-47984# Disable Bitbucket server auto-redirect handling

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
@@ -102,7 +102,8 @@ public class HttpRequest {
 
 
     private  HttpClient getHttpClient(@Nonnull String apiUrl) {
-        HttpClientBuilder clientBuilder = HttpClientBuilder.create().disableAutomaticRetries();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create().disableAutomaticRetries()
+                .disableRedirectHandling();
         setClientProxyParams(apiUrl, clientBuilder);
         return clientBuilder.build();
     }

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.BitbucketApi;
+import io.jenkins.blueocean.blueocean_bitbucket_pipeline.HttpRequest;
+import io.jenkins.blueocean.blueocean_bitbucket_pipeline.HttpResponse;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbBranch;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbOrg;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbPage;
@@ -138,6 +140,13 @@ public class BitbucketApiTest extends BbServerWireMock {
         assertEquals("master", branch.getDisplayId());
         assertTrue(branch instanceof BbServerBranch);
         assertEquals("refs/heads/master", ((BbServerBranch)branch).getId());
+    }
+
+    @Test
+    public void testAutoRedirectDisabled() {
+        HttpResponse response = new HttpRequest.HttpRequestBuilder(apiUrl).build().get(apiUrl+"/rest/api/1.0/test-redirect");
+        assertEquals(302, response.getStatus());
+        assertEquals("http://localhost:7990/bitbucket/rest/api/1.0/redirect-test-success", response.getHeader("Location"));
     }
 
     @Test

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-redirect-test.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-redirect-test.json
@@ -1,0 +1,23 @@
+{
+  "id" : "d5434dae-88c5-3cdd-a506-11adb708a1ad",
+  "request" : {
+    "url" : "/rest/api/1.0/test-redirect",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 302,
+    "bodyFileName" : "body-1.0-application-properties-q4jwO.json",
+    "headers" : {
+      "X-AREQUESTID" : "@1962TV2x594x11x0",
+      "X-ASEN" : "SEN-L9817337",
+      "Location" : "http://localhost:7990/bitbucket/rest/api/1.0/redirect-test-success",
+      "Cache-Control" : "no-cache, no-transform",
+      "Vary" : "X-AUSERNAME,Accept-Encoding",
+      "Transfer-Encoding" : "chunked",
+      "X-Content-Type-Options" : "nosniff",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Wed, 12 Jul 2017 09:54:11 GMT"
+    }
+  },
+  "uuid" : "d5434dae-88c5-3cdd-a506-11adb708a1ad"
+}


### PR DESCRIPTION
# Description

See [JENKINS-47984](https://issues.jenkins-ci.org/browse/JENKINS-47984).

Auto redirection was disabled but had a bug which is fixed. Now API redirection is disabled for Bitbucket.

If user adds BB server endpoint URL or uses one previously added that results in redirection an error will be displayed. See images below:

![image](https://user-images.githubusercontent.com/38139/32920719-3eed8754-cadf-11e7-9fd8-22309f2fd32f.png)

![image](https://user-images.githubusercontent.com/38139/32920733-4f66c802-cadf-11e7-9f33-5108366d33b2.png)

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

