### PR TITLE
JENKINS-44995# Paginate default favorite iterator

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -1,22 +1,26 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.google.common.collect.Iterators;
 import hudson.model.Item;
 import hudson.plugins.favorite.Favorites;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteContainer;
+import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.WebMethod;
-import org.kohsuke.stapler.verb.DELETE;
-
-import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.verb.DELETE;
 
 /**
  * @author Ivan Meredith
@@ -42,21 +46,45 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
 
     @Override
     public Iterator<BlueFavorite> iterator() {
+        StaplerRequest request = Stapler.getCurrentRequest();
+        int start=0;
+        int limit = PagedResponse.DEFAULT_LIMIT;
+
+        if(request != null) {
+            String startParam = request.getParameter("start");
+            if (StringUtils.isNotBlank(startParam)) {
+                start = Integer.parseInt(startParam);
+            }
+
+            String limitParam = request.getParameter("limit");
+            if (StringUtils.isNotBlank(limitParam)) {
+                limit = Integer.parseInt(limitParam);
+            }
+        }
+
+        return iterator(start, limit);
+    }
+
+    @Override
+    public Iterator<BlueFavorite> iterator(int start, int limit) {
         List<BlueFavorite> favorites = new ArrayList<>();
 
-        for(final Item favorite: Favorites.getFavorites(user.user)){
-            if(favorite instanceof AbstractFolder) {
+        Iterator<Item> favoritesIterator = Favorites.getFavorites(user.user).iterator();
+        Iterators.skip(favoritesIterator, start);
+        int count = 0;
+        while(count < limit && favoritesIterator.hasNext()) {
+            Item item = favoritesIterator.next();
+            if(item instanceof AbstractFolder) {
                 continue;
             }
-            BlueFavorite blueFavorite = FavoriteUtil.getFavorite(favorite);
+            BlueFavorite blueFavorite = FavoriteUtil.getFavorite(item);
             if(blueFavorite != null){
                 favorites.add(blueFavorite);
+                count++;
             }
         }
         return favorites.iterator();
     }
-
-
 
     @Override
     public Link getLink() {

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/FavoritesApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/FavoritesApiTest.java
@@ -3,6 +3,7 @@ package io.jenkins.blueocean.service.embedded;
 import com.google.common.collect.ImmutableMap;
 import hudson.model.Project;
 import hudson.model.User;
+import hudson.plugins.favorite.Favorites;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -26,6 +27,32 @@ public class FavoritesApiTest extends BaseTest {
             .build(Map.class);
 
         return project;
+    }
+
+    @Test
+    public void testFavoritePagination() throws IOException, Favorites.FavoriteException {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        hudson.model.User user = User.get("alice");
+
+        Project job1 = j.createFreeStyleProject("job1");
+        Project job2 = j.createFreeStyleProject("job2");
+
+        Favorites.addFavorite(user, job1);
+        Favorites.addFavorite(user, job2);
+
+        List<Map> favorites = new RequestBuilder(baseUrl)
+                .get("/users/"+user.getId()+"/favorites/")
+                .auth("alice", "alice")
+                .build(List.class);
+
+        assertEquals(2, favorites.size());
+
+        favorites = new RequestBuilder(baseUrl)
+                .get("/users/"+user.getId()+"/favorites/?limit=1")
+                .auth("alice", "alice")
+                .build(List.class);
+
+        assertEquals(1, favorites.size());
     }
 
 


### PR DESCRIPTION
# Description

`FavoriteContainer.iterator()` doesn't return paginated list of favorites. Worse, it iterates thru all favorites and then returns iterator. 

This was causing `FavoriteStagePreloader` to return all possible favorites resulting in to slow page load time for logged in users.

This fix by default returns paginated favorites thru default iterator.

See [JENKINS-44995](https://issues.jenkins-ci.org/browse/JENKINS-44995).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

