### PR TITLE
Add correct permissions for jenkins to access docker.sock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.jpi; do mv "$f" "$f.over
 # let scripts customize the reference Jenkins folder. Used in bin/build-in-docker to inject the git build data
 COPY docker/ref /usr/share/jenkins/ref
 
-USER jenkins
+USER jenkins:docker
+
+ADD --chown=:docker /run/docker.sock


### PR DESCRIPTION
This is required for containers to run within jenkins

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

