### PR TITLE
GithubEditorTest using wait.click, more stable selector in editor step pulldown

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -78,10 +78,13 @@ public class EditorPage {
         */
         for (int i = 0; i < numberOfParallels; i++) {
             logger.info("Create stage Parallel-" + i);
-            wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+            // wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+            wait.click(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]"));
             wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-" + i);
-            wait.until(By.cssSelector("button.btn-primary.add")).click();
-            wait.until(By.xpath("//*[text()='Shell Script']")).click();
+            // wait.until(By.cssSelector("button.btn-primary.add")).click();
+            wait.click(By.cssSelector("button.btn-primary.add"));
+            // wait.until(By.xpath("//*[text()='Shell Script']")).click();
+            wait.click(By.cssSelector(".editor-step-selector div[data-functionName=\"sh\"]"));
             wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("netstat -a");
             wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
         }
@@ -92,10 +95,12 @@ public class EditorPage {
         wait.click(By.cssSelector("div.pipeline-big-label.top-level-parallel"));
         wait.until(By.cssSelector("input.stage-name-edit")).clear();
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Top Level Parallel Wrapper Stage");
-        wait.until(By.xpath("//*[text()='Save']")).click();
+        // wait.until(By.xpath("//*[text()='Save']")).click();
+        wait.click(By.xpath("//*[text()='Save']"));
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
-            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            // wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            wait.click(By.xpath("//*[text()='Commit to new branch']"));
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
         } else {
@@ -103,12 +108,15 @@ public class EditorPage {
             This mimics the user changing picking a new branch, and then
             changing their mind and committing to master after all.
             */
-            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            // wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            wait.click(By.xpath("//*[text()='Commit to new branch']"));
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys("i-am-changing-my-mind");
-            wait.until(By.xpath("//*[text()='Commit to master']")).click();
+            //wait.until(By.xpath("//*[text()='Commit to master']")).click();
+            wait.click(By.xpath("//*[text()='Commit to master']"));
             logger.info("Using branch master");
         }
-        wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
+        // wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
+        wait.click(By.xpath("//*[text()=\"Save & run\"]"));
         logger.info("Parallel pipeline saved");
     }
 

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -48,24 +48,25 @@ public class EditorPage {
 
         logger.info("Saved new branch");
     }
+
     public void simplePipeline(String newBranch) {
         logger.info("Editing simple pipeline");
-        wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
+        wait.click(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]"));
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Test stage");
-        wait.until(By.cssSelector("button.btn-primary.add")).click();
-        wait.until(By.xpath("//*[text()='Print Message']")).click();
+        wait.click(By.cssSelector("button.btn-primary.add"));
+        wait.click(By.xpath("//*[text()='Print Message']"));
         wait.until(By.cssSelector("input.TextInput-control")).sendKeys("hi there");
         wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
-        wait.until(By.xpath("//*[text()='Save']")).click();
+        wait.click(By.xpath("//*[text()='Save']"));
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Simple pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
-            wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            wait.click(By.xpath("//*[text()='Commit to new branch']"));
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
             logger.info("Using branch " + newBranch);
         } else {
             logger.info("Using branch master");
         }
-        wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
+        wait.click(By.xpath("//*[text()=\"Save & run\"]"));
         logger.info("Simple pipeline saved");
     }
 

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -78,12 +78,9 @@ public class EditorPage {
         */
         for (int i = 0; i < numberOfParallels; i++) {
             logger.info("Create stage Parallel-" + i);
-            // wait.until(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]")).click();
             wait.click(By.xpath("(//*[@class='pipeline-node-hittarget'])[2]"));
             wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Parallel-" + i);
-            // wait.until(By.cssSelector("button.btn-primary.add")).click();
             wait.click(By.cssSelector("button.btn-primary.add"));
-            // wait.until(By.xpath("//*[text()='Shell Script']")).click();
             wait.click(By.cssSelector(".editor-step-selector div[data-functionName=\"sh\"]"));
             wait.until(By.cssSelector("textarea.editor-step-detail-script")).sendKeys("netstat -a");
             wait.click(By.xpath("(//a[@class='back-from-sheet'])[2]"));
@@ -95,29 +92,24 @@ public class EditorPage {
         wait.click(By.cssSelector("div.pipeline-big-label.top-level-parallel"));
         wait.until(By.cssSelector("input.stage-name-edit")).clear();
         wait.until(By.cssSelector("input.stage-name-edit")).sendKeys("Top Level Parallel Wrapper Stage");
-        // wait.until(By.xpath("//*[text()='Save']")).click();
-        wait.click(By.xpath("//*[text()='Save']"));
+        wait.click(By.cssSelector("button.btn-primary.inverse"));
         wait.until(By.cssSelector("textarea[placeholder=\"What changed?\"]")).sendKeys("Parallel pipeline");
         if(!Strings.isNullOrEmpty(newBranch)) {
-            // wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
+            logger.info("Saving to branch " + newBranch);
             wait.click(By.xpath("//*[text()='Commit to new branch']"));
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys(newBranch);
-            logger.info("Using branch " + newBranch);
         } else {
             /*
             This mimics the user changing picking a new branch, and then
             changing their mind and committing to master after all.
             */
-            // wait.until(By.xpath("//*[text()='Commit to new branch']")).click();
             wait.click(By.xpath("//*[text()='Commit to new branch']"));
             wait.until(By.cssSelector("input[placeholder='my-new-branch']:enabled")).sendKeys("i-am-changing-my-mind");
-            //wait.until(By.xpath("//*[text()='Commit to master']")).click();
             wait.click(By.xpath("//*[text()='Commit to master']"));
             logger.info("Using branch master");
         }
-        // wait.until(By.xpath("//*[text()=\"Save & run\"]")).click();
         wait.click(By.xpath("//*[text()=\"Save & run\"]"));
-        logger.info("Parallel pipeline saved");
+        logger.info("Save & run clicked, Parallel pipeline saved");
     }
 
 }

--- a/blueocean-pipeline-editor/src/main/js/components/editor/AddStepSelectionSheet.jsx
+++ b/blueocean-pipeline-editor/src/main/js/components/editor/AddStepSelectionSheet.jsx
@@ -87,7 +87,7 @@ export class AddStepSelectionSheet extends Component<DefaultProps, Props, State>
         const searchTerm = value.toLowerCase();
         this.setState({searchFilter: s => s.displayName.toLowerCase().indexOf(searchTerm) !== -1});
     }, 300);
-    
+
     selectItemByKeyPress(e, step) {
         if (e.key == 'Enter') {
             this.props.onStepSelected(step);
@@ -97,7 +97,7 @@ export class AddStepSelectionSheet extends Component<DefaultProps, Props, State>
 
     render() {
         const { stepMetadata, selectedStep } = this.state;
-        
+
         return (
             <div className="editor-step-selection-dialog">
                 <div className="editor-step-search">
@@ -107,7 +107,7 @@ export class AddStepSelectionSheet extends Component<DefaultProps, Props, State>
                 </div>
                 <div className="editor-step-selector">
                 {stepMetadata && stepMetadata.filter(isStepValidForSelectionUI).filter(this.state.searchFilter).sort(stepSorter).map(step =>
-                    <div tabIndex="0" onKeyPress={e => this.selectItemByKeyPress(e, step)}
+                    <div tabIndex="0" data-functionName={step.functionName} onKeyPress={e => this.selectItemByKeyPress(e, step)}
                         onClick={() => this.addStep(step)}>
                         {step.displayName}
                     </div>


### PR DESCRIPTION
# GithubEditorTest updates, plus a more stable selector to target
This PR includes two main things.

1. Conversion to `wait.click()`, instead of `wait.until(things).click()`, to hopefully de-flake these tests. `wait.click` has which has retry behavior and an initial check for `elementIsClickable`, built into it. Inspired by [PR 1544](https://github.com/jenkinsci/blueocean-plugin/pull/1544).
2. Addition of `data-functionName={step.functionName}` in the pulldown for creating a step in the editor. This, hopefully, provides a more stable selector for the tests to look for. It matches up nicely to the step which will be created in the Jenkinsfile - e.g., "Shell Script" matches up to `sh`.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate: N/A.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: this is an acceptance test addition. Unit and acceptance tests not applicable
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

# To run:

- Follow the instructions provided in [the acceptance tests' README](https://github.com/kshultzCB/blueocean-plugin/tree/add-parallel-editor-test/acceptance-tests) for setting up the "live" acceptance tests
- Invoke `mvn test -Dprofile=live -Dtest=GithubEditorTest`