### PR TITLE
[JENKINS-47158] Ensure that synthetic FlowNode is not saved.

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -575,7 +575,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                 createSyntheticStageId(firstNodeId, PARALLEL_SYNTHETIC_STAGE_NAME), parents){
             @Override
             public void save() throws IOException {
-                // no-op
+                // no-op to avoid JENKINS-45892 violations from serializing the synthetic FlowNode.
             }
 
             @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -572,6 +573,11 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         }
         FlowNode syntheticNode = new FlowNode(firstBranch.getNode().getExecution(),
                 createSyntheticStageId(firstNodeId, PARALLEL_SYNTHETIC_STAGE_NAME), parents){
+            @Override
+            public void save() throws IOException {
+                // no-op
+            }
+
             @Override
             protected String getTypeDisplayName() {
                 return PARALLEL_SYNTHETIC_STAGE_NAME;


### PR DESCRIPTION
# Description

See [JENKINS-47158](https://issues.jenkins-ci.org/browse/JENKINS-47158).

This is just a bandaid - as discussed on JENKINS-47158, the usage of
synthetic `FlowNode`s for visualization-only purposes is not
ideal. But at a minimum, this prevents the serialization of the
synthetic `FlowNode`s, making JENKINS-45892 warnings go away, and not,
well, serializing a bunch of stuff we almost certainly shouldn't be.

No manual testing really needed here, but if you want, run on core 2.75 or later, use a parallel Pipeline like [the one specified in this JIRA comment](https://issues.jenkins-ci.org/browse/JENKINS-47158?focusedCommentId=316531&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-316531), and make sure you don't see anything about JENKINS-45892 in the Jenkins log.

Assuming this is accepted, it should go into the next 1.3.x release as well as 1.4 - this is a critical issue.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

cc @jglick, who isn't eligible to be a reviewer.