### PR TITLE
Spelling repository

### DIFF
--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -63,7 +63,7 @@ public class GithubEditorTest {
     CustomJenkinsServer jenkins;
 
     /**
-     * Cleans up repostory after the test has completed.
+     * Cleans up repository after the test has completed.
      *
      * @throws IOException
      */

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/creation/GitCreationTest.java
@@ -62,7 +62,7 @@ public class GitCreationTest extends BlueOceanAcceptanceTest {
 
     @Ignore
     @Test
-    public void testSSHPrivateRepostory() throws IOException, GitAPIException, URISyntaxException {
+    public void testSSHPrivateRepository() throws IOException, GitAPIException, URISyntaxException {
         String gitUrl = liveProperties.getProperty("git.ssh.repository");
         String privateKeyFile = liveProperties.getProperty("git.ssh.keyfile");
         String pipelineName = liveProperties.getProperty("git.ssh.pipelineName");

--- a/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-1.js
+++ b/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-1.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 export default {
-    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRespositoryContainer',
+    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRepositoryContainer',
     _links: {
         self: {
             _class: 'io.jenkins.blueocean.rest.hal.Link',

--- a/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-2.js
+++ b/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-2.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 export default {
-    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRespositoryContainer',
+    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRepositoryContainer',
     _links: {
         self: {
             _class: 'io.jenkins.blueocean.rest.hal.Link',

--- a/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-3.js
+++ b/blueocean-dashboard/src/main/js/creation/github/api/mocks/repos-3.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 export default {
-    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRespositoryContainer',
+    _class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubRepositoryContainer',
     _links: {
         self: {
             _class: 'io.jenkins.blueocean.rest.hal.Link',

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GHRepoEx.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GHRepoEx.java
@@ -7,7 +7,7 @@ import org.kohsuke.github.GHRepository;
 /**
  * Expose github repository 'private' field
  *
- * GHRepositry defines _private but doesn't get deserialized reliably with Jackson
+ * GHRepository defines _private but doesn't get deserialized reliably with Jackson
  *
  * @author Vivek Pandey
  */

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrganization.java
@@ -38,7 +38,7 @@ public class GithubOrganization extends AbstractGithubOrganization {
 
     @Override
     public ScmRepositoryContainer getRepositories() {
-        return new GithubRespositoryContainer(scm, ghOrganization.getUrl().toString(), getName(), credential,this);
+        return new GithubRepositoryContainer(scm, ghOrganization.getUrl().toString(), getName(), credential,this);
     }
 
     @Override

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubRepositories.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubRepositories.java
@@ -32,10 +32,10 @@ public class GithubRepositories extends ScmRepositories {
     private final Integer lastPage;
     private final int pageSize;
     private final StandardUsernamePasswordCredentials credential;
-    private final GithubRespositoryContainer parent;
+    private final GithubRepositoryContainer parent;
 
 
-    public GithubRepositories(StandardUsernamePasswordCredentials credentials, String orgUrl, GithubRespositoryContainer parent) {
+    public GithubRepositories(StandardUsernamePasswordCredentials credentials, String orgUrl, GithubRepositoryContainer parent) {
         this.self = parent.getLink().rel("repositories");
         this.accessToken = credentials.getPassword().getPlainText();
         this.credential = credentials;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubRepositoryContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubRepositoryContainer.java
@@ -15,7 +15,7 @@ import java.net.HttpURLConnection;
 /**
  * @author Vivek Pandey
  */
-public class GithubRespositoryContainer extends ScmRepositoryContainer {
+public class GithubRepositoryContainer extends ScmRepositoryContainer {
     private final Link self;
     private final StandardUsernamePasswordCredentials credentials;
     private final String rootUrl;
@@ -23,11 +23,11 @@ public class GithubRespositoryContainer extends ScmRepositoryContainer {
     private final String orgUrl;
     private final String repoType;
 
-    public GithubRespositoryContainer(Scm scm, String orgUrl, String orgId, StandardUsernamePasswordCredentials credentials, Reachable parent) {
+    public GithubRepositoryContainer(Scm scm, String orgUrl, String orgId, StandardUsernamePasswordCredentials credentials, Reachable parent) {
         this(scm, orgUrl, orgId, "all", credentials, parent);
     }
 
-    public GithubRespositoryContainer(Scm scm, String orgUrl, String orgId, String repoType, StandardUsernamePasswordCredentials credentials, Reachable parent) {
+    public GithubRepositoryContainer(Scm scm, String orgUrl, String orgId, String repoType, StandardUsernamePasswordCredentials credentials, Reachable parent) {
         this.rootUrl = scm.getUri();
         this.self = parent.getLink().rel("repositories");
         this.credentials = credentials;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubUserOrganization.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubUserOrganization.java
@@ -48,6 +48,6 @@ public class GithubUserOrganization  extends AbstractGithubOrganization{
 
     @Override
     public ScmRepositoryContainer getRepositories() {
-        return new GithubRespositoryContainer(parent, String.format("%s/user", parent.getUri()), getName(), "owner" ,credential,this);
+        return new GithubRepositoryContainer(parent, String.format("%s/user", parent.getUri()), getName(), "owner" ,credential,this);
     }
 }

--- a/blueocean-rest/README.md
+++ b/blueocean-rest/README.md
@@ -2114,7 +2114,7 @@ curl -XGET -u xxx:yyy http://localhost:8080/jenkins/blue/rest/organizations/jenk
 curl -v -u xxx:yyy http://localhost:8080/jenkins/blue/rest/organizations/jenkins/scm/github/organizations/CloudBees-community/repositories/?credentialId=github&pageSize=10&pageNumber=3
 
 {
-  "_class" : "io.jenkins.blueocean.blueocean_github_pipeline.GithubRespositoryContainer",
+  "_class" : "io.jenkins.blueocean.blueocean_github_pipeline.GithubRepositoryContainer",
   "_links" : {
     "self" : {
       "_class" : "io.jenkins.blueocean.rest.hal.Link",


### PR DESCRIPTION
# Description
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`
Split from #1664

Note this includes an API change.
At present, it doesn't include the API shim.
I'm not entirely certain what the consequences of omitting such a shim are, but...

# Submitter checklist
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given