### PR TITLE
Revert "sign images we push to dockerhub"

### DIFF
--- a/docker/official/build.sh
+++ b/docker/official/build.sh
@@ -35,7 +35,6 @@ docker tag "jenkinsci/blueocean:$BLUEOCEAN_VERSION" jenkinsci/blueocean:latest
 docker tag "jenkinsci/blueocean:$BLUEOCEAN_VERSION" "jenkinsci/blueocean:$FULL_VERSION"
 
 # push it real good
-export DOCKER_CONTENT_TRUST=1
 docker push "jenkinsci/blueocean:$BLUEOCEAN_VERSION"
 docker push "jenkinsci/blueocean:$FULL_VERSION"
 docker push jenkinsci/blueocean:latest


### PR DESCRIPTION
This reverts commit 0acb925d2d6458ede2d8e31348503191a639c951.

Signing appears to require a persistent key to be created in our infrastructure
which does not presently exist:

	Signing and pushing trust metadata
	You are about to create a new root signing key passphrase. This passphrase
	will be used to protect the most sensitive key in your signing system. Please
	choose a long, complex passphrase and be careful to keep the password and the
	key file itself secure and backed up. It is highly recommended that you use a
	password manager to generate the passphrase and keep it safe. There will be no
	way to recover this key. You can find the key in your config directory.
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	Enter passphrase for new root key with ID 66e9aff:
	maximum number of passphrase attempts exceeded

Fixes [JENKINS-48572](https://issues.jenkins-ci.org/browse/JENKINS-48572)

