### PR TITLE
[JENKINS-50885] Make jira plugin optional

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-jira</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Bundled plugins for improved out of the box experience -->


### PR DESCRIPTION
# Description

JIRA plugin is still a pain, and in theory could be made optional, but still available. 
I believe this will still install it but it can then later be removed or excluded as needed. 

JIRA: https://issues.jenkins-ci.org/browse/JENKINS-50885