### PR TITLE
JENKINS-48322# Fix replaceIfNotAtTopLevel warning

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
 
     private volatile String mappedUrl;
-    private final ModelObject modelObject;
+    private transient final ModelObject modelObject;
 
     public BlueOceanUrlObjectImpl(ModelObject modelObject) {
         this.modelObject = modelObject;


### PR DESCRIPTION
# Description

BlueOceanUrlObjectImpl unintentionally references ModelObject as non-transient resulting in to replaceIfNotAtTopLevel warning. See https://issues.jenkins-ci.org/browse/JENKINS-45892.

See [JENKINS-48322](https://issues.jenkins-ci.org/browse/JENKINS-48322).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
