### PR TITLE
JENKINS-49036 don't allow log lines to expand bigger than their container

### DIFF
--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -319,6 +319,7 @@ a.pipelineRedirectLink svg {
         color: @pre-color;
         padding-left: 22px;
         padding-right: 15px;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
# Description
Log lines would not break if there were no breakable characters (i.e. space char) and instead expand out. This PR just sets a max-width to the log lines so they cannot expand more than their container.

See [JENKINS-49036](https://issues.jenkins-ci.org/browse/JENKINS-49036).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

