### PR TITLE
CD-489# Test fix due to artifact url format change in htmlpublisher 1.16

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/htmlpublisher/HTMLArtifactTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/htmlpublisher/HTMLArtifactTest.java
@@ -39,7 +39,7 @@ public class HTMLArtifactTest extends PipelineBaseTest {
         Assert.assertEquals("/blue/rest/organizations/jenkins/pipelines/project/runs/1/artifacts/io.jenkins.blueocean.htmlpublisher.HTMLArtifact%253AMy%252520Cool%252520report/", artifact.getLink().getHref());
         Assert.assertEquals("My Cool report", artifact.getName());
         Assert.assertEquals("My Cool report", artifact.getPath());
-        Assert.assertEquals("/job/project/1/My_Cool_report", artifact.getUrl());
+        Assert.assertNotNull(artifact.getUrl());
         Assert.assertEquals(-1, artifact.getSize());
         Assert.assertFalse(artifact.isDownloadable());
     }


### PR DESCRIPTION
Blueocean test should not be testing url format, all we care is artifact
url is not null.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

