### PR TITLE
JENKINS-49298 fastsearch steals focus on "t" key

### DIFF
--- a/blueocean-dashboard/src/main/js/components/Pipelines.jsx
+++ b/blueocean-dashboard/src/main/js/components/Pipelines.jsx
@@ -69,7 +69,11 @@ export class Pipelines extends Component {
     }
 
     handleKeyDownEvent = (event) => {
-        if (document.activeElement !== this.getSearchInput()) {
+        if (document.activeElement !== this.getSearchInput() && 
+            document.activeElement.tagName !== 'TEXTAREA' &&
+            document.activeElement.tagName !== 'INPUT' &&
+            !document.querySelectorAll('.ModalContainer').length
+        ) {
             if (event.key === 't') {
                 this.getSearchInput().focus();
                 event.preventDefault();

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -332,3 +332,7 @@ a.pipelineRedirectLink svg {
 .activity .run-button-component {
     margin-bottom: 16px;
 }
+
+.search-pipelines-input .clear-icon-container svg[icon="ContentClear"] {
+    fill: rgba(255, 255, 255, 0.6);
+}


### PR DESCRIPTION
This fixes fastsearch stealing focus from other input tags. It will also only steal focus when no modal window is active. Also fixes fastsearch clear icon color.

# Description

See [JENKINS-49298](https://issues.jenkins-ci.org/browse/JENKINS-49298).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

