### PR TITLE
Bug/jenkins 46217 bitbucket changed password error

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
@@ -71,6 +71,7 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         if(!message.getErrors().isEmpty()){
             throw new ServiceException.BadRequestException(message);
         }
+        validateExistingCredential(apiUrl);
         return super.getState();
     }
 
@@ -209,8 +210,8 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         final StandardUsernamePasswordCredentials credential = new UsernamePasswordCredentialsImpl(CredentialsScope.USER,
                 createCredentialId(apiUrl), "Bitbucket server credentials", userName, password);
 
-        BitbucketApi api = getApi(apiUrl, this.getId(), credential);
-        api.getUser(); //if credentials are wrong, this call will fail with 403 error
+        //if credentials are wrong, this call will fail with 401 error
+        validateCredential(apiUrl, credential);
 
         StandardUsernamePasswordCredentials bbCredentials = CredentialsUtils.findCredential(createCredentialId(apiUrl),
                 StandardUsernamePasswordCredentials.class, new BlueOceanDomainRequirement());
@@ -259,7 +260,53 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         }
         if(!errorList.isEmpty()){
             throw new ServiceException.BadRequestException(
-                    new ErrorMessage(400, "Invalid request").addAll(errorList));
+                    new ErrorMessage(401, "Invalid request").addAll(errorList));
+        }
+    }
+
+    /**
+     * Validate that the credential is valid for the specified apiUrl.
+     * Will throw a 401 ServiceException if the credential is invalid.
+     * @param apiUrl
+     * @param credential
+     */
+    private void validateCredential(String apiUrl, StandardUsernamePasswordCredentials credential) {
+        try {
+            BitbucketApi api = getApi(apiUrl, this.getId(), credential);
+            api.getUser(); //if credentials are wrong, this call will fail with 401 error
+        } catch (ServiceException ex) {
+            if (ex.status == 401) {
+                throw new ServiceException.UnauthorizedException(
+                    new ErrorMessage(401, "Invalid username / password")
+                );
+            } else {
+                throw ex;
+            }
+
+        }
+    }
+
+    /**
+     * Validate that the existing credential is valid (if it exists).
+     * Will throw a 401 ServiceException if the credential is invalid.
+     * @param apiUrl
+     */
+    private void validateExistingCredential(@Nonnull String apiUrl) {
+        StandardUsernamePasswordCredentials bbCredentials = CredentialsUtils.findCredential(createCredentialId(apiUrl),
+            StandardUsernamePasswordCredentials.class, new BlueOceanDomainRequirement());
+
+        if (bbCredentials != null) {
+            try {
+                validateCredential(apiUrl, bbCredentials);
+            } catch (ServiceException ex) {
+                if (ex.status == 401) {
+                    throw new ServiceException.UnauthorizedException(
+                        new ErrorMessage(401, "Existing credential failed authorization")
+                    );
+                } else {
+                    throw ex;
+                }
+            }
         }
     }
 

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
@@ -260,7 +260,7 @@ public abstract class AbstractBitbucketScm extends AbstractScm {
         }
         if(!errorList.isEmpty()){
             throw new ServiceException.BadRequestException(
-                    new ErrorMessage(401, "Invalid request").addAll(errorList));
+                    new ErrorMessage(400, "Invalid request").addAll(errorList));
         }
     }
 

--- a/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsApi.js
+++ b/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsApi.js
@@ -5,6 +5,7 @@ import TypedError from '../TypedError';
 export const LoadError = {
     TOKEN_NOT_FOUND: 'TOKEN_NOT_FOUND',
     TOKEN_INVALID: 'TOKEN_INVALID',
+    TOKEN_REVOKED: 'TOKEN_REVOKED',
 };
 
 export const SaveError = {
@@ -42,6 +43,11 @@ class BbCredentialsApi {
 
     _findExistingCredentialFailure(error) {
         const { responseBody } = error;
+
+        if (responseBody.message.indexOf('Existing credential failed') >= 0) {
+            throw new TypedError(LoadError.TOKEN_REVOKED, responseBody);
+        }
+
         throw new TypedError(LoadError.TOKEN_INVALID, responseBody);
     }
 

--- a/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsManager.js
+++ b/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsManager.js
@@ -46,6 +46,8 @@ class BbCredentialsManager {
             this.stateId = BbCredentialState.NEW_REQUIRED;
         } else if (error.type === LoadError.TOKEN_INVALID) {
             this.stateId = BbCredentialState.INVALID_CREDENTIAL;
+        } else if (error.type === LoadError.TOKEN_REVOKED) {
+            this.stateId = BbCredentialState.REVOKED_CREDENTIAL;
         } else {
             this.stateId = BbCredentialState.UNEXPECTED_ERROR_CREDENTIAL;
         }

--- a/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsPicker.jsx
+++ b/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsPicker.jsx
@@ -76,6 +76,8 @@ class BbCredentialsPicker extends React.Component {
     _getErrorMessage(stateId) {
         if (stateId === BbCredentialsState.INVALID_CREDENTIAL) {
             return t('creation.bitbucket.connect.invalid_username_password');
+        } else if (stateId === BbCredentialsState.REVOKED_CREDENTIAL) {
+            return t('creation.bitbucket.connect.revoked_credential');
         } else if (stateId === BbCredentialsState.UNEXPECTED_ERROR_CREDENTIAL) {
             return t('creation.bitbucket.connect.unexpected_error');
         }

--- a/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsState.js
+++ b/blueocean-dashboard/src/main/js/credentials/bitbucket/BbCredentialsState.js
@@ -8,6 +8,7 @@ const BbCredentialState = new Enum({
     NEW_REQUIRED: 'new_required',
     SAVE_SUCCESS: 'save_success',
     INVALID_CREDENTIAL: 'invalid_credential',
+    REVOKED_CREDENTIAL: 'revoked_credential',
     UNEXPECTED_ERROR_CREDENTIAL: 'unexpected_error_credential',
 });
 

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages.properties
@@ -119,6 +119,7 @@ creation.bbserver.version.error=Error checking version of HTTP server. HTTP erro
 
 ## Bitbucket credential screen
 creation.bitbucket.connect.invalid_username_password=Invalid username and/or password
+creation.bitbucket.connect.revoked_credential=Existing username / password invalid. Please enter new credentials.
 creation.bitbucket.connect.unexpected_error=Bitbucket credential validation failed with unexpected error. Please try again
 creation.bitbucket.connect=Connect to Bitbucket
 creation.bitbucket.connect.authorize=Jenkins needs user credential to authorize itself with Bitbucket


### PR DESCRIPTION
# Description
- See [JENKINS-46217](https://issues.jenkins-ci.org/browse/JENKINS-46217).
- Note: adding the credential validation check to `AbstractBitbucketScm.getState()` was enough to get the username / credentials prompt to display at the right time, albeit with a cryptic "Invalid username / password" message. I tried to smarten up the UI by returning a specific error message from the server which corresponds to a more helpful message:  "Existing username / password invalid. Please enter new credentials."
- I manually tested the Bitbucket Cloud scenario and found that it works okay. Not sure if there is value in adding a separate test for "cloud" specifically since it exercises the same code paths but figured I'd see what @vivek thinks there.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

