### PR TITLE
[JENKINS-51921] Prevent onClick of generated syntetic events in dropDown

### DIFF
--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.162",
+  "version": "0.0.163-thor3",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.163-thor3",
+  "version": "0.0.163",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/jenkins-design-language/src/js/components/forms/Dropdown.jsx
+++ b/jenkins-design-language/src/js/components/forms/Dropdown.jsx
@@ -88,7 +88,17 @@ export class Dropdown extends React.Component {
         // console.log('_onDropdownMouseEvent');
         // prevent navigation if anchor was clicked
         event.preventDefault();
-        this._toggleDropdownMenu();
+        /*
+         * Some browser will fire a click event when you set focus on this element while in an another
+         * event loop if those browser fire this event it will be from 0 0 hence not a real click.
+         *
+         * Another workaround could have been to create a timeout and set the focus after a certain time,
+         * however that has the problem that the timeout can vary, leaving the whole component in a focus limbo
+         */
+        const { clientX, clientY } = event;
+        if( clientY !== 0 && clientX !== 0) {
+            this._toggleDropdownMenu();
+        }
     };
 
     _handleKeyEvent = event => {
@@ -131,6 +141,20 @@ export class Dropdown extends React.Component {
             case KeyCodes.ENTER:
                 event.preventDefault();
                 this._selectFocusedItem();
+                break;
+            default:
+                break;
+        }
+    };
+
+    _keyEvent = event => {
+        const { keyCode } = event;
+
+        switch (keyCode) {
+            case KeyCodes.SPACEBAR:
+            case KeyCodes.ENTER:
+                event.preventDefault();
+                this._toggleDropdownMenu();
                 break;
             default:
                 break;
@@ -306,6 +330,7 @@ export class Dropdown extends React.Component {
                     disabled={buttonDisabled}
                     title={buttonTitle}
                     onClick={this._onDropdownMouseEvent}
+                    onKeyDown={ this._keyEvent }
                 >
                     {buttonLabel}
                 </button>

--- a/jenkins-design-language/test/js/components/Dropdown-spec.jsx
+++ b/jenkins-design-language/test/js/components/Dropdown-spec.jsx
@@ -56,6 +56,22 @@ describe("Dropdown", () => {
         assert.equal(drop.find('ul.Dropdown-menu li').length, options.length); // dropdown options same length then our array?
         assert.equal(drop.find('#unit').length, 1); // only on footer?
     });
+    it('dropDown should show footer on space key', () => {
+        const wrapper = mount(<Dropdown { ...{
+            options,
+            footer: <div id="unit">This is a custom footer</div>,
+        }}
+        />);
+        assert.ok(wrapper);
+        const drop = wrapper.find('Dropdown');
+        const props = drop.find('button').props();
+        assert.equal(props.title, 'Select an option');
+        // click on dropDown button
+        drop.find('button').simulate('keyDown', { keyCode: 32 }); // trigger keydown event
+        assert.equal(drop.find('ul.Dropdown-menu').length, 1);
+        assert.equal(drop.find('ul.Dropdown-menu li').length, options.length); // dropdown options same length then our array?
+        assert.equal(drop.find('#unit').length, 1); // only on footer?
+    });
     it('dropDown should still have focus after option selection', () => {
         const wrapper = mount(<Dropdown { ...{
             options,


### PR DESCRIPTION
# Description

See [JENKINS-51921](https://issues.jenkins-ci.org/browse/JENKINS-51921).

Prevent synthetic events to trigger onClick.

Some browser like FF and IE will fire an onClick event if you focus the dropDownButton in another event loop.

Base cause described in http://helephant.com/2008/01/16/focus-event-handler-run-in-different-order-in-ie-than-firefox/ more info https://allyjs.io/tests/event-sequence/table.html


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

