### PR TITLE
JENKINS-49756# Fix for BB server defult branch API in bb server >= 5.6.0

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -283,7 +283,9 @@ public class BitbucketServerApi extends BitbucketApi {
         try {
             HttpResponse response = request.get(String.format("%s/%s/repos/%s/branches/default",baseUrl+"projects",
                     orgId, repoSlug));
-            if(response.getStatus() == 404){
+            int status = response.getStatus();
+            //With 5.6.0 its 204, before that it was 404
+            if(status == 404 || status == 204){
                 return null; //empty repo gives 404, we ignore these
             }
             InputStream inputStream = response.getContent();
@@ -301,7 +303,8 @@ public class BitbucketServerApi extends BitbucketApi {
                     orgId, repoSlug));
 
             HttpResponse response = request.head(uriBuilder.build().toString());
-            return response.getStatus() == 404;
+            int status = response.getStatus();
+            return status == 404 || status == 204; //with BB server 5.6.0 204 is returned for empty repo
         } catch (URISyntaxException e) {
             throw handleException(e);
         }

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
@@ -163,6 +163,24 @@ public class BitbucketApiTest extends BbServerWireMock {
     }
 
     @Test
+    public void testEmptyRepo204(){
+        BbBranch branch = api.getDefaultBranch("TESTP","empty1");
+        assertNull(branch);
+    }
+
+    @Test
+    public void testDefaultBranchPre5_6_0(){
+        BbBranch branch = api.getDefaultBranch("TESTP","empty-repo-test");
+        assertNull(branch);
+    }
+
+    @Test
+    public void testDefaultBranch5_6_0(){
+        BbBranch branch = api.getDefaultBranch("TESTP","empty1");
+        assertNull(branch);
+    }
+
+    @Test
     public void testCreateNewBranchOnExistingRepo(){
         BbBranch branch = api.getDefaultBranch("TESTP","pipeline-demo-test");
         BbBranch newBranch = api.createBranch("TESTP", "pipeline-demo-test",

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-branches-default-5.6.0.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-branches-default-5.6.0.json
@@ -1,0 +1,24 @@
+{
+  "id" : "3cb8ad8e-bf64-3779-b249-1c1ca33c783a",
+  "request" : {
+    "url" : "/rest/api/1.0/projects/TESTP/repos/empty1/branches/default",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 204,
+    "bodyFileName" : "body-branches-default-C98AD.json",
+    "headers" : {
+      "X-AREQUESTID" : "@190KU8Bx1085x620x0",
+      "X-ASEN" : "SEN-L9817337",
+      "X-AUSERID" : "1",
+      "X-AUSERNAME" : "vivek",
+      "Cache-Control" : "no-cache, no-transform",
+      "Vary" : "X-AUSERNAME,Accept-Encoding",
+      "Transfer-Encoding" : "chunked",
+      "X-Content-Type-Options" : "nosniff",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Wed, 21 Jun 2017 18:05:02 GMT"
+    }
+  },
+  "uuid" : "3cb8ad8e-bf64-3779-b249-1c1ca33c783a"
+}


### PR DESCRIPTION
# Description

See [JENKINS-49756](https://issues.jenkins-ci.org/browse/JENKINS-49756).

For empty repo we are expecting HTTP status 404 but getting 204 when we call default branch API. This change of 204 instead of 404 was introduced in  BB server 5.6.0, https://jira.atlassian.com/browse/BSERV-10313.


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

