### PR TITLE
JENKINS-49419 Avoid detached head on checkout

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketPipelineCreateRequest.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketPipelineCreateRequest.java
@@ -21,6 +21,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
@@ -68,6 +69,7 @@ public class BitbucketPipelineCreateRequest extends AbstractMultiBranchCreateReq
                 .withTrait(new OriginPullRequestDiscoveryTrait(strategies))
                 .withTrait(new CleanBeforeCheckoutTrait())
                 .withTrait(new CleanAfterCheckoutTrait())
+                .withTrait(new LocalBranchTrait())
                 .build();
 
         //Setup Jenkins root url, if not set bitbucket cloud notification will fail

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketPipelineCreateRequestTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketPipelineCreateRequestTest.java
@@ -12,6 +12,7 @@ import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
@@ -65,6 +66,7 @@ public class BitbucketPipelineCreateRequestTest extends BbServerWireMock {
 
         Assert.assertNotNull(SCMTrait.find(traits, CleanAfterCheckoutTrait.class));
         Assert.assertNotNull(SCMTrait.find(traits, CleanBeforeCheckoutTrait.class));
+        Assert.assertNotNull(SCMTrait.find(traits, LocalBranchTrait.class));
 
         BranchDiscoveryTrait branchDiscoveryTrait = SCMTrait.find(traits, BranchDiscoveryTrait.class);
         Assert.assertNotNull(branchDiscoveryTrait);

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequest.java
@@ -12,6 +12,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import org.apache.commons.lang.StringUtils;
@@ -38,6 +39,7 @@ public class GitPipelineCreateRequest extends AbstractMultiBranchCreateRequest {
         traits.add(new BranchDiscoveryTrait());
         traits.add(new CleanBeforeCheckoutTrait());
         traits.add(new CleanAfterCheckoutTrait());
+        traits.add(new LocalBranchTrait());
         return gitSource;
     }
 

--- a/blueocean-git-pipeline/src/test/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequestTest.java
+++ b/blueocean-git-pipeline/src/test/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequestTest.java
@@ -10,6 +10,7 @@ import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMTrait;
 import org.junit.Assert;
@@ -59,6 +60,7 @@ public class GitPipelineCreateRequestTest extends PipelineBaseTest {
         Assert.assertNotNull(SCMTrait.find(traits, BranchDiscoveryTrait.class));
         Assert.assertNotNull(SCMTrait.find(traits, CleanAfterCheckoutTrait.class));
         Assert.assertNotNull(SCMTrait.find(traits, CleanBeforeCheckoutTrait.class));
+        Assert.assertNotNull(SCMTrait.find(traits, LocalBranchTrait.class));
     }
 
 }

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequest.java
@@ -16,6 +16,7 @@ import io.jenkins.blueocean.scm.api.AbstractScmSourceEvent;
 import jenkins.branch.MultiBranchProject;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
@@ -64,6 +65,7 @@ public class GithubPipelineCreateRequest extends AbstractMultiBranchCreateReques
                 .withTrait(new OriginPullRequestDiscoveryTrait(strategies))
                 .withTrait(new CleanBeforeCheckoutTrait())
                 .withTrait(new CleanAfterCheckoutTrait())
+                .withTrait(new LocalBranchTrait())
                 .build();
     }
 

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
@@ -29,6 +29,7 @@ import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.traits.CleanAfterCheckoutTrait;
 import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
+import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMTrait;
@@ -75,6 +76,7 @@ public class GithubPipelineCreateRequestTest extends GithubMockBase {
 
         Assert.assertNotNull(SCMTrait.find(traits, CleanAfterCheckoutTrait.class));
         Assert.assertNotNull(SCMTrait.find(traits, CleanBeforeCheckoutTrait.class));
+        Assert.assertNotNull(SCMTrait.find(traits, LocalBranchTrait.class));
 
         BranchDiscoveryTrait branchDiscoveryTrait = SCMTrait.find(traits, BranchDiscoveryTrait.class);
         Assert.assertNotNull(branchDiscoveryTrait);


### PR DESCRIPTION
# Description

Any Pipeline created with blue ocean should checkout to the local branch rather than leaving the checkout in detached head state.

See [JENKINS-49419](https://issues.jenkins-ci.org/browse/JENKINS-49419).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

