### PR TITLE
JENKINS-50572# Fix for Bitbucket save content fails with LinkageError

### DIFF
--- a/blueocean-bitbucket-pipeline/pom.xml
+++ b/blueocean-bitbucket-pipeline/pom.xml
@@ -46,13 +46,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpmime</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
 
     <dependency>
@@ -81,12 +76,6 @@
       <artifactId>blueocean-rest-impl</artifactId>
       <version>1.6.0-beta-1-SNAPSHOT</version>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>fluent-hc</artifactId>
-      <version>4.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -43,8 +43,8 @@
         <artifactId>pubsub-light</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/blueocean-jira/pom.xml
+++ b/blueocean-jira/pom.xml
@@ -39,12 +39,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -50,8 +50,8 @@
 
         <!-- Test plugins -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
     <jenkins-test-harness.version>2.30</jenkins-test-harness.version>
     <scm-api.version>2.2.2</scm-api.version>
-    <git.version>3.6.0</git.version>
+    <git.version>3.8.0</git.version>
   </properties>
 
   <scm>
@@ -338,7 +338,13 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>git-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -475,6 +481,12 @@
             <version>3.5.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.3-2.1</version>
+        </dependency>
+
         <!-- Other -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -511,6 +523,10 @@
                 <!-- Upper bound dependency fix
                     TODO: Remove it after https://github.com/jenkinsci/jira-plugin/pull/130 is merged and released.
                 -->
+                <exclusion>
+                    <groupId>com.atlassian.httpclient</groupId>
+                    <artifactId>atlassian-httpclient-plugin</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-beans</artifactId>
@@ -845,24 +861,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-            <version>4.5.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.damnhandy</groupId>
             <artifactId>handy-uri-templates</artifactId>
             <version>2.1.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-            <version>4.5.3</version>
         </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Description

Fix for LinkageError.
```
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method "org.apache.http.entity.mime.MultipartEntityBuilder.build()Lorg/apache/http/HttpEntity;" the class loader (instance of hudson/ClassicPluginStrategy$AntClassLoader2) of the current class, io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi, and the class loader (instance of hudson/ClassicPluginStrategy$AntClassLoader2) for the method's defining class, org/apache/http/entity/mime/MultipartEntityBuilder, have different Class objects for the type org/apache/http/HttpEntity used in the signature
```
This was happening because different versions of httpmime.jar was loaded by git-client, jira-plugin and blueocean. Fix is to make sure apache http libs are the version loaded by `apache-httpcomponents-client-4-api`. 
 

See [JENKINS-50572](https://issues.jenkins-ci.org/browse/JENKINS-50572).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

