### PR TITLE
Add better logger

### DIFF
--- a/blueocean-core-js/src/js/Logger.js
+++ b/blueocean-core-js/src/js/Logger.js
@@ -1,0 +1,117 @@
+/**
+ * A logger that provides links back to the actual log message source in chrome debug tools
+ * as well as providing stack traces automatically at DEBUG level
+ *
+ * and is easy to configure. It supports node's process.env and browser's localStorage
+ * and even query params
+ */
+
+/**
+ * A logging class that provides methods which correctly link to the script location
+ * where logging happens
+ */
+export class Logger {
+    /**
+     * Basic logging levels
+     */
+    static Level = {
+        ERROR: 0,
+        WARN: 10,
+        INFO: 20,
+        LOG: 30,
+        DEBUG: 40,
+        TRACE: 50,
+    };
+
+    /**
+     * List of any specified logging level rules
+     * @type Array
+     */
+    static logLevels = [];
+
+    /**
+     * Creates a new Logger
+     *
+     * @argument {array<class|string>} channel log channel
+     */
+    constructor(...channel) {
+        this._channel = channel
+            .map(part => part.toString())
+            .reduce((arr, val) => arr.concat(val.split('.')), [])
+            .join('.');
+        this.setLogLevel(this.getLevel());
+    }
+
+    setLogLevel(level) {
+        this._logLevel = level;
+        for (const l of Object.keys(Logger.Level)) {
+            this.init(l);
+        }
+    }
+
+    init(levelName) {
+        const functionName = levelName.toLowerCase();
+        if (this.isEnabled(Logger.Level[levelName])) {
+            // If this channel is debugging enabled, use console.warn so we also get a stack trace, at least on chrome
+            let fn = Logger.Level[levelName] !== Logger.Level.ERROR && this.isEnabled(Logger.Level.DEBUG) ? console.warn : console[functionName];
+            if (!fn) {
+                fn = console.log;
+            }
+            this[functionName] = fn.bind(console, '[' + levelName + '] ' + this._channel + ':');
+        } else {
+            this[functionName] = function () {};
+        }
+    }
+
+    isEnabled(level) {
+        return level <= this._logLevel;
+    }
+
+    getLevel() {
+        let level = Logger.Level.ERROR;
+        for (const logLevel of Logger.logLevels) {
+            if (logLevel.pattern.test(this._channel)) {
+                level = logLevel.level;
+            }
+        }
+        return level;
+    }
+}
+
+function parseLoggingRules(rules) {
+    if (!rules) {
+        return;
+    }
+    rules.split(/,/).map(rule => {
+        const [ wildcard, level ] = rule.split(/=/);
+        Logger.logLevels.push({
+            pattern: new RegExp(wildcard
+                .split('')
+                .map(c => c === '*' ? '.*' : c.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&"))
+                .join('')),
+            level: Logger.Level[level],
+        });
+    });
+}
+
+// browser local storage
+if (localStorage) {
+    parseLoggingRules(localStorage.getItem('blueocean_logging'));
+}
+
+// node process env
+if (process && process.env) {
+    parseLoggingRules(process.env.blueocean_logging);
+}
+
+// browser query string
+if (window && window.location && window.location.href) {
+    const pattern = /.*[?&]blueocean_logging=([^&#]+).*/;
+    if (pattern.test(window.location.href)) {
+        parseLoggingRules(decodeURIComponent(window.location.href).replace(pattern, '$1'));
+    }
+}
+
+export default function createLogger(...channel) {
+    return new Logger(...channel);
+}


### PR DESCRIPTION
# Description

Fixes some deficiencies in `@jenkins-cd/logging`, including:

* Provides actual location back to originating source code in console (e.g. click the link on the right of the chrome console takes you to the log statement in the source)
* DEBUG mode provides stack traces
* Allows outputting of objects, just like `console.log`
* Allows easier configuration:
  * Nested logging paths a la log4j: `blueocean.pipeline.activity.*=DEBUG`
  * Temporarily enable via a URL parameter, e.g. enable everything at DEBUG level: `blueocean_logging=*=DEBUG`

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

