### PR TITLE
[JENKINS-51533] Bugfix not showing all artifacts

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -503,15 +503,14 @@ public class PipelineApiTest extends BaseTest {
         assertEquals(1, artifacts.size());
         assertEquals("fizz", ((Map) artifacts.get(0)).get("name"));
 
-        String artifactName = (String) ((Map) artifacts.get(0)).get("name");
-        String name = ArtifactImpl.class.getName() + ":" + artifactName;
+        String artifactId = (String) ((Map) artifacts.get(0)).get("id");
         ArtifactContainerImpl container = new ArtifactContainerImpl(b, new Reachable() {
             @Override
             public Link getLink() {
                 return new Link("/blue/rest/organizations/jenkins/pipelines/pipeline1/runs/1/artifacts/");
             }
         });
-        BlueArtifact blueArtifact = container.get(name);
+        BlueArtifact blueArtifact = container.get(artifactId);
         assertNotNull(blueArtifact);
     }
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/ArtifactImplTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/ArtifactImplTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import hudson.model.Run;
+import io.jenkins.blueocean.rest.hal.Link;
+import java.util.ArrayList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Run.class,Link.class})
+public class ArtifactImplTest {
+
+    @Test
+    public void findUniqueArtifactsWithSameName() throws IllegalAccessException {
+        //mock artifacts
+        Run.Artifact artifact1 = mock(Run.Artifact.class);
+        Run.Artifact artifact2 = mock(Run.Artifact.class);
+        //artifact1 mocks
+        when(artifact1.getFileName()).thenReturn("test-suite.log");
+        MemberModifier.field(Run.Artifact.class, "relativePath").set(artifact1, "path1/test-suite.log");
+        when(artifact1.getHref()).thenReturn("path1/test-suite.log");
+        //artifact2 mocks
+        when(artifact2.getFileName()).thenReturn("test-suite.log");
+        MemberModifier.field(Run.Artifact.class, "relativePath").set(artifact2, "path2/test-suite.log");
+        when(artifact2.getHref()).thenReturn("path2/test-suite.log");
+        //list of artifacts
+        ArrayList artifactList = new ArrayList();
+        artifactList.add(artifact1);
+        artifactList.add(artifact2);
+        //mock run
+        Run run = mock(Run.class);
+        when(run.getUrl()).thenReturn("job/myfolder/job/myjob/1/");
+        when(run.getArtifacts()).thenReturn(artifactList);
+
+        Link parentLink = mock(Link.class);
+
+        ArtifactImpl a1 = new ArtifactImpl(run, artifact1, parentLink);
+        ArtifactImpl a2 = new ArtifactImpl(run, artifact2, parentLink);
+        assertThat(a1.getId(), is(not(a2.getId())));
+    }
+}

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueArtifact.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueArtifact.java
@@ -22,7 +22,7 @@ public abstract class BlueArtifact extends Resource{
 
     @Exported(name= ID)
     public final String getId() {
-        return this.getClass().getName() + ":" + rawEncode(getName());
+        return this.getClass().getName() + ":" + rawEncode(getPath());
     }
 
     @Exported(name=NAME)


### PR DESCRIPTION
Description
-----------

Files which are the same _name_ are not shown as artifacts in the Blue Ocean UI.

It is possible for multiple files of the same name to be collected but under different artifact paths.  This change fixes a conflict of the unique ID field where artifacts with the same name but different paths should have a unique ID.  By having a unique ID, all artifacts will be shown in the Blue Ocean UI.

Compare the following discrepencies of artifacts being listed in these two URLs.

- https://build.gimp.org/job/gimp/job/master/117/ (complete artifact list)
- https://build.gimp.org/blue/organizations/jenkins/gimp/detail/master/117/artifacts (incomplete artifact list)

> **Note:** `test-suite.log` is a file with the same name collected under different paths.

See also:

- [JENKINS-51533][JENKINS-51533] Blue Ocean Artifact tab not showing all artifacts.

Manual Test
-----------

Requirements:

* Docker
* Bash

Bootstrap Jenkins.

```bash
git clone --recursive https://gitlab.gnome.org/Infrastructure/gimp-ci-jenkins.git
cd gimp-ci-jenkins/
./jenkins_bootstrap.sh
```

Open `http://localhost:8080/` and after GIMP master is finished being built, start another build of GIMP master.  The second build of GIMP master is required so that GIMP generates unit tests.  By default pipelines do not run unit tests for the first Jenkins build in order to safely create all dependency artifacts.

Build the Blue Ocean plugin at this pull request commit and upload the following artifacts to Jenkins:

- `blueocean-commons/target/blueocean-commons.hpi` (required by `blueocean-rest.hpi`)
- `blueocean-rest/target/blueocean-rest.hpi` (contains the fix)

Screenshots
-----------

Before

![screenshot-before](https://user-images.githubusercontent.com/875669/41074326-76d114e8-69bc-11e8-8757-1a610ddcd45f.png)

After

![screenshot-after](https://user-images.githubusercontent.com/875669/41074325-76b9dfa8-69bc-11e8-8a02-96e775392e07.png)

Submitter checklist
-------------------

- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

[JENKINS-51533]: https://issues.jenkins-ci.org/browse/JENKINS-51533

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

