### PR TITLE
JENKINS-48872# Fix deserialization error for missing ModelObject field

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
@@ -3,7 +3,6 @@ package io.jenkins.blueocean.service.embedded;
 import hudson.model.ModelObject;
 import io.jenkins.blueocean.rest.factory.BlueOceanUrlMapper;
 import io.jenkins.blueocean.rest.model.BlueOceanUrlObject;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -12,6 +11,9 @@ import javax.annotation.Nonnull;
 public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
 
     private final String mappedUrl;
+
+    // leave it there to avoid deserialization errors for older version of this object
+    private transient ModelObject modelObject;
 
     public BlueOceanUrlObjectImpl(ModelObject modelObject) {
         this.mappedUrl = computeUrl(modelObject);

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
@@ -1,5 +1,6 @@
 package io.jenkins.blueocean.service.embedded;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.ModelObject;
 import io.jenkins.blueocean.rest.factory.BlueOceanUrlMapper;
 import io.jenkins.blueocean.rest.model.BlueOceanUrlObject;
@@ -13,6 +14,7 @@ public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
     private final String mappedUrl;
 
     // leave it there to avoid deserialization errors for older version of this object
+    @SuppressFBWarnings(value = "UUF_UNUSED_FIELD", justification = "Field is present to avoid deserialization errors for older version of this object")
     private transient ModelObject modelObject;
 
     public BlueOceanUrlObjectImpl(ModelObject modelObject) {


### PR DESCRIPTION
# Description

ModelObject was serialized in prior version (1.4.0-beta4 and older), it was removed as part of fix that went in PR #1609. This caused error reported in OldData. Fix is to simply put back unused ModelObject as transient. 

@michaelneale @jglick Do not like this fix, is there better ways other plugins handle it? On the other hand, we could mark this issue as will not fix as 'Discard Unreadable Data' is just fine. Just that it will surprise anyone upgrading to 1.4.0 and we might want to port #1609 to 1.3.0.

See [JENKINS-48872](https://issues.jenkins-ci.org/browse/JENKINS-48872).


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given