### PR TITLE
JENKINS-49519 Limit the amount of analytics data being collected

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
@@ -51,6 +51,7 @@ public abstract class AbstractAnalytics extends Analytics {
         AnalyticsConfig config = AnalyticsConfigService.get();
         if (!belongsToActiveCohort(config, server)) {
             LOGGER.log(Level.FINE, "Server is not in active cohort. No analytics event has been sent");
+            return;
         }
         Map<String, Object> allProps = req.properties == null ? Maps.newHashMap() : Maps.newHashMap(req.properties);
         // Enhance with additional properties

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
@@ -50,7 +50,7 @@ public abstract class AbstractAnalytics extends Analytics {
         String server = server();
         AnalyticsConfig config = AnalyticsConfigService.get();
         if (!belongsToActiveCohort(config, server)) {
-            LOGGER.log(Level.INFO, "Server is not in active cohort. No analytics event has been sent");
+            LOGGER.log(Level.FINE, "Server is not in active cohort. No analytics event has been sent");
         }
         Map<String, Object> allProps = req.properties == null ? Maps.newHashMap() : Maps.newHashMap(req.properties);
         // Enhance with additional properties

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
@@ -99,6 +99,9 @@ public abstract class AbstractAnalytics extends Analytics {
     }
 
     private boolean belongsToActiveCohort(AnalyticsConfig config, String user) {
+        if (AnalyticsConfig.EMPTY.equals(config)) {
+            return false;
+        }
         int currentCohort = Hashing.consistentHash(user.hashCode(), config.cohorts);
         List<Integer> activeCohorts = config.allActiveCohorts();
         return activeCohorts.contains(currentCohort);

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfig.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfig.java
@@ -1,0 +1,42 @@
+package io.jenkins.blueocean.service.embedded.analytics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class AnalyticsConfig {
+
+    public static final AnalyticsConfig EMPTY = new AnalyticsConfig(0, new ArrayList<>());
+
+    @JsonProperty("cohorts")
+    final int cohorts;
+    @JsonProperty("activeCohorts")
+    final List<String> activeCohorts;
+
+    AnalyticsConfig(
+        @JsonProperty("cohorts") int cohorts,
+        @JsonProperty("activeCohorts") List<String> activeCohorts
+    ) {
+        this.cohorts = cohorts;
+        this.activeCohorts = activeCohorts;
+    }
+
+    List<Integer> allActiveCohorts() {
+        List<Integer> allActiveCohorts = new ArrayList<>();
+        for (String rawCohort : activeCohorts) {
+            int pos = rawCohort.indexOf("-");
+            if (pos > -1) {
+                int lower = Integer.parseInt(rawCohort.substring(0, pos));
+                int upper = Integer.parseInt(rawCohort.substring(pos+1, rawCohort.length()));
+                for (int i = lower; i < (upper + 1); i++) {
+                    allActiveCohorts.add(i);
+                }
+            } else {
+                allActiveCohorts.add(Integer.parseInt(rawCohort));
+            }
+        }
+
+        return allActiveCohorts;
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfigService.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfigService.java
@@ -1,0 +1,62 @@
+package io.jenkins.blueocean.service.embedded.analytics;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import hudson.ProxyConfiguration;
+import io.jenkins.blueocean.commons.JsonConverter;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class AnalyticsConfigService {
+
+    private static final Logger LOGGER = Logger.getLogger(AnalyticsConfigService.class.getName());
+
+    private static final String ANALYTICS_CONFIG_URL = "https://jenkins.io/projects/blueocean/analytics.json";
+
+    public static AnalyticsConfig get() {
+        return configSupplier.get();
+    }
+
+    private static Supplier<AnalyticsConfig> configSupplier = Suppliers.memoizeWithExpiration(() -> {
+        AnalyticsConfig config;
+        try {
+            config = loadAnalyticsConfig();
+        } catch (Throwable e) {
+            config = AnalyticsConfig.EMPTY;
+            LOGGER.log(Level.SEVERE, "Could not load analytics configuration", e);
+        }
+        return config;
+    }, 1, TimeUnit.DAYS);
+
+    private static AnalyticsConfig loadAnalyticsConfig() throws IOException {
+        URL url = new URL("https://jenkins.io/projects/blueocean/analytics.json");
+        ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+        Proxy proxy = proxyConfig == null ? null : proxyConfig.createProxy(null);
+        HttpURLConnection connection;
+        if (proxy == null) {
+            connection = (HttpURLConnection) url.openConnection();
+        } else {
+            connection = (HttpURLConnection) url.openConnection(proxy);
+        }
+        int resp = connection.getResponseCode();
+        if (resp != 200) {
+            throw new IOException("Received code " + resp + " when reading " + ANALYTICS_CONFIG_URL);
+        }
+        AnalyticsConfig config;
+        try (InputStream is = connection.getInputStream()) {
+            config = JsonConverter.toJava(is, AnalyticsConfig.class);
+        }
+        return config;
+    }
+
+    private AnalyticsConfigService() {
+    }
+}

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfigTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsConfigTest.java
@@ -1,0 +1,26 @@
+package io.jenkins.blueocean.service.embedded.analytics;
+
+import io.jenkins.blueocean.commons.JsonConverter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class AnalyticsConfigTest {
+    @Test
+    public void serializeDeseralize() {
+        AnalyticsConfig config = new AnalyticsConfig(1000, Arrays.asList("10", "20", "30-50"));
+        String json = JsonConverter.toJson(config);
+        AnalyticsConfig deserializedConfig = JsonConverter.toJava(json, AnalyticsConfig.class);
+
+        Assert.assertEquals(config.cohorts, deserializedConfig.cohorts);
+
+        deserializedConfig.allActiveCohorts();
+
+        Assert.assertEquals(3, config.activeCohorts.size());
+
+        Assert.assertEquals("10", config.activeCohorts.get(0));
+        Assert.assertEquals("20", config.activeCohorts.get(1));
+        Assert.assertEquals("30-50", config.activeCohorts.get(2));
+    }
+}


### PR DESCRIPTION
# Description

This config kept on jenkins.io. It expresses that there are 1000 cohorts, of which 10 are active (1% of the Jenkins server install base).

```
{
  "cohorts": 1000,
  "activeCohorts": [
    "0-9"
  ]
}
```

The server will decide based on its server identity if it is enrolled into the range 0-9 or not.

See https://github.com/jenkins-infra/jenkins.io/pull/1387 for the configuration file
See [JENKINS-49519](https://issues.jenkins-ci.org/browse/JENKINS-49519).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

