### PR TITLE
[JENKINS-52029] - Create experimental BlueOcean image with JDK 10 support

### DIFF
--- a/Dockerfile.jdk10
+++ b/Dockerfile.jdk10
@@ -1,0 +1,26 @@
+#
+# Before building this Dockerfile, BlueOcean needs to be built locally using Maven
+# You can build everything needed and this Dockerfile by invoking `bin/build-in-docker.sh -m`
+#
+
+# Should be kept in sync with jenkins.properties of pom.xml
+# Patch version is not to be considered, we prefer to base the image off the latest LTS of the line
+# and keep the dependency on the baseline in pom.xml
+FROM jenkins/jenkins-experimental:latest-jdk10
+
+USER root
+
+COPY blueocean/target/plugins /usr/share/jenkins/ref/plugins/
+
+RUN for f in /usr/share/jenkins/ref/plugins/*.hpi; do mv "$f" "${f%%hpi}jpi"; done
+RUN install-plugins.sh antisamy-markup-formatter matrix-auth # for security, you know
+# https://github.com/jenkinsci/workflow-support-plugin/tree/java10-support
+RUN install-plugins.sh "workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc295.e017dc58c0a3"
+
+# Force use of locally built blueocean plugin
+RUN for f in /usr/share/jenkins/ref/plugins/blueocean-*.jpi; do mv "$f" "$f.override"; done
+
+# let scripts customize the reference Jenkins folder. Used in bin/build-in-docker to inject the git build data
+COPY docker/ref /usr/share/jenkins/ref
+
+USER jenkins


### PR DESCRIPTION
# Description

See [JENKINS-52029](https://issues.jenkins-ci.org/browse/JENKINS-52029). The image is hosted on DockerHub as `jenkins/jenkins-experimental:blueocean-jdk10`

Base images:

* https://github.com/jenkinsci/jenkins/blob/java10-support/Dockerfile
* https://github.com/jenkinsci/docker/tree/java10

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees @jenkinsci/java10-support 