### PR TITLE
JENKINS-51346: Replace id with data tag for HTML5 compliance

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -66,8 +66,7 @@ public class EditorPage {
      */
     public void deleteStage(String stageName) {
         logger.info("Deleting stage " + stageName);
-        // Click the name of the stage
-        wait.click(By.id("pipeline-big-label-" + stageName));
+        wait.click(By.xpath("//*[@data-stagename=\"" + stageName + "\"]"));
         // Click the little popup button
         wait.click(By.cssSelector("div.more-menu"));
         // Click Delete

--- a/blueocean-pipeline-editor/src/main/js/components/editor/EditorPipelineGraph.jsx
+++ b/blueocean-pipeline-editor/src/main/js/components/editor/EditorPipelineGraph.jsx
@@ -402,8 +402,7 @@ export class EditorPipelineGraph extends Component<DefaultProps, Props, State> {
             }
         }
         return (
-            // The id is in here to facilitate easier test automation.
-            <div className={classNames.join(' ')} id={`pipeline-big-label-${details.text ? `${details.text}` : ""}`} style={style} key={key} onClick={e => this.nodeClicked({ isPlaceholder: false, stage }, e)}>
+            <div className={classNames.join(' ')} data-stagename={`${details.text ? `${details.text}` : ""}`} style={style} key={key} onClick={e => this.nodeClicked({ isPlaceholder: false, stage }, e)}>
                 {details.text || NBSP}
                 {inner}
             </div>


### PR DESCRIPTION
# Description

See [JENKINS-51346](https://issues.jenkins-ci.org/browse/JENKINS-51346). 

In [PR 1733](https://github.com/jenkinsci/blueocean-plugin/pull/1733), I added an `id` to allow for easier targeting of stages by ATH tests. What I didn't think about was the fact that spaces aren't supposed to be in `id`s. And we want to be able to target stage names that include spaces from the tests, without any additional string manipulation tricks to remove the spaces on the JS side.

So, this PR gets rid of the id, and instead puts in a `data` tag. Of course, I changed the test to go along with.

There's one odd thing. I can't get the data tag to play nicely using camelcase. `data-stagename` works fine, but `data-stageName` never shows with the capital `N`. So I gave up on it and stuck with `data-stagename`.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: tests not applicable, since this is a test.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

