### PR TITLE
Fix JENKINS-49028 null protect call to getShortDescription()

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeUtil.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeUtil.java
@@ -152,11 +152,15 @@ public class PipelineNodeUtil {
                 if(p.equals(stage)){
                     Queue.Item item = QueueItemAction.getQueueItem(nodeBlock);
                     if (item != null) {
-                        String cause = item.getCauseOfBlockage().getShortDescription();
-                        if (cause == null) {
-                            CauseOfBlockage causeOfBlockage = item.task.getCauseOfBlockage();
-                            if(causeOfBlockage != null) {
-                                return causeOfBlockage.getShortDescription();
+                        CauseOfBlockage causeOfBlockage = item.getCauseOfBlockage();
+                        String cause = null;
+                        if (causeOfBlockage != null) {
+                            cause = causeOfBlockage.getShortDescription();
+                            if (cause == null) {
+                                causeOfBlockage = item.task.getCauseOfBlockage();
+                                if(causeOfBlockage != null) {
+                                    return causeOfBlockage.getShortDescription();
+                                }
                             }
                         }
                         return cause;

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeUtilTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeUtilTest.java
@@ -1,0 +1,70 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.google.common.collect.ImmutableList;
+import hudson.model.Queue;
+import hudson.model.queue.CauseOfBlockage;
+import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(QueueItemAction.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+public class PipelineNodeUtilTest {
+    /**
+     * This test tests all code paths of getCauseOfBlockage.
+     * @throws Exception
+     */
+    @Test
+    public void getCauseOfBlockage() throws Exception {
+        CauseOfBlockage blockage = mock(CauseOfBlockage.class);
+        CauseOfBlockage taskBlockage = mock(CauseOfBlockage.class);
+
+        FlowNode stage = mock(FlowNode.class);
+        FlowNode nodeBlock = mock(FlowNode.class);
+        Queue.Item item = mock(Queue.Item.class);
+        mockStatic(QueueItemAction.class);
+        String cause = null;
+
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, null);
+        assertNull(cause);
+
+        when(nodeBlock.getParents()).thenReturn(ImmutableList.of());
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, null);
+        assertNull(cause);
+
+        when(nodeBlock.getParents()).thenReturn(ImmutableList.of(stage));
+        when(QueueItemAction.getQueueItem(nodeBlock)).thenReturn(null);
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, null);
+        assertNull(cause);
+
+        when(QueueItemAction.getQueueItem(nodeBlock)).thenReturn(item);
+        when(item.getCauseOfBlockage()).thenReturn(null);
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, null);
+        assertNull(cause);
+
+        when(blockage.getShortDescription()).thenReturn("test");
+        when(item.getCauseOfBlockage()).thenReturn(blockage);
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, nodeBlock);
+        assertEquals("test", cause);
+
+        when(blockage.getShortDescription()).thenReturn(null);
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, null);
+        assertNull(cause);
+
+        when(taskBlockage.getShortDescription()).thenReturn("test1");
+        Whitebox.setInternalState(item,"task", mock(Queue.Task.class));
+        when(item.task.getCauseOfBlockage()).thenReturn(taskBlockage);
+        cause = PipelineNodeUtil.getCauseOfBlockage(stage, nodeBlock);
+        assertEquals("test1", cause);
+    }
+}


### PR DESCRIPTION
# Description

See [JENKINS-49028](https://issues.jenkins-ci.org/browse/JENKINS-49028).

As per my comments in the Jira. I've been unable to generate an appropriate unit test for this issue. PipeLineNodeUtils does not seem to have its own independent unit tests. The fix is for an obvious NPE due to a null dereference.  