### PR TITLE
Hotfix release:perform

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest-impl</artifactId>
-            <version>1.4.0-beta-1-SNAPSHOT</version>
+            <version>1.4.0-beta-3-SNAPSHOT</version>
             <type>test-jar</type>
         </dependency>
         <dependency>

--- a/blueocean-config/package.json
+++ b/blueocean-config/package.json
@@ -4,7 +4,6 @@
   "description": "Configuration injected in BlueOcean UI",
   "scripts": {
     "build": "jjsbuilder",
-    "mvnclean": "echo 'clean'",
     "mvnbuild": "jjsbuilder --tasks bundle",
     "mvntest": "jjsbuilder --tasks test,lint"
   },

--- a/blueocean-core-js/gulpfile.js
+++ b/blueocean-core-js/gulpfile.js
@@ -12,14 +12,11 @@ const babel = require('gulp-babel');
 const less = require('gulp-less');
 const rename = require('gulp-rename');
 const copy = require('gulp-copy');
-const del = require('del');
-const runSequence = require('run-sequence');
 const fs = require('fs');
 
 // Options, src/dest folders, etc
 
 const config = {
-    clean: ["dist"],
     react: {
         sources: ["src/**/*.{js,jsx}", "!**/__mocks__/**"],
         dest: "dist"
@@ -40,25 +37,14 @@ const config = {
 
 // Watch all
 
-gulp.task("watch", ["clean-build"], () => {
+gulp.task("watch", ["build"], () => {
     gulp.watch(config.react.sources, ["compile-react"]);
     gulp.watch(config.less.watch, ["less"]);
 });
 
 // Default to all
 
-gulp.task("default", () =>
-    runSequence("clean", "lint", "test", "build", "validate"));
-
-// Clean and build only, for watching
-
-gulp.task("clean-build", () =>
-    runSequence("clean", "build", "validate"));
-
-// Clean
-
-gulp.task("clean", () =>
-    del(config.clean));
+gulp.task("default", ["validate"]);
 
 // Build all
 
@@ -88,7 +74,7 @@ gulp.task("copy-less-assets", () =>
         .pipe(copy(config.copy.less_assets.dest, { prefix: 2 })));
 
 // Validate contents
-gulp.task("validate", () => {
+gulp.task("validate", ["lint", "test"], () => {
     const paths = [
         config.react.dest,
     ];
@@ -123,4 +109,4 @@ builder.bundle('src/js/index.js', 'blueocean-core-js.js')
     .import("react-router@any")
     .export("@jenkins-cd/js-extensions")
     .export("@jenkins-cd/logging")
-    .export('mobx')
+    .export('mobx');

--- a/blueocean-core-js/gulpfile.js
+++ b/blueocean-core-js/gulpfile.js
@@ -19,7 +19,7 @@ const fs = require('fs');
 // Options, src/dest folders, etc
 
 const config = {
-    clean: ["dist", "target"],
+    clean: ["dist"],
     react: {
         sources: ["src/**/*.{js,jsx}", "!**/__mocks__/**"],
         dest: "dist"

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -15,7 +15,6 @@
     "test": "gulp test",
     "test:debug": "node --debug-brk ./node_modules/.bin/gulp test:debug",
     "test:fast": "gulp test:fast",
-    "mvnclean": "gulp clean",
     "mvnbuild": "gulp lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test"

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -15,7 +15,7 @@
     "test": "gulp test",
     "test:debug": "node --debug-brk ./node_modules/.bin/gulp test:debug",
     "test:fast": "gulp test:fast",
-    "mvnbuild": "gulp lint build bundle",
+    "mvnbuild": "gulp clean lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test"
   },

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -15,7 +15,7 @@
     "test": "gulp test",
     "test:debug": "node --debug-brk ./node_modules/.bin/gulp test:debug",
     "test:fast": "gulp test:fast",
-    "mvnbuild": "gulp clean lint build bundle",
+    "mvnbuild": "gulp lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test"
   },

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -14,7 +14,6 @@
     "test:watch": "gulp test:debug",
     "bundle": "gulp bundle",
     "bundle:watch": "gulp bundle:watch",
-    "mvnclean": "echo 'clean'",
     "mvnbuild": "gulp lint bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test"

--- a/blueocean-personalization/package.json
+++ b/blueocean-personalization/package.json
@@ -12,7 +12,6 @@
     "test:watch": "gulp test:debug",
     "bundle": "gulp bundle",
     "bundle:watch": "gulp bundle:watch",
-    "mvnclean": "echo 'clean'",
     "mvnbuild": "gulp bundle",
     "mvntest": "gulp test lint"
   },

--- a/blueocean-pipeline-editor/package.json
+++ b/blueocean-pipeline-editor/package.json
@@ -11,7 +11,6 @@
     "test:watch": "jjsbuilder --tasks test:watch",
     "bundle": "jjsbuilder --tasks bundle",
     "bundle:watch": "jjsbuilder --tasks bundle:watch",
-    "mvnclean": "echo 'clean'",
     "mvnbuild": "jjsbuilder --tasks lint,bundle",
     "mvnbuild:fast": "jjsbuilder --tasks bundle",
     "mvntest": "jjsbuilder --tasks test"

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -9,7 +9,6 @@
     "test:watch": "gulp test:watch",
     "bundle": "gulp bundle",
     "bundle:watch": "gulp bundle:watch",
-    "mvnclean": "echo 'clean'",
     "mvnbuild": "gulp lint bundle && browserify src/main/js/ie/iepolyfills.js > target/classes/org/jenkins/ui/jsmodules/blueocean-web/iepolyfills.js",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test"

--- a/jenkins-design-language/gulpfile.js
+++ b/jenkins-design-language/gulpfile.js
@@ -13,8 +13,6 @@ const fs = require('fs');
 const sourcemaps = require('gulp-sourcemaps');
 const babel = require('gulp-babel');
 const less = require('gulp-less');
-const clean = require('gulp-clean');
-const runSequence = require('run-sequence');
 const rename = require('gulp-rename');
 const copy = require('gulp-copy');
 const svgmin = require('gulp-svgmin');
@@ -23,7 +21,6 @@ const lint = require('gulp-eslint');
 // Options, src/dest folders, etc
 
 const config = {
-    clean: ["dist"],
     react: {
         sources: "src/**/*.{js,jsx}",
         dest: "dist"
@@ -70,32 +67,20 @@ const config = {
 
 // Watch all
 
-gulp.task("watch", ["clean-build"], () => {
+gulp.task("watch", ["build"], () => {
    gulp.watch(config.react.sources, ["compile-react"]);
    gulp.watch(config.less.watch, ["less"]);
 });
 
 // Watch only styles, for when you're using Storybook
 
-gulp.task("watch-styles", ["clean-build"], () => {
+gulp.task("watch-styles", ["build"], () => {
    gulp.watch(config.less.watch, ["less"]);
 });
 
 // Default to all
 
-gulp.task("default", () =>
-    runSequence("clean", "lint", "test", "build", "validate"));
-
-// Clean and build only, for watching
-
-gulp.task("clean-build", () =>
-    runSequence("clean", "build", "validate"));
-
-// Clean
-
-gulp.task("clean", () =>
-    gulp.src(config.clean, {read: false})
-        .pipe(clean()));
+gulp.task("default", ["lint", "test", "build", "validate"]);
 
 // Build all
 

--- a/jenkins-design-language/gulpfile.js
+++ b/jenkins-design-language/gulpfile.js
@@ -84,7 +84,7 @@ gulp.task("watch-styles", ["clean-build"], () => {
 // Default to all
 
 gulp.task("default", () =>
-    runSequence("clean", "lint", "test", "build", "validate"));
+    runSequence("lint", "test", "build", "validate"));
 
 // Clean and build only, for watching
 

--- a/jenkins-design-language/gulpfile.js
+++ b/jenkins-design-language/gulpfile.js
@@ -23,7 +23,7 @@ const lint = require('gulp-eslint');
 // Options, src/dest folders, etc
 
 const config = {
-    clean: ["dist", "target"],
+    clean: ["dist"],
     react: {
         sources: "src/**/*.{js,jsx}",
         dest: "dist"

--- a/jenkins-design-language/gulpfile.js
+++ b/jenkins-design-language/gulpfile.js
@@ -84,7 +84,7 @@ gulp.task("watch-styles", ["clean-build"], () => {
 // Default to all
 
 gulp.task("default", () =>
-    runSequence("lint", "test", "build", "validate"));
+    runSequence("clean", "lint", "test", "build", "validate"));
 
 // Clean and build only, for watching
 

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -10,7 +10,6 @@
     "flow": "flow",
     "lint": "gulp lint",
     "gulp": "gulp build",
-    "mvnclean": "gulp clean",
     "mvnbuild": "gulp lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test",

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -10,7 +10,7 @@
     "flow": "flow",
     "lint": "gulp lint",
     "gulp": "gulp build",
-    "mvnbuild": "gulp lint build bundle",
+    "mvnbuild": "gulp clean lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test",
     "bundle:watch": "gulp bundle:watch",

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -10,7 +10,7 @@
     "flow": "flow",
     "lint": "gulp lint",
     "gulp": "gulp build",
-    "mvnbuild": "gulp clean lint build bundle",
+    "mvnbuild": "gulp lint build bundle",
     "mvnbuild:fast": "gulp bundle",
     "mvntest": "gulp test",
     "bundle:watch": "gulp bundle:watch",

--- a/pom.xml
+++ b/pom.xml
@@ -1074,18 +1074,6 @@
 
                             <execution>
                                 <phase>initialize</phase>
-                                <id>gulp clean</id>
-                                <goals>
-                                    <goal>npm</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- The package.json must define an "mvnclean" script -->
-                                    <arguments>run mvnclean</arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <phase>initialize</phase>
                                 <id>npm install</id>
                                 <goals>
                                     <goal>npm</goal>


### PR DESCRIPTION
# Description

Bringing back the PR with @cliffmeyers's proposed gulp and lifecycle changes. We tried this but it failed to deploy on release:prepare stage: 

```

    [INFO] [04:43:33] Error: EEXIST: file already exists, mkdir '/jenkins/workspace/blueocean-release/jenkins-design-language/dist/js'

    [INFO]     at Error (native)
```