### PR TITLE
[FIXED JENKINS-49991] Link to home should not full refresh

### DIFF
--- a/blueocean-core-js/src/js/components/BlueLogo.jsx
+++ b/blueocean-core-js/src/js/components/BlueLogo.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
 
 const JenkinsLogo = () => (
     <svg
@@ -76,12 +77,8 @@ const JenkinsLogo = () => (
     </svg>
 );
 
-export const BlueLogo = props => (
-    <a href={props.href || '#'} className="BlueOceanLogo">
+export const BlueLogo = () => (
+    <Link to={'/'} className="BlueOceanLogo">
         <JenkinsLogo />
-    </a>
+    </Link>
 );
-
-BlueLogo.propTypes = {
-    href: PropTypes.string,
-};

--- a/blueocean-core-js/src/js/components/ContentPageHeader.jsx
+++ b/blueocean-core-js/src/js/components/ContentPageHeader.jsx
@@ -23,7 +23,7 @@ export const SiteHeader = props => {
         <BasicHeader className="ContentPageHeader">
             <TopNav>
                 <Extensions.Renderer extensionPoint="jenkins.header.logo">
-                    <BlueLogo href={`${props.homeURL}/`} />
+                    <BlueLogo />
                 </Extensions.Renderer>
                 <div className="u-flex-grow" />
                 {topNavLinks}


### PR DESCRIPTION
# Description

See [JENKINS-49991](https://issues.jenkins-ci.org/browse/JENKINS-49991).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
 - UX fix, no logic changes or new features
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.
 1. Go to a page in Blue Ocean other than the home page (e.g. Create New Pipeline)
 1. Click the "Jenkins" link in the top left to return to the home page
 1. Verify that the app has returned to the Blue Ocean home page
 1. Verify that no full page refresh was performed

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

