### PR TITLE
Remove obsolete code that caused the PR tab to refresh when pressing "Show More"

### DIFF
--- a/blueocean-dashboard/src/main/js/components/PullRequests.jsx
+++ b/blueocean-dashboard/src/main/js/components/PullRequests.jsx
@@ -52,10 +52,6 @@ export class PullRequests extends Component {
         }
         const pullRequests = this.pager.data;
 
-        if (this.pager.pending) {
-            return null;
-        }
-
         if (!this.pager.pending && !this.pager.data.length) {
             return <NoPullRequestsPlaceholder t={t} />;
         }


### PR DESCRIPTION
# Description
Found some obsolete code that caused the render function to "return null" once every time when getting the next items before re-rendering

See [JENKINS-47460](https://issues.jenkins-ci.org/browse/JENKINS-47460).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

