### PR TITLE
Move jacoco HTML archiving so it runs all the time in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,11 +38,11 @@ node() {
           try {
             sh "mvn clean install -B -DcleanNode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.test.failure.ignore -s settings.xml -Dmaven.artifact.threads=30"
           } catch(e) {
-            archive '*/target/code-coverage/**/*.html'
             throw e;
           }
           junit '**/target/surefire-reports/TEST-*.xml'
           junit '**/target/jest-reports/*.xml'
+          archive '*/target/code-coverage/**/*.html'
           archive '*/target/*.hpi'
         }
 

--- a/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
@@ -118,16 +118,17 @@ public class WaitUtil {
      * @param by
      */
     public void click(By by) {
-        for (int i = 0; i < RETRY_COUNT + 1; i++) {
+        for (int i = 1; i < RETRY_COUNT + 1; i++) {
             try {
                 until(ExpectedConditions.elementToBeClickable(by)).click();
-                if (i > 0) {
+                if (i > 1) {
                     logger.info(String.format("Retry click successful on attempt " + i + " for %s", by.toString()));
                 }
                 return;
             } catch (WebDriverException ex) {
                 if (ex.getMessage().contains("is not clickable at point")) {
-                    logger.warn(String.format("%s not clickable: will retry click", by.toString()));
+                    logger.warn(String.format("%s not clickable on attempt " + i + ", will sleep 500ms and retry ", by.toString()));
+                    tinySleep();
                     logger.debug("exception: " + ex.getMessage());
                 } else {
                     throw ex;
@@ -188,4 +189,18 @@ public class WaitUtil {
         }
         return null;
     }
+
+    /**
+     * Sleep method to work around the occasional glitch with
+     * perfectly clickable buttons not behaving correctly
+     * in these tests.
+     */
+    public void tinySleep() {
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException ex) {
+            logger.info("Exception thrown by tinySleep");
+        }
+    }
+
 }


### PR DESCRIPTION
# Description

See [JENKINS-50436](https://issues.jenkins-ci.org/browse/JENKINS-50436). It might be useful to have Jacoco HTML reports available after each build in CI, not just the failed builds. Since master is usually green, it's not common to see 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: Not applicable. This is only a small Jenkinsfile change to see what it'd be like to surface the code coverage HTML reports all the time.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below: Not applicable.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
