### PR TITLE
Keep the editor from blowing up when seeing sequential stages

### DIFF
--- a/blueocean-pipeline-editor/src/main/js/services/PipelineSyntaxConverter.js
+++ b/blueocean-pipeline-editor/src/main/js/services/PipelineSyntaxConverter.js
@@ -187,6 +187,8 @@ export function convertStageFromJson(topStage: PipelineStage): StageInfo {
             const stage = convertStageFromJson(topStage.parallel[j]);
             topStageInfo.children.push(stage);
         }
+    } else if (topStage.stages) {
+        // TODO: Will need to be filled in when we actually have the ability to do something with sequential stages.
     } else {
         throw new Error('Unable to determine stage type: ' + JSON.stringify(topStage));
     }

--- a/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
+++ b/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
@@ -354,6 +354,121 @@ describe('Pipeline Syntax Converter', () => {
         assert(out.pipeline.stages[0].parallel[1].name == 'stage 2', "Bad parallel conversion");
     });
 
+    it('reads sequential stages with nested stages nested in a parallel without failing due to unknown stage type', () => {
+        const p = {"pipeline": {
+                "stages": [  {
+                    "name": "foo",
+                    "parallel":     [
+                        {
+                            "name": "first",
+                            "branches": [        {
+                                "name": "default",
+                                "steps": [          {
+                                    "name": "echo",
+                                    "arguments": [            {
+                                        "key": "message",
+                                        "value":               {
+                                            "isLiteral": false,
+                                            "value": "\"First stage, ${WHICH_AGENT}\""
+                                        }
+                                    }]
+                                }]
+                            }],
+                            "agent":         {
+                                "type": "label",
+                                "argument":           {
+                                    "isLiteral": true,
+                                    "value": "first-agent"
+                                }
+                            }
+                        },
+                        {
+                            "name": "second",
+                            "stages":         [
+                                {
+                                    "name": "inner-first",
+                                    "branches": [            {
+                                        "name": "default",
+                                        "steps":               [
+                                            {
+                                                "name": "echo",
+                                                "arguments": [                  {
+                                                    "key": "message",
+                                                    "value":                     {
+                                                        "isLiteral": false,
+                                                        "value": "\"Second stage, ${WHICH_AGENT}\""
+                                                    }
+                                                }]
+                                            },
+                                            {
+                                                "name": "script",
+                                                "arguments": [                  {
+                                                    "key": "scriptBlock",
+                                                    "value":                     {
+                                                        "isLiteral": true,
+                                                        "value": "if (isUnix()) {\n                                    sh 'mvn --version'\n                                } else {\n                                    bat 'mvn --version'\n                                }"
+                                                    }
+                                                }]
+                                            }
+                                        ]
+                                    }],
+                                    "agent":             {
+                                        "type": "label",
+                                        "argument":               {
+                                            "isLiteral": true,
+                                            "value": "second-agent"
+                                        }
+                                    },
+                                    "tools": [            {
+                                        "key": "maven",
+                                        "value":               {
+                                            "isLiteral": true,
+                                            "value": "apache-maven-3.0.1"
+                                        }
+                                    }]
+                                },
+                                {
+                                    "name": "inner-second",
+                                    "branches": [            {
+                                        "name": "default",
+                                        "steps": [              {
+                                            "name": "echo",
+                                            "arguments": [                {
+                                                "key": "message",
+                                                "value":                   {
+                                                    "isLiteral": true,
+                                                    "value": "WE SHOULD NEVER GET HERE"
+                                                }
+                                            }]
+                                        }]
+                                    }],
+                                    "when": {"conditions": [            {
+                                            "name": "expression",
+                                            "arguments": [              {
+                                                "key": "scriptBlock",
+                                                "value":                 {
+                                                    "isLiteral": true,
+                                                    "value": "return false"
+                                                }
+                                            }]
+                                        }]}
+                                }
+                            ]
+                        }
+                    ]
+                }],
+                "agent": {"type": "none"}
+            }};
+
+        const internal = convertJsonToInternalModel(p);
+        assert(internal.children[0].children.length == 2, "Stages not parallel");
+        assert(internal.children[0].steps.length == 0, "Steps not at correct stage");
+        assert(internal.children[0].children[0].name == 'first', "Wrong stage name");
+        assert(internal.children[0].children[1].name == 'second', "Wrong stage name");
+        assert(internal.children[0].children[1].steps.length == 0, "Stage containing sequential stages incorrectly has steps");
+        // TODO: Actually test the conversion into nested sequential stages once that capacity is added.
+    });
+
     it('reads sequential stages with nested stages without failing due to unknown stage type', () => {
         const p = {"pipeline": {
                 "stages": [  {

--- a/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
+++ b/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
@@ -354,4 +354,52 @@ describe('Pipeline Syntax Converter', () => {
         assert(out.pipeline.stages[0].parallel[1].name == 'stage 2', "Bad parallel conversion");
     });
 
+    it('reads sequential stages with nested stages without failing due to unknown stage type', () => {
+        const p = {"pipeline": {
+                "stages": [  {
+                    "name": "foo",
+                    "stages":     [
+                        {
+                            "name": "bar",
+                            "branches": [        {
+                                "name": "default",
+                                "steps": [          {
+                                    "name": "echo",
+                                    "arguments": [            {
+                                        "key": "message",
+                                        "value":               {
+                                            "isLiteral": false,
+                                            "value": "\"In stage ${STAGE_NAME} in group foo\""
+                                        }
+                                    }]
+                                }]
+                            }]
+                        },
+                        {
+                            "name": "baz",
+                            "branches": [        {
+                                "name": "default",
+                                "steps": [          {
+                                    "name": "echo",
+                                    "arguments": [            {
+                                        "key": "message",
+                                        "value":               {
+                                            "isLiteral": false,
+                                            "value": "\"In stage ${STAGE_NAME} in group foo\""
+                                        }
+                                    }]
+                                }]
+                            }]
+                        }
+                    ]
+                }],
+                "agent": {"type": "none"}
+            }};
+
+        const internal = convertJsonToInternalModel(p);
+        assert(internal.children.length == 1, "Parent of sequential stages not read");
+        assert(internal.children[0].steps.length == 0, "Steps not at correct stage");
+        // TODO: Actually test the conversion into nested sequential stages once that capacity is added.
+    });
+
 });

--- a/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
+++ b/blueocean-pipeline-editor/src/test/js/services/PipelineSyntaxConverter-spec.js
@@ -466,7 +466,9 @@ describe('Pipeline Syntax Converter', () => {
         assert(internal.children[0].children[0].name == 'first', "Wrong stage name");
         assert(internal.children[0].children[1].name == 'second', "Wrong stage name");
         assert(internal.children[0].children[1].steps.length == 0, "Stage containing sequential stages incorrectly has steps");
+
         // TODO: Actually test the conversion into nested sequential stages once that capacity is added.
+        assert(!Array.isArray(internal.children[0].children[1].stages), "Nested stage contains sequential stages - update tests");
     });
 
     it('reads sequential stages with nested stages without failing due to unknown stage type', () => {
@@ -514,7 +516,9 @@ describe('Pipeline Syntax Converter', () => {
         const internal = convertJsonToInternalModel(p);
         assert(internal.children.length == 1, "Parent of sequential stages not read");
         assert(internal.children[0].steps.length == 0, "Steps not at correct stage");
+
         // TODO: Actually test the conversion into nested sequential stages once that capacity is added.
+        assert(!Array.isArray(internal.children[0].stages == null), "Nested stage contains sequential stages - update tests");
     });
 
 });


### PR DESCRIPTION
# Description

Note that this doesn't actually do a thing for working with sequential
stages, so editting a Pipeline with sequential stages (once that's
actually released in Declarative) will not render anything, etc. But
it keeps things from blowing up for now.

Declarative PR that's relevant: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/227

The included test makes sure that we can convert a Declarative JSON representation that contains a `stage` with nested `stages` - you can manually verify by trying to edit a Jenkinsfile like https://github.com/abayer/pipeline-model-definition-plugin/blob/79cad4ee2026e2123dcf13c6614c1988303fc034/pipeline-model-definition/src/test/resources/topLevelStageGroup.groovy after building and installing that PR (since validation will fail otherwise).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

