### PR TITLE
[JENKINS-51585] JWT response should have status code 204 since it does not provide content

### DIFF
--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtToken.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/JwtToken.java
@@ -80,7 +80,10 @@ public class JwtToken implements HttpResponse {
      */
     @Override
     public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
-        rsp.setStatus(200);
+        rsp.setStatus(204);
+        /* https://httpstatuses.com/204 No Content
+        The server has successfully fulfilled the request and
+        that there is no additional content to send in the response payload body */
         rsp.addHeader(X_BLUEOCEAN_JWT, sign());
     }
 }


### PR DESCRIPTION
Use correct status code for the empty response of the JWT. Otherwise FF will try to parse the response and throw an exception because of it.

# Description

See [JENKINS-51585](https://issues.jenkins-ci.org/browse/JENKINS-51585).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

