### PR TITLE
JENKINS-47022 - Fix for IE dropdown losing focus on selection

### DIFF
--- a/jenkins-design-language/src/js/components/forms/Dropdown.jsx
+++ b/jenkins-design-language/src/js/components/forms/Dropdown.jsx
@@ -265,6 +265,11 @@ export class Dropdown extends React.Component {
         if (this.props.onChange) {
             this.props.onChange(option, index);
         }
+
+        //restore the focus on the button element in IE
+        if (this.buttonRef.setActive) {
+            this.buttonRef.setActive();
+        }
     }
 
     _optionToLabel(option) {


### PR DESCRIPTION
# Description
This uses the proprietary IE setActive method to restore focus to the dropdown button element after applying the selection

See [JENKINS-47022](https://issues.jenkins-ci.org/browse/JENKINS-47022).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

