### PR TITLE
JENKINS-47952 Back browser button behaviour is broken when closing run details screen

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -64,8 +64,6 @@ class RunDetails extends Component {
 
     componentWillMount() {
         this._fetchRun(this.props);
-        this.opener = locationService.previous;
-        this.initialHistoryLength = history.length;
     }
 
     componentWillReceiveProps(nextProps) {
@@ -137,15 +135,7 @@ class RunDetails extends Component {
 
     afterClose = () => {
         const { router, params } = this.context;
-        if (this.opener) {
-            // step back in the history to the item that's prior to initial load of RunDetails
-            const offsetToInitialRoute = this.initialHistoryLength - history.length;
-            router.go(offsetToInitialRoute - 1);
-        } else {
-            // back to the 'Activity' tab (using 'replace' to discard history item for RunDetails)
-            const fallbackUrl = buildPipelineUrl(params.organization, params.pipeline);
-            router.replace(fallbackUrl);
-        }
+        router.push(buildPipelineUrl(params.organization, params.pipeline));
     };
 
     render() {


### PR DESCRIPTION
Refactor react-router related code of what happens when run details closes so the back/forward browser buttons behave naturally

# Description

See [JENKINS-47952](https://issues.jenkins-ci.org/browse/JENKINS-47952).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

