### PR TITLE
[JENKINS-48285] - Make UserImplPermissionTest work with >= 2.77 cores

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
@@ -49,6 +49,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.DELETE;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -56,6 +59,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Node;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.model.User;
@@ -110,6 +114,21 @@ public class UserImplPermissionTest {
         mockStatic(Jenkins.class);
         when(Jenkins.getAuthentication()).thenReturn(authentication);
         when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        try {
+            // After Jenkins 2.77 hasPermission is no longer in Node.class and is not final so we need to mock it
+            // prior to it is called as being final and mocking it will fail for the same reason.
+            // TODO remove after core base line is >= 2.77
+            Node.class.getDeclaredMethod("hasPermission", Permission.class);
+        } catch (NoSuchMethodException e) {
+            when(jenkins.hasPermission(Mockito.any())).thenAnswer(new Answer<Boolean>() {
+                public Boolean answer(InvocationOnMock invocation) {
+                    Permission permission = invocation.getArgumentAt(0, Permission.class);
+                    Jenkins j = (Jenkins) invocation.getMock();
+                    return j.getACL().hasPermission(permission);
+                }
+            });
+        }
 
         mockStatic(User.class);
         when(User.get("some_user", false, Collections.EMPTY_MAP)).thenReturn(user);


### PR DESCRIPTION
# Description

See [JENKINS-48285](https://issues.jenkins-ci.org/browse/JENKINS-48285).

So this change ([PR ](https://github.com/jenkinsci/jenkins/pull/2999)- [JENKINS-46610](https://issues.jenkins-ci.org/browse/JENKINS-46610)) moved all the hasPermission methods from several classes to a default method in the interface. In the test the method wasn't mocked because it was final and we didn't need to. Not the method is not final so it needs to be mocked.
I had to relay in a hackish check because pre 2.77 will fail the mock given that the method is final. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
