### PR TITLE
JENKINS-48378 Add stability / consistency to ParallelNavigationTest.java

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/model/MultiBranchPipeline.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/model/MultiBranchPipeline.java
@@ -42,6 +42,10 @@ public class MultiBranchPipeline extends AbstractPipeline {
         jobApi.abortAllBuilds(getFolder(), getName());
     }
 
+    public void deleteThisPipeline(String name) throws IOException {
+        jobApi.deletePipeline(name);
+    }
+
     @Override
     public boolean isMultiBranch() {
         return true;

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/ParallelNavigationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/ParallelNavigationTest.java
@@ -60,7 +60,7 @@ public class ParallelNavigationTest {
         wait.until(By.xpath("//*[text()=\"firstBranch\"]"));
 
         // and clicking on the unselected node will yield us the second branch
-        wait.until(By.xpath("//*[contains(@class, 'pipeline-node')][3]")).click();
+        wait.click(By.xpath("//*[contains(@class, 'pipeline-node')][3]"));
         wait.until(By.xpath("//*[text()=\"secondBranch\"]"));
 
         pipeline.stopAllRuns();
@@ -86,12 +86,12 @@ public class ParallelNavigationTest {
 
         // at first we see branch one
         wait.until(By.xpath("//*[text()=\"firstBranch\"]"));
-        wait.until(By.cssSelector(".btn.inputStepSubmit")).click();
+        wait.click(By.cssSelector(".btn.inputStepSubmit"));
 
         // and clicking on the unselected node will yield us the second branch
-        wait.until(By.xpath("//*[contains(@class, 'pipeline-node')][3]")).click();
+        wait.click(By.xpath("//*[contains(@class, 'pipeline-node')][3]"));
         wait.until(By.xpath("//*[text()=\"secondBranch\"]"));
-        wait.until(By.cssSelector(".btn.inputStepSubmit")).click();
+        wait.click(By.cssSelector(".btn.inputStepSubmit"));
     }
 
 

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/ParallelNavigationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/ParallelNavigationTest.java
@@ -10,8 +10,7 @@ import io.blueocean.ath.factory.MultiBranchPipelineFactory;
 import io.blueocean.ath.model.MultiBranchPipeline;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 
@@ -35,9 +34,40 @@ public class ParallelNavigationTest {
     @Inject
     WaitUtil wait;
 
-
     @Inject
     MultiBranchPipelineFactory mbpFactory;
+
+    // Names of the pipelines we'll create
+    String navTest          = "ParallelNavTest_tested";
+    String navTestWithInput = "ParallelNavTestWithInput_tested";
+
+    // Initialize our MultiBranchPipeline objects
+    static MultiBranchPipeline navTestPipeline = null;
+    static MultiBranchPipeline navTestWithInputPipeline = null;
+
+    // Create the pipelines in a @Before, instead of in each individual test
+    @Before
+    public void setupPipelines () throws IOException, GitAPIException, InterruptedException {
+        // Create navTest
+        logger.info("Creating pipeline " + navTest);
+        URL navTestJenkinsfile = Resources.getResource(ParallelNavigationTest.class, "ParallelNavigationTest/Jenkinsfile");
+        Files.copy(new File(navTestJenkinsfile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
+        git.addAll();
+        git.commit("Initial commit for " + navTest);
+        logger.info("Committed Jenkinsfile for " + navTest);
+        navTestPipeline = mbpFactory.pipeline(navTest).createPipeline(git);
+        logger.info("Finished creating " + navTest);
+
+        // Create navTestWithInput
+        logger.info("Creating pipeline " + navTestWithInput);
+        URL navTestInputJenkinsile = Resources.getResource(ParallelNavigationTest.class, "ParallelNavigationTest/Jenkinsfile.input");
+        Files.copy(new File(navTestInputJenkinsile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
+        git.addAll();
+        git.commit("Initial commit for " + navTestWithInput);
+        logger.info("Committed Jenkinsfile for " + navTestWithInput);
+        navTestWithInputPipeline = mbpFactory.pipeline(navTestWithInput).createPipeline(git);
+        logger.info("Finished creating " + navTestWithInput);
+    }
 
     /**
      * This checks that we can run a pipeline with 2 long running parallel branches.
@@ -45,27 +75,16 @@ public class ParallelNavigationTest {
      */
     @Test
     public void parallelNavigationTest () throws IOException, GitAPIException, InterruptedException {
-        String pipelineName = "ParallelNavigationTest_tested";
-
-        URL jenkinsFile = Resources.getResource(ParallelNavigationTest.class, "ParallelNavigationTest/Jenkinsfile");
-        Files.copy(new File(jenkinsFile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
-        git.addAll();
-        git.commit("initial commit");
-        logger.info("Commited Jenkinsfile");
-
-        MultiBranchPipeline pipeline = mbpFactory.pipeline(pipelineName).createPipeline(git);
-        pipeline.getRunDetailsPipelinePage().open(1);
-
-        // at first we see branch one
+        logger.info("Beginning parallelNavigationTest()");
+        navTestPipeline.getRunDetailsPipelinePage().open(1);
+        // At first we see branch one
         wait.until(By.xpath("//*[text()=\"firstBranch\"]"));
-
+        logger.info("Found first branch");
         // and clicking on the unselected node will yield us the second branch
         wait.click(By.xpath("//*[contains(@class, 'pipeline-node')][3]"));
         wait.until(By.xpath("//*[text()=\"secondBranch\"]"));
-
-        pipeline.stopAllRuns();
+        logger.info("Found second branch");
     }
-
 
     /**
      * This checks that you can have input on 2 different parallel branches. There are no stages either side of the parallel construct.
@@ -73,26 +92,32 @@ public class ParallelNavigationTest {
      */
     @Test
     public void parallelNavigationTestInput () throws IOException, GitAPIException, InterruptedException {
-        String pipelineName = "ParallelNavigationTest_tested_input";
-
-        URL jenkinsFile = Resources.getResource(ParallelNavigationTest.class, "ParallelNavigationTest/Jenkinsfile.input");
-        Files.copy(new File(jenkinsFile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
-        git.addAll();
-        git.commit("initial commit");
-        logger.info("Commited Jenkinsfile");
-
-        MultiBranchPipeline pipeline = mbpFactory.pipeline(pipelineName).createPipeline(git);
-        pipeline.getRunDetailsPipelinePage().open(1);
-
-        // at first we see branch one
+        logger.info("Beginning parallelNavigationTestInput()");
+        navTestWithInputPipeline.getRunDetailsPipelinePage().open(1);
+        // At first we see branch one
         wait.until(By.xpath("//*[text()=\"firstBranch\"]"));
+        logger.info("Found first branch");
         wait.click(By.cssSelector(".btn.inputStepSubmit"));
-
-        // and clicking on the unselected node will yield us the second branch
+        logger.info("Clicked the inputStepSubmit button");
+        // And clicking on the unselected node will yield us the second branch
         wait.click(By.xpath("//*[contains(@class, 'pipeline-node')][3]"));
         wait.until(By.xpath("//*[text()=\"secondBranch\"]"));
+        logger.info("Found second branch");
         wait.click(By.cssSelector(".btn.inputStepSubmit"));
+        logger.info("Clicked the inputStepSubmit button");
+
     }
 
-
+    @AfterClass
+    public static void deleteTestPipelines() throws IOException, GitAPIException, InterruptedException {
+        MultiBranchPipeline[] listOfPipelineJobs = {navTestPipeline, navTestWithInputPipeline};
+        for (MultiBranchPipeline pipelineToCleanup:listOfPipelineJobs) {
+            /*
+            stopAllRuns and deleteThisPipeline both provide their own
+            logger messages, no need to create new ones here.
+            */
+            pipelineToCleanup.stopAllRuns();
+            pipelineToCleanup.deleteThisPipeline(pipelineToCleanup.getName());
+        }
+    }
 }


### PR DESCRIPTION
# Description

See [JENKINS-48378](https://issues.jenkins-ci.org/browse/JENKINS-48378). This PR includes:

1. Conversion of `wait.until` calls into `wait.click()` calls, to hopefully help de-flake these tests
2. Creation of the test Pipelines has been moved out of the test cases themselves, and into a `@Before` method called `setupPipelines()`.
3. Removal of the test Pipelines is now part of the test, and is in an `@AfterClass` method called `deleteTestPipelines()`.
4. `deleteTestPipelines()` calls a new method, `io.blueocean.ath.model.MultiBranchPipeline#deleteThisPipeline`, which deletes the pipeline specified by the caller, by use of `jobApi.deletePipeline(name)`. 

# To Run:

1. Follow the instructions provided in t[he acceptance tests' README](https://github.com/jenkinsci/blueocean-plugin/blob/master/acceptance-tests/README.md) for running "offline" acceptance tests. 
2. Invoke `mvn test -Dprofile=offline -Dtest=ParallelNavigationTest`

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: N/A, because this is test code.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

