### PR TITLE
[JENKINS-51627] the code was just plain wrong and ugly :)

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.service.embedded;
 
 import com.google.common.base.Preconditions;
 import hudson.model.Action;
+import hudson.model.InvisibleAction;
 import hudson.model.UsageStatistics;
 import io.jenkins.blueocean.analytics.Analytics;
 import io.jenkins.blueocean.rest.model.BlueOceanUrlObject;
@@ -40,5 +41,14 @@ public final class BlueOceanUrlAction implements Action {
 
     public boolean isAnalyticsEnabled() {
         return Analytics.isAnalyticsEnabled();
+    }
+
+    private Object readResolve() {
+        // Work around any actions that where erroneously persisted (JENKINS-51584)
+        return DoNotShowPersistedBlueOceanUrlActions.INSTANCE;
+    }
+
+    private static final class DoNotShowPersistedBlueOceanUrlActions extends InvisibleAction {
+        private static final DoNotShowPersistedBlueOceanUrlActions INSTANCE = new DoNotShowPersistedBlueOceanUrlActions();
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction.java
@@ -48,7 +48,7 @@ public final class BlueOceanUrlAction implements Action {
         return DoNotShowPersistedBlueOceanUrlActions.INSTANCE;
     }
 
-    private static final class DoNotShowPersistedBlueOceanUrlActions extends InvisibleAction {
+    protected static final class DoNotShowPersistedBlueOceanUrlActions extends InvisibleAction {
         private static final DoNotShowPersistedBlueOceanUrlActions INSTANCE = new DoNotShowPersistedBlueOceanUrlActions();
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenu.java
@@ -41,39 +41,21 @@ public class TryBlueOceanMenu extends TransientActionFactory<ModelObject> {
     public Collection<? extends Action> createFor(@Nonnull ModelObject target) {
         // we do not report actions as it might appear multiple times, we simply add it to Actionable
         BlueOceanUrlObjectFactory f = getFirst();
-        if(f != null){
+        if(f != null) {
+            // TODO remove this if block once we are using a core > 2.126
+            // Work around JENKINS-51584
+            if (target instanceof hudson.model.Queue.Item) {
+                return Collections.emptyList();
+            }
             BlueOceanUrlObject blueOceanUrlObject = f.get(target);
             BlueOceanUrlAction a = new BlueOceanUrlAction(blueOceanUrlObject);
-            if(target instanceof Actionable){
-                if(exists((Actionable) target, a)){
-                    return Collections.emptyList();
-                }
-                try {
-                    // Possibly not needed. Maybe only needed if there is a bug in exists(). Which
-                    // thee was. Unsure exactly how this code works so leaving it in
-                    ((Actionable) target).removeActions(BlueOceanUrlAction.class);
-                }catch (Throwable e){
-                    //ignore, replace is not supported
-                    //JENKINS-44964 sometimes replaceAction will fail because one of the actions inserted is null
-                    //only seen in the wild when the maven plugin is available
-                }
-                return Collections.singleton(a);
-            }
+            return Collections.singleton(a);
         }
         return Collections.emptyList();
     }
 
-    private boolean exists(Actionable actionable, BlueOceanUrlAction blueOceanUrlAction){
-        for(Action a: actionable.getActions()) {
-            // JENKINS-44926 only call getURLName on these actions if action is BLueOceanUrlAction
-            if (a instanceof BlueOceanUrlAction) {
-                String blueUrl  = blueOceanUrlAction.getUrlName();
-                String thisUrl = a.getUrlName();
-                if(thisUrl != null && thisUrl.equals(blueUrl)){
-                    return true;
-                }
-            }
-        }
-        return false;
+    @Override
+    public Class<? extends Action> actionType() {
+        return BlueOceanUrlAction.class;
     }
 }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlActionTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlActionTest.java
@@ -1,0 +1,24 @@
+package io.jenkins.blueocean.service.embedded;
+
+import hudson.util.XStream2;
+import io.jenkins.blueocean.rest.model.BlueOceanUrlObject;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class BlueOceanUrlActionTest {
+
+    @Test
+    public void testMigration() {
+        BlueOceanUrlObject mock = mock(BlueOceanUrlObject.class);
+
+        BlueOceanUrlAction original = new BlueOceanUrlAction(mock);
+        XStream2 xs = new XStream2();
+        String s = xs.toXML(original);
+        Object result = xs.fromXML(s);
+        assertThat(result, instanceOf(BlueOceanUrlAction.DoNotShowPersistedBlueOceanUrlActions.class));
+    }
+}


### PR DESCRIPTION
See [JENKINS-51627](https://issues.jenkins-ci.org/browse/JENKINS-51627).

Tidy up the code that prevents multiple "try blue" actions from showing.
The code attempted to make sure that only one "Try BlueOcean" action was shown butno one looked at the reason why multiple where shown.
The reason that multiple actions where shown was a bug in core that affected Queue.Items and their subclasses.  Given that almost all Queue.Items have no page of their own there is little point in creating an Action for them (and this solves the fact that they get persisted and then shown for a AbstractBuild.

In the case they are already persisted we just replace the action with an invisibleAction such that the only rendered "Try Blue" will be the one created afresh from the TransientActionFactory


NOtes to tester (this is untested).  TO verify run the **existing** code and create a freestyle job.
build it multiple times.
stop jenkins and validate in the build.xml you have multiple blueActions defined.
start jenkins and update the code to the version contained here.
restart jenkins and do a few more builds.
check the old builds just have one BLue Action shown.  check the new builds have one blue action shown.

# Submitter checklist

- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

