### PR TITLE
[FIX-JENKINS-49743] Dropdown defaultOption have to include object as …

### DIFF
--- a/jenkins-design-language/src/js/components/forms/Dropdown.jsx
+++ b/jenkins-design-language/src/js/components/forms/Dropdown.jsx
@@ -376,7 +376,10 @@ Dropdown.propTypes = {
     style: PropTypes.object,
     placeholder: PropTypes.string,
     options: PropTypes.array,
-    defaultOption: PropTypes.node,
+    defaultOption: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.object,
+    ]),
     title: PropTypes.string,
     labelField: PropTypes.string,
     labelFunction: PropTypes.func,


### PR DESCRIPTION
…valid input type

Adding object to proptypes

# Description

See [JENKINS-49743](https://issues.jenkins-ci.org/browse/JENKINS-49743).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

