### PR TITLE
JENKINS-48219# When creating git pipeline check Item.READ permission instead of overall READ permission

### DIFF
--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
@@ -23,26 +23,23 @@
  */
 package io.jenkins.blueocean.blueocean_git_pipeline;
 
-import java.io.IOException;
-
-import hudson.model.User;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.kohsuke.stapler.StaplerRequest;
-
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.User;
 import hudson.remoting.Base64;
-import hudson.security.Permission;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.impl.pipeline.ScmContentProvider;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.GitContent;
+import java.io.IOException;
 import javax.annotation.Nonnull;
 import jenkins.branch.MultiBranchProject;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Content provider for load/save with git repositories
@@ -184,7 +181,7 @@ public class GitReadSaveService extends ScmContentProvider {
 
     @Override
     public Object saveContent(@Nonnull StaplerRequest req, @Nonnull Item item) {
-        item.checkPermission(Permission.WRITE);
+        item.checkPermission(Item.CONFIGURE);
         User user = User.current();
         if (user == null) {
             throw new ServiceException.UnauthorizedException("Not authenticated");

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
@@ -162,7 +162,7 @@ public class GitReadSaveService extends ScmContentProvider {
 
     @Override
     public Object getContent(@Nonnull StaplerRequest req, @Nonnull Item item) {
-        item.checkPermission(Permission.READ);
+        item.checkPermission(Item.READ);
         User user = User.current();
         if (user == null) {
             throw new ServiceException.UnauthorizedException("Not authenticated");


### PR DESCRIPTION
# Description

Git creation flow checks for overall read permission in getContent() API call. It should really be checking that Item's READ permission instead.

cc: @daniel-beck @kzantow 

See [JENKINS-48219](https://issues.jenkins-ci.org/browse/JENKINS-48219).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

