### PR TITLE
[JENKINS-XXXXX] Added a dependency with blueocean-common

### DIFF
--- a/jenkins-design-language/pom.xml
+++ b/jenkins-design-language/pom.xml
@@ -15,6 +15,14 @@
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Design+Language</url>
 
+    <dependencies>
+        <dependency>
+           <groupId>io.jenkins.blueocean</groupId>
+           <artifactId>blueocean-commons</artifactId>
+           <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <resources>
             <resource>
@@ -41,18 +49,5 @@
             </resource>
         </resources>
     </build>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

if `jenkins-design-language` does not have any Maven dependency with core plugins of Blue Ocean, this plugin could be installed independently of the rest of Blue Ocean plugins.

This would be an not desired behavior.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

