### PR TITLE
release 1.3: [JENKINS-47158] Ensure that synthetic FlowNode is not saved. (#1584)

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -561,6 +562,11 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         }
         FlowNode syntheticNode = new FlowNode(firstBranch.getNode().getExecution(),
                 createSyntheticStageId(firstNodeId, PARALLEL_SYNTHETIC_STAGE_NAME), parents){
+            @Override
+            public void save() throws IOException {
+                // no-op to avoid JENKINS-45892 violations from serializing the synthetic FlowNode.
+            }
+
             @Override
             protected String getTypeDisplayName() {
                 return PARALLEL_SYNTHETIC_STAGE_NAME;

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -16,6 +16,7 @@ import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -29,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Iterator;
@@ -38,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 
 import static io.jenkins.blueocean.rest.impl.pipeline.PipelineStepImpl.PARAMETERS_ELEMENT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -2371,6 +2374,32 @@ public class PipelineNodeTest extends PipelineBaseTest {
         assertEquals(edges.get(0).get("id"), receivedEdges.get(0).get("id"));
         assertEquals(edges.get(1).get("id"), receivedEdges.get(1).get("id"));
         assertEquals(edges.get(2).get("id"), receivedEdges.get(2).get("id"));
+    }
+
+    @Issue("JENKINS-47158")
+    @Test
+    public void syntheticParallelFlowNodeNotSaved() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
+        p.setDefinition(new CpsFlowDefinition("parallel a: {\n" +
+            "    node {\n" +
+            "        echo 'a'\n" +
+            "    }\n" +
+            "}, b: {\n" +
+            "    node {\n" +
+            "        echo 'b'\n" +
+            "    }\n" +
+            "}\n", true));
+        WorkflowRun b = j.buildAndAssertSuccess(p);
+        get("/organizations/jenkins/pipelines/pipeline1/runs/1/nodes/", List.class);
+        FlowExecution rawExec = b.getExecution();
+        assert(rawExec instanceof CpsFlowExecution);
+        CpsFlowExecution execution = (CpsFlowExecution) rawExec;
+        File storage = execution.getStorageDir();
+
+        // Nodes 5 and 6 are the parallel branch start nodes. Make sure no "5-parallel-synthetic.xml" and "6..." files
+        // exist in the storage directory, showing we haven't saved them.
+        assertFalse(new File(storage, "5-parallel-synthetic.xml").exists());
+        assertFalse(new File(storage, "6-parallel-synthetic.xml").exists());
     }
 
     @Test


### PR DESCRIPTION
A cherry pick from master of https://github.com/jenkinsci/blueocean-plugin/pull/1584

* [JENKINS-47158] Ensure that synthetic FlowNode is not saved.

This is just a bandaid - as discussed on JENKINS-47158, the usage of
synthetic `FlowNode`s for visualization-only purposes is not
ideal. But at a minimum, this prevents the serialization of the
synthetic `FlowNode`s, making JENKINS-45892 warnings go away, and not,
well, serializing a bunch of stuff we almost certainly shouldn't be.

* Add note as to why we're not saving.


