### PR TITLE
fix expandable-path folder icon color in the contentPageHeader

### DIFF
--- a/jenkins-design-language/less/components/expandable-path.less
+++ b/jenkins-design-language/less/components/expandable-path.less
@@ -47,7 +47,7 @@
                 }
             }
 
-            .ContentPageHeader-main & svg {
+            .BasicHeader & svg {
                 fill: rgba(255, 255, 255, 0.5);
             }
         }


### PR DESCRIPTION
Fix expandable-path folder icon color in the contentPageHeader

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

