### PR TITLE
[JENKINS-45476] Only insert one blueocean link

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
@@ -49,7 +49,9 @@ public class TryBlueOceanMenu extends TransientActionFactory<ModelObject> {
                     return Collections.emptyList();
                 }
                 try {
-                    ((Actionable) target).replaceAction(a);
+                    // Possibly not needed. Maybe only needed if there is a bug in exists(). Which
+                    // thee was. Unsure exactly how this code works so leaving it in
+                    ((Actionable) target).removeActions(BlueOceanUrlAction.class);
                 }catch (Throwable e){
                     //ignore, replace is not supported
                     //JENKINS-44964 sometimes replaceAction will fail because one of the actions inserted is null
@@ -62,7 +64,7 @@ public class TryBlueOceanMenu extends TransientActionFactory<ModelObject> {
     }
 
     private boolean exists(Actionable actionable, BlueOceanUrlAction blueOceanUrlAction){
-        for(Action a: actionable.getActions()) {
+        for(Action a: actionable.getAllActions()) {
             // JENKINS-44926 only call getURLName on these actions if action is BLueOceanUrlAction
             if (a instanceof BlueOceanUrlAction) {
                 String blueUrl  = blueOceanUrlAction.getUrlName();

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
@@ -64,7 +64,7 @@ public class TryBlueOceanMenu extends TransientActionFactory<ModelObject> {
     }
 
     private boolean exists(Actionable actionable, BlueOceanUrlAction blueOceanUrlAction){
-        for(Action a: actionable.getAllActions()) {
+        for(Action a: actionable.getActions()) {
             // JENKINS-44926 only call getURLName on these actions if action is BLueOceanUrlAction
             if (a instanceof BlueOceanUrlAction) {
                 String blueUrl  = blueOceanUrlAction.getUrlName();


### PR DESCRIPTION
# Description

I'm unsure of how to replicate this but I'm pretty sure I know what was going on. I think the `exists` method was bugged, which meant `replaceActions` was updating the one that existed, and then we were returning one more from `createFor`.

I've changed it to remove any links if `exists` doesn't` find one. I'm not sure if this is needed, but it works fin

See [JENKINS-45476](https://issues.jenkins-ci.org/browse/JENKINS-45476).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

