### PR TITLE
Bug/jenkins 48306 extra fetches sse loading worm

### DIFF
--- a/blueocean-core-js/src/js/fetch.js
+++ b/blueocean-core-js/src/js/fetch.js
@@ -272,11 +272,11 @@ export const Fetch = {
      * @param {Object} [options.fetchOptions] - Optional isomorphic-fetch options.
      * @returns JSON body.
      */
-    fetchJSON(url, { onSuccess, onError, fetchOptions, disableCapabilites, ignoreRefreshHeader } = {}) {
+    fetchJSON(url, { onSuccess, onError, fetchOptions, disableCapabilites, disableLoadingIndicator, ignoreRefreshHeader } = {}) {
         const fixedUrl = FetchFunctions.prefixUrl(url);
         let future;
         if (!config.isJWTEnabled()) {
-            future = FetchFunctions.rawFetchJSON(fixedUrl, { onSuccess, onError, fetchOptions, ignoreRefreshHeader });
+            future = FetchFunctions.rawFetchJSON(fixedUrl, { onSuccess, onError, fetchOptions, disableLoadingIndicator, ignoreRefreshHeader });
         } else {
             future = jwt.getToken()
                 .then(token => FetchFunctions.rawFetchJSON(fixedUrl, {

--- a/blueocean-core-js/src/js/services/ActivityService.js
+++ b/blueocean-core-js/src/js/services/ActivityService.js
@@ -59,15 +59,15 @@ export class ActivityService extends BunkerService {
      *
      * @param {string} href self href of activity.
      * @param {boolean} useCache Use the cache to lookup data or always fetch a new one.
+     * @param {boolean} disableLoadingIndicator Hide the visual progress indicator displayed during fetch.
      * @returns {Promise} Promise of fetched data.
      */
-    fetchActivity(href, { useCache } = {}) {
+    fetchActivity(href, { useCache, disableLoadingIndicator } = {}) {
         if (useCache && this.hasItem(href)) {
             return Promise.resolve(this.getItem(href));
         }
 
-
-        return Fetch.fetchJSON(href)
+        return Fetch.fetchJSON(href, { disableLoadingIndicator })
             .then(data => {
                 // Should really have dedupe on methods like these, but for now
                 // just clone data so that we dont modify other instances.

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -1,9 +1,11 @@
 
 export class DefaultSSEHandler {
+
     constructor(pipelineService, activityService, pagerService) {
         this.pipelineService = pipelineService;
         this.activityService = activityService;
         this.pagerService = pagerService;
+        this.loggingEnabled = false;
     }
 
     handleEvents = (event) => {
@@ -137,6 +139,16 @@ export class DefaultSSEHandler {
      * @private
      */
     _updateRun(event, href) {
+        const pipelineHref = this._computePipelineHref(event);
+        const logMessage = `${event.jenkins_event} for pipeline ${pipelineHref} with run ${href}`;
+
+        if (!this.pipelineService.hasItem(pipelineHref)) {
+            this.loggingEnabled && console.log(`aborting fetch for ${logMessage}`);
+            return;
+        }
+
+        this.loggingEnabled && console.log(`fetch ${logMessage}`);
+
         this.activityService.fetchActivity(href, { useCache: false }).then((run) => {
             this.activityService.setItem(run);
             for (const key of this.branchPagerKeys(event)) {
@@ -147,5 +159,32 @@ export class DefaultSSEHandler {
             }
             this.pipelineService.updateLatestRun(run);
         });
+    }
+
+    /**
+     * Compute the REST URL / href for the job referenced in the supplied server side event.
+     * @param event
+     * @returns {string}
+     * @private
+     */
+    _computePipelineHref(event) {
+        let jobRestUrl = event.blueocean_job_rest_url;
+
+        if (event.blueocean_job_branch_name) {
+            // trim the last two path segments (e.g. 'branches/branch-name')
+            jobRestUrl = jobRestUrl
+                .split('/')
+                .filter(p => p)
+                .slice(0, -2)
+                .join('/');
+        }
+        // ensure leading / trailing slashes
+        if (jobRestUrl.slice(0, 1) !== '/') {
+            jobRestUrl = `/${jobRestUrl}`;
+        }
+        if (jobRestUrl.slice(-1) !== '/') {
+            jobRestUrl += '/';
+        }
+        return jobRestUrl;
     }
 }

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -149,7 +149,7 @@ export class DefaultSSEHandler {
 
         this.loggingEnabled && console.log(`fetch ${logMessage}`);
 
-        this.activityService.fetchActivity(href, { useCache: false }).then((run) => {
+        this.activityService.fetchActivity(href, { useCache: false, disableLoadingIndicator: true }).then((run) => {
             this.activityService.setItem(run);
             for (const key of this.branchPagerKeys(event)) {
                 const pager = this.pagerService.getPager({ key });

--- a/blueocean-core-js/test/js/services/DefaultSSEHandler-spec.js
+++ b/blueocean-core-js/test/js/services/DefaultSSEHandler-spec.js
@@ -1,0 +1,122 @@
+import {assert} from 'chai';
+import sinon from 'sinon';
+
+import {DefaultSSEHandler} from '../../../src/js/services/DefaultSSEHandler';
+
+
+class ActivityServiceMock {
+    fetchActivity(event) {
+        return Promise.resolve({});
+    }
+}
+
+class PipelineServiceMock {
+    constructor() {
+        this.data = {};
+    }
+    hasItem(key) {
+        return !!this.data[key];
+    }
+    _setItem(key, item) {
+        this.data[key] = item;
+    }
+}
+
+class PagerServiceMock {}
+
+
+const eventRunStartedPipeline = {
+    blueocean_job_pipeline_name: "folder1/folder2/folder3/nested-pipeline",
+    blueocean_job_rest_url: "/blue/rest/organizations/jenkins/pipelines/folder1/pipelines/folder2/pipelines/folder3/pipelines/nested-pipeline/",
+    blueocean_queue_item_expected_build_number: "16",
+    jenkins_channel: "job",
+    jenkins_event: "job_run_started",
+    jenkins_event_timestamp: "1512670842446",
+    jenkins_event_uuid: "9b4e135d-981c-4a8f-8199-351d197a8f83",
+    jenkins_instance_url: "http://localhost:8080/jenkins/",
+    jenkins_object_id: "16",
+    jenkins_object_name: "#16",
+    jenkins_object_type: "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+    jenkins_object_url: "job/folder1/job/folder2/job/folder3/job/nested-pipeline/16/",
+    jenkins_org: "jenkins",
+    job_name: "folder1/folder2/folder3/nested-pipeline",
+    job_run_queueId: "9",
+    job_run_status: "RUNNING",
+    sse_subs_dispatcher: "jenkins-blueocean-core-js-1512665768044-xeni2",
+    sse_subs_dispatcher_inst: "148615817",
+};
+
+const eventRunStartedMultibranch = {
+    blueocean_job_branch_name: 'duration-5m',
+    blueocean_job_pipeline_name: 'pipeline-samples',
+    blueocean_job_rest_url: '/blue/rest/organizations/jenkins/pipelines/pipeline-samples/branches/duration-5m/',
+    blueocean_queue_item_expected_build_number: '13',
+    jenkins_channel: 'job',
+    jenkins_event: 'job_run_started',
+    jenkins_event_timestamp: '1512670672779',
+    jenkins_event_uuid: 'a310d02e-a8d4-4dd4-af61-ce8c068360bb',
+    jenkins_instance_url: 'http://localhost:8080/jenkins/',
+    jenkins_object_id: '13',
+    jenkins_object_name: '#13',
+    jenkins_object_type: 'org.jenkinsci.plugins.workflow.job.WorkflowRun',
+    jenkins_object_url: 'job/pipeline-samples/job/duration-5m/13/',
+    jenkins_org: 'jenkins',
+    job_name: 'pipeline-samples/duration-5m',
+    job_run_queueId: '7',
+    job_run_status: 'RUNNING',
+    sse_subs_dispatcher: 'jenkins-blueocean-core-js-1512665768044-xeni2',
+    sse_subs_dispatcher_inst: '148615817'
+};
+
+const pipelineSamplesJobUrl = '/blue/rest/organizations/jenkins/pipelines/pipeline-samples/';
+
+
+describe('DefaultSSEHandler', () => {
+    let sseHandler;
+    let pipelineService;
+    let activityService;
+    let fetchActivitySpy;
+
+    beforeEach(() => {
+        pipelineService = new PipelineServiceMock();
+        activityService = new ActivityServiceMock();
+        fetchActivitySpy = sinon.spy(activityService, 'fetchActivity');
+        sseHandler = new DefaultSSEHandler(pipelineService, activityService, new PagerServiceMock());
+    });
+
+    describe('handleEvents', () => {
+        it('fetches activity for a loaded pipeline', () => {
+            pipelineService._setItem(eventRunStartedPipeline.blueocean_job_rest_url, {});
+            sseHandler.handleEvents(eventRunStartedPipeline);
+            assert.isTrue(fetchActivitySpy.calledOnce);
+        });
+
+        it('does not fetch activity for an unloaded pipeline', () => {
+            sseHandler.handleEvents(eventRunStartedPipeline);
+            assert.isTrue(fetchActivitySpy.notCalled);
+        });
+
+        it('fetches activity for a loaded multibranch pipeline', () => {
+            pipelineService._setItem(pipelineSamplesJobUrl, {});
+            sseHandler.handleEvents(eventRunStartedMultibranch);
+            assert.isTrue(fetchActivitySpy.calledOnce);
+        });
+
+        it('does not fetch activity for an unloaded multibranch pipeline', () => {
+            sseHandler.handleEvents(eventRunStartedMultibranch);
+            assert.isTrue(fetchActivitySpy.notCalled);
+        });
+    });
+
+    describe('_computePipelineHref', () => {
+        it('works for pipeline event', () => {
+            const href = sseHandler._computePipelineHref(eventRunStartedPipeline);
+            assert.equal(href, eventRunStartedPipeline.blueocean_job_rest_url);
+        });
+
+        it('works for multibranch event', () => {
+            const href = sseHandler._computePipelineHref(eventRunStartedMultibranch);
+            assert.equal(href, pipelineSamplesJobUrl);
+        });
+    });
+});


### PR DESCRIPTION
# Description
- Improve `DefaultSSEHandler` so that it only will fetch a run after receiving SSE if the corresponding pipeline has already been loaded/cached in `PipelineService`. On busy CI servers (e.g. builds.apache.org) the app was making in 3-5 fetches per second and caching data that was not in any way displayed to the user.
- Disable the loading indicator for this specific background fetch. Less important after the above was implemented but still a visual improvement.
- See [JENKINS-48306](https://issues.jenkins-ci.org/browse/JENKINS-48306).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

