### PR TITLE
JENKINS-50829: ATH for stopping running jobs, plus simplified EditorPage code

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/model/AbstractPipeline.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/model/AbstractPipeline.java
@@ -6,10 +6,12 @@ import com.google.common.net.UrlEscapers;
 import com.google.inject.Inject;
 import io.blueocean.ath.BaseUrl;
 import io.blueocean.ath.factory.ActivityPageFactory;
+import io.blueocean.ath.factory.BranchPageFactory;
 import io.blueocean.ath.factory.RunDetailsArtifactsPageFactory;
 import io.blueocean.ath.factory.RunDetailsPipelinePageFactory;
 import io.blueocean.ath.factory.RunDetailsTestsPageFactory;
 import io.blueocean.ath.pages.blue.ActivityPage;
+import io.blueocean.ath.pages.blue.BranchPage;
 import io.blueocean.ath.pages.blue.RunDetailsArtifactsPage;
 import io.blueocean.ath.pages.blue.RunDetailsPipelinePage;
 import io.blueocean.ath.pages.blue.RunDetailsTestsPage;
@@ -27,6 +29,9 @@ public abstract class AbstractPipeline {
 
     @Inject
     ActivityPageFactory activityPageFactory;
+
+    @Inject
+    BranchPageFactory branchPageFactory;
 
     @Inject
     RunDetailsPipelinePageFactory runDetailsPipelinePageFactory;
@@ -92,6 +97,10 @@ public abstract class AbstractPipeline {
 
     public ActivityPage getActivityPage() {
         return activityPageFactory.withPipeline(this);
+    }
+
+    public BranchPage getBranchPage() {
+        return branchPageFactory.withPipeline(this);
     }
 
     public RunDetailsPipelinePage getRunDetailsPipelinePage() {

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/BranchPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/BranchPage.java
@@ -56,11 +56,38 @@ public class BranchPage implements WebDriverMixin {
         return this;
     }
 
+    public ActivityPage clickActivityTab() {
+        wait.click(By.cssSelector("a.activity"));
+        logger.info("Clicked Activity tab");
+        return activityPageFactory.withPipeline(pipeline).checkUrl();
+    }
+
     public ActivityPage clickHistoryButton(String branch) {
         wait.until(By.cssSelector("div[data-branch='" + branch + "'] a.history-button")).click();
         logger.info("Clicked history button of branch " + branch);
         return activityPageFactory.withPipeline(pipeline).checkUrl(branch);
     }
+
+    public BranchPage clickRunButton(String branch) {
+        wait.click(By.cssSelector("div[data-branch='" + branch + "'] a.run-button"));
+        logger.info("Clicked run button of branch " + branch);
+        // return activityPageFactory.withPipeline(pipeline).checkUrl(branch);
+        return this;
+    }
+
+    public BranchPage open() {
+        driver.get(pipeline.getUrl() + "/branches");
+        checkUrl();
+        logger.info("Opened branch page for " + pipeline);
+        return this;
+    }
+
+    public BranchPage clickStopButton(String branch) {
+        wait.click(By.cssSelector("div[data-branch='" + branch + "'] a.stop-button"));
+        logger.info("Clicked stop button of branch " + branch);
+        return this;
+    }
+
 
     public EditorPage openEditor(String branch) {
         wait.until(By.cssSelector("div[data-branch='" + branch + "'] a.pipeline-editor-link")).click();

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/BranchPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/BranchPage.java
@@ -71,14 +71,6 @@ public class BranchPage implements WebDriverMixin {
     public BranchPage clickRunButton(String branch) {
         wait.click(By.cssSelector("div[data-branch='" + branch + "'] a.run-button"));
         logger.info("Clicked run button of branch " + branch);
-        // return activityPageFactory.withPipeline(pipeline).checkUrl(branch);
-        return this;
-    }
-
-    public BranchPage open() {
-        driver.get(pipeline.getUrl() + "/branches");
-        checkUrl();
-        logger.info("Opened branch page for " + pipeline);
         return this;
     }
 
@@ -88,6 +80,12 @@ public class BranchPage implements WebDriverMixin {
         return this;
     }
 
+    public BranchPage open() {
+        driver.get(pipeline.getUrl() + "/branches");
+        checkUrl();
+        logger.info("Opened branch page for " + pipeline);
+        return this;
+    }
 
     public EditorPage openEditor(String branch) {
         wait.until(By.cssSelector("div[data-branch='" + branch + "'] a.pipeline-editor-link")).click();

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -37,12 +37,11 @@ public class EditorPage {
      * with two steps in it.
      *
      * @param pipelineToEdit the AbstractPipeline object we're working with
-     * @param newBranch the name of the new branch we'll save to
      * @param newStageName the name of the new stage we'll create
      */
-    public void addStageToPipeline(MultiBranchPipeline pipelineToEdit, String newBranch, String newStageName) {
+    public void addStageToPipeline(MultiBranchPipeline pipelineToEdit, String newStageName) {
         pipeline = pipelineToEdit;
-        logger.info("Editing pipeline " + pipeline.getName() + ", saving to branch " + newBranch + ", with new stage " + newStageName);
+        logger.info("Editing pipeline " + pipeline.getName() + "to add a new stage " + newStageName);
         wait.click(By.id("pipeline-node-hittarget-3-add"));
         wait.sendKeys(By.cssSelector("input.stage-name-edit"),newStageName);
         logger.info("Adding a shell step");
@@ -56,18 +55,7 @@ public class EditorPage {
         wait.click(By.cssSelector(".editor-step-selector div[data-functionName=\"echo\"]"));
         wait.sendKeys(By.cssSelector("input.TextInput-control"),"Echo step added by ATH");
         wait.click(By.cssSelector("div.sheet.active a.back-from-sheet"));
-        logger.info("Stages added, about to save");
-        wait.click(By.xpath("//*[text()='Save']"));
-        wait.sendKeys(By.cssSelector("textarea[placeholder=\"What changed?\"]"),"We added a stage");
-        if(!Strings.isNullOrEmpty(newBranch)) {
-            wait.click(By.xpath("//*[text()='Commit to new branch']"));
-            wait.sendKeys(By.cssSelector("input[placeholder='my-new-branch']:enabled"),newBranch);
-            logger.info("Using branch " + newBranch);
-        } else {
-            logger.info("Using branch master");
-        }
-        wait.click(By.xpath("//*[text()=\"Save & run\"]"));
-        logger.info("Pipeline saved with edited stages in place");
+        logger.info("Stages added, ready to save");
     }
 
     /**

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -156,7 +156,8 @@ public class GithubEditorTest {
         sseClient.clear();
         BranchPage branchPage = activityPage.clickBranchTab();
         branchPage.openEditor("master");
-        editorPage.addStageToPipeline(pipeline, newBranchName, newStageName);
+        editorPage.addStageToPipeline(pipeline, newStageName);
+        editorPage.saveBranch(newBranchName);
         activityPage.checkUrl();
         activityPage.getRunRowForBranch(newBranchName);
         sseClient.untilEvents(pipeline.buildsFinished);

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/CommitMessagesTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/CommitMessagesTest.java
@@ -53,7 +53,7 @@ public class CommitMessagesTest extends BlueOceanAcceptanceTest {
         Files.copy(new File(jenkinsFile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
         git.addAll();
         git.commit("initial commit");
-        logger.info("Commited Jenkinsfile");
+        logger.info("Committed Jenkinsfile");
 
         MultiBranchPipeline pipeline = mbpFactory.pipeline(pipelineName).createPipeline(git);
         sseClientRule.untilEvents(pipeline.buildsFinished);
@@ -63,7 +63,7 @@ public class CommitMessagesTest extends BlueOceanAcceptanceTest {
         git.addAll();
         git.commit("2nd commit");
 
-        logger.info("Commited a second time");
+        logger.info("Committed a second time");
 
         pipeline.buildBranch(branchName);
         sseClientRule.untilEvents(pipeline.buildsFinished);

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
@@ -1,0 +1,99 @@
+package io.blueocean.ath.offline.multibranch;
+
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import io.blueocean.ath.ATHJUnitRunner;
+import io.blueocean.ath.BlueOceanAcceptanceTest;
+import io.blueocean.ath.GitRepositoryRule;
+import io.blueocean.ath.factory.MultiBranchPipelineFactory;
+import io.blueocean.ath.model.MultiBranchPipeline;
+import io.blueocean.ath.pages.blue.ActivityPage;
+import io.blueocean.ath.pages.blue.BranchPage;
+import io.blueocean.ath.sse.SSEClientRule;
+import org.apache.log4j.Logger;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.junit.JGitTestUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebElement;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(ATHJUnitRunner.class)
+
+public class StartStopTest extends BlueOceanAcceptanceTest {
+    private Logger logger = Logger.getLogger(CommitMessagesTest.class);
+
+    @Rule
+    @Inject
+    public GitRepositoryRule git;
+
+    @Rule
+    @Inject
+    public SSEClientRule sseClientRule;
+
+    @Inject
+    MultiBranchPipelineFactory mbpFactory;
+
+    /**
+     * This tests the commit messages are being picked up from git and displayed on the run in activity.
+     */
+    @Test
+    public void startStopTest() throws IOException, GitAPIException {
+        final String pipelineName = "StartStopTest_startStopTest";
+        final String firstBranch = "master";
+        final String secondBranch = "second-branch";
+
+        URL navTestJenkinsfile = Resources.getResource(ParallelNavigationTest.class, "StartStopTest/Jenkinsfile");
+        Files.copy(new File(navTestJenkinsfile.getFile()), new File(git.gitDirectory, "Jenkinsfile"));
+        git.addAll();
+        git.commit("Initial commit of Jenkinsfile");
+        logger.info("Committed Jenkinsfile");
+
+        MultiBranchPipeline stopStartPipeline = mbpFactory.pipeline(pipelineName).createPipeline(git);
+        sseClientRule.untilEvents(stopStartPipeline.buildsFinished);
+        sseClientRule.clear();
+
+        git.createBranch(secondBranch);
+        JGitTestUtil.writeTrashFile(git.client.getRepository(), "some-new-filename", "Hello from startStopTest");
+        git.addAll();
+        git.commit("2nd commit going in now");
+        logger.info("Committed a second time");
+
+        // Fire a rescan to get the new branch to show up
+        stopStartPipeline.rescanThisPipeline();
+        sseClientRule.untilEvents(stopStartPipeline.buildsFinished);
+
+        // This is where the browser actually goes to the UI
+        // ActivityPage activityPage = stopStartPipeline.getActivityPage().open();
+        BranchPage branchPage = stopStartPipeline.getBranchPage().open();
+        logger.info("Should have two branches now");
+
+        logger.info("OPEN BRANCH PAGE DOES THIS WORK");
+        // BranchPage branchPage = stopStartPipeline.getBranchPage().open();
+        branchPage.clickRunButton(firstBranch);
+        branchPage.clickRunButton(secondBranch);
+        // next we want to stop them.
+        branchPage.clickStopButton(firstBranch);
+        branchPage.clickStopButton(secondBranch);
+        // sseClientRule.untilEvents(stopStartPipeline.buildsFinished);
+        // This or activityPage.open.whatever?
+        // branchPage.clickActivityTab();
+        ActivityPage activityPage = stopStartPipeline.getActivityPage().open();
+        // Now we need to verify that the builds were stopped. So need to add
+        // methods to activityPage to do that. Maybe with an assert. Example
+        // From elsewhere:
+        // activityPage.assertIsDuration(cells.get(5).getText());
+        // so maybe this?
+        // activityPage.assertIsStoppedRun(firstBranch);
+        logger.info("We did it.");
+    }
+}

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
@@ -2,6 +2,7 @@ package io.blueocean.ath.offline.multibranch;
 
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
+
 import io.blueocean.ath.ATHJUnitRunner;
 import io.blueocean.ath.BlueOceanAcceptanceTest;
 import io.blueocean.ath.GitRepositoryRule;
@@ -10,6 +11,7 @@ import io.blueocean.ath.model.MultiBranchPipeline;
 import io.blueocean.ath.pages.blue.ActivityPage;
 import io.blueocean.ath.pages.blue.BranchPage;
 import io.blueocean.ath.sse.SSEClientRule;
+import io.blueocean.ath.WaitUtil;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.junit.JGitTestUtil;
@@ -44,7 +46,7 @@ public class StartStopTest extends BlueOceanAcceptanceTest {
     MultiBranchPipelineFactory mbpFactory;
 
     /**
-     * This tests the commit messages are being picked up from git and displayed on the run in activity.
+     * This tests the ability to start and stop builds of a pipeline.
      */
     @Test
     public void startStopTest() throws IOException, GitAPIException {
@@ -72,28 +74,14 @@ public class StartStopTest extends BlueOceanAcceptanceTest {
         stopStartPipeline.rescanThisPipeline();
         sseClientRule.untilEvents(stopStartPipeline.buildsFinished);
 
-        // This is where the browser actually goes to the UI
-        // ActivityPage activityPage = stopStartPipeline.getActivityPage().open();
         BranchPage branchPage = stopStartPipeline.getBranchPage().open();
         logger.info("Should have two branches now");
-
-        logger.info("OPEN BRANCH PAGE DOES THIS WORK");
-        // BranchPage branchPage = stopStartPipeline.getBranchPage().open();
         branchPage.clickRunButton(firstBranch);
         branchPage.clickRunButton(secondBranch);
-        // next we want to stop them.
         branchPage.clickStopButton(firstBranch);
         branchPage.clickStopButton(secondBranch);
-        // sseClientRule.untilEvents(stopStartPipeline.buildsFinished);
-        // This or activityPage.open.whatever?
-        // branchPage.clickActivityTab();
         ActivityPage activityPage = stopStartPipeline.getActivityPage().open();
-        // Now we need to verify that the builds were stopped. So need to add
-        // methods to activityPage to do that. Maybe with an assert. Example
-        // From elsewhere:
-        // activityPage.assertIsDuration(cells.get(5).getText());
-        // so maybe this?
-        // activityPage.assertIsStoppedRun(firstBranch);
-        logger.info("We did it.");
+        activityPage.checkPipeline();
+        logger.info("Branches started and stopped successfully.");
     }
 }

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/multibranch/StartStopTest.java
@@ -3,34 +3,26 @@ package io.blueocean.ath.offline.multibranch;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 
-import io.blueocean.ath.ATHJUnitRunner;
-import io.blueocean.ath.BlueOceanAcceptanceTest;
-import io.blueocean.ath.GitRepositoryRule;
+import io.blueocean.ath.*;
 import io.blueocean.ath.factory.MultiBranchPipelineFactory;
 import io.blueocean.ath.model.MultiBranchPipeline;
 import io.blueocean.ath.pages.blue.ActivityPage;
 import io.blueocean.ath.pages.blue.BranchPage;
 import io.blueocean.ath.sse.SSEClientRule;
-import io.blueocean.ath.WaitUtil;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.junit.JGitTestUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.WebElement;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
+@Login
 @RunWith(ATHJUnitRunner.class)
-
 public class StartStopTest extends BlueOceanAcceptanceTest {
     private Logger logger = Logger.getLogger(CommitMessagesTest.class);
 

--- a/acceptance-tests/src/test/resources/io/blueocean/ath/offline/multibranch/StartStopTest/Jenkinsfile
+++ b/acceptance-tests/src/test/resources/io/blueocean/ath/offline/multibranch/StartStopTest/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+  agent any
+  stages {
+    stage('first-stage') {
+      steps {
+        echo 'One!'
+        echo 'Two!'
+        echo 'Three!'
+      }
+    }
+    stage('second-stage') {
+      steps {
+        echo 'This is a stage too.'
+        sh 'netstat -a'
+      }
+    }
+    stage('take a big nap') {
+      steps {
+        echo 'We need this to take a while so the Stop button is clickable'
+        sleep 5
+      }
+    }
+  }
+}

--- a/acceptance-tests/src/test/resources/io/blueocean/ath/offline/multibranch/StartStopTest/Jenkinsfile
+++ b/acceptance-tests/src/test/resources/io/blueocean/ath/offline/multibranch/StartStopTest/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     stage('take a big nap') {
       steps {
         echo 'We need this to take a while so the Stop button is clickable'
-        sleep 5
+        sleep 3
       }
     }
   }


### PR DESCRIPTION
# Description

See [JENKINS-50829](https://issues.jenkins-ci.org/browse/JENKINS-50829). This PR adds a test which starts, and then stops, two branches in a multibranch pipeline. A Jenkinsfile for use with this test is included.

Also included: 

- A simplification to `EditorPage.AddStageToPipeline`. This simplification removes the redundant branch saving logic which was in it previously. The calling `GithubEditorTest#testEditorAddStages()` now uses `EditorPage.saveBranch` to maintain the flow of the test.

- Minor spelling correction in `CommitMessagesTest`

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

To test: 
- Start up the acceptance tests in your preferred way. 
- Run `mvn test -Dtest=StartStopTest`