### PR TITLE
JENKINS-49455 & JENKINS-45486 don't step out of karaoke mode when scrolling up if run is paused

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsPipeline.jsx
@@ -47,7 +47,7 @@ export class RunDetailsPipeline extends Component {
     }
     // we bail out on arrow_up key
     _handleKeys(event) {
-        if (event.keyCode === 38 && this.augmenter.karaoke) {
+        if (event.keyCode === 38 && this.augmenter.karaoke && this.props.result.state !== 'PAUSED') {
             logger.debug('stop follow along by key up');
             this.augmenter.setKaraoke(false);
         }
@@ -55,7 +55,7 @@ export class RunDetailsPipeline extends Component {
     // need to register handler to step out of karaoke mode
     // we bail out on scroll up
     _onScrollHandler(elem) {
-        if (elem.deltaY < 0 && this.augmenter.karaoke) {
+        if (elem.deltaY < 0 && this.augmenter.karaoke && this.props.result.state !== 'PAUSED') {
             logger.debug('stop follow along by scroll up');
             this.augmenter.setKaraoke(false);
         }


### PR DESCRIPTION
This change stops stepping out of karaoke mode if scrolling up or 'key up' is pressed when run is paused

I don't think this can or should be tested

See [JENKINS-49455](https://issues.jenkins-ci.org/browse/JENKINS-49455) [JENKINS-45486](https://issues.jenkins-ci.org/browse/JENKINS-45486).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

