### PR TITLE
[JENKINS-51779] Avoid com.google.common.collect.Iterators.skip

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -1,10 +1,10 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import com.google.common.collect.Iterators;
 import hudson.model.Item;
 import hudson.plugins.favorite.Favorites;
 import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.Utils;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueFavorite;
 import io.jenkins.blueocean.rest.model.BlueFavoriteContainer;
@@ -70,7 +70,7 @@ public class FavoriteContainerImpl extends BlueFavoriteContainer {
         List<BlueFavorite> favorites = new ArrayList<>();
 
         Iterator<Item> favoritesIterator = Favorites.getFavorites(user.user).iterator();
-        Iterators.skip(favoritesIterator, start);
+        Utils.skip(favoritesIterator, start);
         int count = 0;
         while(count < limit && favoritesIterator.hasNext()) {
             Item item = favoritesIterator.next();


### PR DESCRIPTION
A follow-up from https://github.com/jenkinsci/jenkins/pull/3481: the only other code in @jenkinsci I could find which was calling this method. Ironically, you already knew about it since #1033 and had a workaround being used in `MultibranchPipelineRunContainer` and `Pageables`—just not `FavoriteContainerImpl`.