### PR TITLE
JENKINS-47022 - Fix for dropdown losing focus on selection

### DIFF
--- a/jenkins-design-language/src/js/components/forms/Dropdown.jsx
+++ b/jenkins-design-language/src/js/components/forms/Dropdown.jsx
@@ -266,9 +266,9 @@ export class Dropdown extends React.Component {
             this.props.onChange(option, index);
         }
 
-        //restore the focus on the button element in IE
-        if (this.buttonRef.setActive) {
-            this.buttonRef.setActive();
+        //restore the focus on the button element
+        if (this.buttonRef && this.buttonRef.focus) {
+            this.buttonRef.focus();
         }
     }
 

--- a/jenkins-design-language/src/js/components/forms/Dropdown.jsx
+++ b/jenkins-design-language/src/js/components/forms/Dropdown.jsx
@@ -265,6 +265,11 @@ export class Dropdown extends React.Component {
         if (this.props.onChange) {
             this.props.onChange(option, index);
         }
+
+        //restore the focus on the button element in IE
+        if (this.buttonRef.setActive) {
+            this.buttonRef.setActive();
+        }
     }
 
     _optionToLabel(option) {

--- a/jenkins-design-language/test/js/components/Dropdown-spec.jsx
+++ b/jenkins-design-language/test/js/components/Dropdown-spec.jsx
@@ -56,4 +56,20 @@ describe("Dropdown", () => {
         assert.equal(drop.find('ul.Dropdown-menu li').length, options.length); // dropdown options same length then our array?
         assert.equal(drop.find('#unit').length, 1); // only on footer?
     });
+    it('dropDown should still have focus after option selection', () => {
+        const wrapper = mount(<Dropdown { ...{
+            options,
+        }}
+        />);
+        assert.ok(wrapper);
+        const drop = wrapper.find('Dropdown');
+        // click the dropDown button
+        drop.find('button').simulate('click');
+        // click on the 1st option
+        drop.find("li a").first().simulate('click');
+        //get focused element
+        const focusedElement = document.activeElement;
+        //verify that the focused element is the dropdown button
+        assert.equal(focusedElement, drop.find('button').get(0));
+    });
 });


### PR DESCRIPTION
# Description
This forces the dropdown to regain focus after a selection, still working on adding a unit test for this

See [JENKINS-47022](https://issues.jenkins-ci.org/browse/JENKINS-47022).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

