### PR TITLE
JENKINS-48357# Fix jira-plugin binary compatibility issue

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -95,12 +95,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-pipeline-editor</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>blueocean-jira</artifactId>
-        </dependency>
-
+        
         <!-- Bundled plugins for improved out of the box experience -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <module>blueocean-git-pipeline</module>
     <module>blueocean-bitbucket-pipeline</module>
     <module>blueocean-pipeline-editor</module>
-    <module>blueocean-jira</module>
   </modules>
 
   <repositories>
@@ -299,12 +298,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>blueocean-autofavorite</artifactId>
             <version>1.2.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>blueocean-jira</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- TODO: should be moved out of blueocean repo as separate plugin -->
@@ -495,41 +488,6 @@
                 <exclusion>
                     <groupId>org.jenkins-ci</groupId>
                     <artifactId>annotation-indexer</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jira</artifactId>
-            <version>2.4.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-
-                <!-- Upper bound dependency fix
-                    TODO: Remove it after https://github.com/jenkinsci/jira-plugin/pull/130 is merged and released.
-                -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpmime</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.objenesis</groupId>
-                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Till we have fixed jira-plugin, possibly without dependency on atlassian
libraries, lets disable and stop distributing blueocean-jira plugin.

Side effect of this removal will be that JIRA issues from commit message
wont have link to JIRA. Given the trouble its causing in deployments to
user, its worth disabling at this point.

# Description

See [JENKINS-48357](https://issues.jenkins-ci.org/browse/JENKINS-48357).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
