### PR TITLE
JENKINS-51161 reduce the CPU ussage of the SVG spinners

### DIFF
--- a/jenkins-design-language/less/components/result-status.less
+++ b/jenkins-design-language/less/components/result-status.less
@@ -12,6 +12,10 @@
     opacity: 0;
 }
 
+.svgResultStatus {
+    transform: translateZ(0);
+ }
+
 .svgResultStatus circle.success {
     stroke: none;
     fill: @brand-success-lite;
@@ -81,6 +85,16 @@
         fill: @brand-info-lite;
         stroke: @brand-info-lite;
     }
+}
+
+.progress-spinner.running.spin {
+    animation: progress-spinner-rotate 4s linear;
+    animation-iteration-count: infinite;
+}
+
+@keyframes progress-spinner-rotate {
+    0% { transform: rotate(0deg) }
+    100% { transform: rotate(360deg) }
 }
 
 .progress-spinner circle.inner,
@@ -194,7 +208,13 @@
 .result-item-icon {
     display:flex;
     align-items:flex-start;
-    margin: -1px 0 -1px -1px
+    margin: -1px 0 -1px -1px;
+    transform: translateZ(0);
+
+    .spinAnimation {
+        animation: progress-spinner-rotate 4s linear;
+        animation-iteration-count: infinite;
+    }
 }
 
 .result-item-title {
@@ -294,8 +314,7 @@
 }
 
 .pipeline-selection-highlight circle {
-    fill: none; //@brand-selection;
-    //stroke: @brand-selection;
+    fill: none;
     stroke: @brand-primary;
 }
 

--- a/jenkins-design-language/src/js/components/ResultItem.jsx
+++ b/jenkins-design-language/src/js/components/ResultItem.jsx
@@ -41,24 +41,18 @@ export class ResultItem extends Component {
         this.handleProps(this.props, this.props);
 
         this.infiniteRotationRunning = false;
-        this.setState({
-            infiniteRotateDegrees: 0,
-        });
+        this.infiniteRotateDegrees = 0;
+        this.isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
     }
 
     infiniteLoadingTimer = () => {
-        let infiniteRotateDegrees = this.state.infiniteRotateDegrees;
+        this.infiniteRotateDegrees += 1.5;
 
-        infiniteRotateDegrees += 1.5;
-
-        if (infiniteRotateDegrees >= 360) {
-            infiniteRotateDegrees = 0;
+        if (this.infiniteRotateDegrees >= 360) {
+            this.infiniteRotateDegrees = 0;
         }
 
-        this.setState({
-            infiniteRotateDegrees: infiniteRotateDegrees,
-        });
-
+        this.animatedElement.setAttribute('transform', `rotate(${this.infiniteRotateDegrees})`);
         this.requestAnimationFrameId = requestAnimationFrame(this.infiniteLoadingTimer);
     };
 
@@ -126,6 +120,7 @@ export class ResultItem extends Component {
 
         const outerClassName = classes.join(' ');
         const iconClassName = `result-item-icon result-bg ${resultClean}`;
+        const isIconSpinning = resultClean === 'running' && !this.infiniteRotationRunning ? 'spinAnimation' : '';
 
         const linkifyOptions = {
             attributes: {
@@ -133,7 +128,7 @@ export class ResultItem extends Component {
             },
         };
 
-        if (resultClean === 'running' && !this.infiniteRotationRunning) {
+        if (resultClean === 'running' && !this.infiniteRotationRunning && this.isIE11) {
             requestAnimationFrame(this.infiniteLoadingTimer);
             this.infiniteRotationRunning = true;
         }
@@ -144,7 +139,9 @@ export class ResultItem extends Component {
                     <span className={iconClassName}>
                         <svg width="28" height="34">
                             <g transform="translate(14 18)" className="result-status-glyph">
-                                <g transform={`rotate(${this.state.infiniteRotateDegrees})`}>{statusGlyph}</g>
+                                <g className={isIconSpinning} ref={c => (this.animatedElement = c)}>
+                                    {statusGlyph}
+                                </g>
                             </g>
                         </svg>
                     </span>

--- a/jenkins-design-language/src/js/components/status/SvgSpinner.jsx
+++ b/jenkins-design-language/src/js/components/status/SvgSpinner.jsx
@@ -8,24 +8,18 @@ export const strokeWidth = 3.5; // px. Maybe we can fetch this from CSS at runti
 export default class SvgSpinner extends Component {
     componentWillMount() {
         this.infiniteRotationRunning = false;
-        this.setState({
-            infiniteRotateDegrees: 0,
-        });
+        this.infiniteRotateDegrees = 0;
+        this.isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
     }
 
     infiniteLoadingTimer = () => {
-        let infiniteRotateDegrees = this.state.infiniteRotateDegrees;
+        this.infiniteRotateDegrees += 1.5;
 
-        infiniteRotateDegrees += 1.5;
-
-        if (infiniteRotateDegrees >= 360) {
-            infiniteRotateDegrees = 0;
+        if (this.infiniteRotateDegrees >= 360) {
+            this.infiniteRotateDegrees = 0;
         }
 
-        this.setState({
-            infiniteRotateDegrees: infiniteRotateDegrees,
-        });
-
+        this.animatedElement.setAttribute('transform', `rotate(${this.infiniteRotateDegrees})`);
         this.requestAnimationFrameId = requestAnimationFrame(this.infiniteLoadingTimer);
     };
 
@@ -53,7 +47,7 @@ export default class SvgSpinner extends Component {
             groupClasses.push('spin');
             percentage = 25;
 
-            if (!this.infiniteRotationRunning) {
+            if (!this.infiniteRotationRunning && this.isIE11) {
                 requestAnimationFrame(this.infiniteLoadingTimer);
 
                 this.infiniteRotationRunning = true;
@@ -66,7 +60,7 @@ export default class SvgSpinner extends Component {
         const innerRadius = radius / 3;
 
         return (
-            <g className={groupClasses.join(' ')} transform={`rotate(${this.state.infiniteRotateDegrees})`}>
+            <g className={groupClasses.join(' ')} ref={c => (this.animatedElement = c)}>
                 <circle cx="0" cy="0" r={radius} strokeWidth={strokeWidth} />
                 <circle className="inner" cx="0" cy="0" r={innerRadius} />
                 {percentage ? <path className={result} fill="none" strokeWidth={strokeWidth} d={d} /> : null}


### PR DESCRIPTION
# Description
These changes make the spinner a CSS animation instead of a JS one for non-IE browsers. This reduces the overall CPU usage especially when multiple spinners are present on the same page (we weren't using a single function call for all spinners and it didn't scale very well because of this).
Also by using "transform: translateZ(0)" some full page re-paints do not happen anymore which further reduce the CPU usage.

See [JENKINS-51161](https://issues.jenkins-ci.org/browse/JENKINS-51161).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

