### PR TITLE
[JENKINS-48274] Set default email for git commit

### DIFF
--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
@@ -84,7 +84,7 @@ class GitBareRepoReadSaveRequest extends GitCacheCloneReadSaveRequest {
                     String mailAddress = MailAddressResolver.resolve(user);
 
                     if(mailAddress == null) {
-                        mailAddress = "jenkinsUsername@email-address-not-set";
+                        mailAddress = "jenkins-pipeline-editor-user-" + user.getId() + "@email-address-not-set";
                     }
 
                     StandardCredentials credential = getCredential();

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
@@ -82,6 +82,11 @@ class GitBareRepoReadSaveRequest extends GitCacheCloneReadSaveRequest {
                         throw new ServiceException.UnauthorizedException("Not authenticated");
                     }
                     String mailAddress = MailAddressResolver.resolve(user);
+
+                    if(mailAddress == null) {
+                        mailAddress = "jenkinsUsername@email-address-not-set";
+                    }
+
                     StandardCredentials credential = getCredential();
 
                     // Make sure up-to-date and credentials work

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitBareRepoReadSaveRequest.java
@@ -84,7 +84,7 @@ class GitBareRepoReadSaveRequest extends GitCacheCloneReadSaveRequest {
                     String mailAddress = MailAddressResolver.resolve(user);
 
                     if(mailAddress == null) {
-                        mailAddress = "jenkins-pipeline-editor-user-" + user.getId() + "@email-address-not-set";
+                        mailAddress = user.getId() + "@email-address-not-set";
                     }
 
                     StandardCredentials credential = getCredential();

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -607,7 +607,9 @@ public abstract class PipelineBaseTest{
         hudson.model.User bob = User.get(userId);
 
         bob.setFullName(fullName);
-        bob.addProperty(new Mailer.UserProperty(email));
+        if(email != null ) {
+            bob.addProperty(new Mailer.UserProperty(email));
+        }
 
 
         UserDetails d = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(bob.getId());


### PR DESCRIPTION
This commit sets the defailt email for git commits from the pipeline editor
to jenkinsUsername@email-address-not-set.

# Description

See [JENKINS-48274](https://issues.jenkins-ci.org/browse/JENKINS-48274).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

