### PR TITLE
[JENKINS-51372] De-flake BitbucketServerTest

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/ActivityPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/ActivityPage.java
@@ -133,6 +133,7 @@ public class ActivityPage {
 
     public void checkBasicDomElements() {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("article.activity")));
+        logger.info("checkBasicDomElements: Activity tab found");
     }
 
     public void checkFavoriteStatus(boolean isFavorited) {

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -151,7 +151,7 @@ public class EditorPage {
         wait.click(By.cssSelector(".editor-step-selector div[data-functionName=\"echo\"]"));
         wait.sendKeys(By.cssSelector("input.TextInput-control"),"simplePipeline creating echo message");
         wait.click(By.cssSelector("div.sheet.active a.back-from-sheet"));
-        saveBranch(newBranch);
+        logger.info("Pipeline created and ready to be saved");
     }
 
     /**
@@ -180,5 +180,4 @@ public class EditorPage {
         wait.sendKeys(By.cssSelector("input.stage-name-edit"),"Top Level Parallel Wrapper Stage");
         logger.info("Parallel pipeline created and ready to save");
     }
-
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -121,6 +121,7 @@ public class EditorPage {
     public void saveBranch(String branch) {
         logger.info("saveBranch method called");
         wait.click(By.xpath("//*[text()='Save']"));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("textarea[placeholder=\"What changed?\"]")));
         wait.sendKeys(By.cssSelector("textarea[placeholder=\"What changed?\"]"), "ATH made changes and is saving");
         if(!Strings.isNullOrEmpty(branch)) {
             wait.click(By.xpath("//span[text()='Commit to new branch']"));

--- a/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/live/GithubEditorTest.java
@@ -127,6 +127,7 @@ public class GithubEditorTest {
         creationPage.createPipeline(token, organization, repo, true);
         MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
         editorPage.simplePipeline();
+        editorPage.saveBranch("master");
         ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
         driver.navigate().refresh();
         sseClient.untilEvents(pipeline.buildsFinished);
@@ -148,6 +149,7 @@ public class GithubEditorTest {
         creationPage.createPipeline(token, organization, repo, true);
         MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
         editorPage.simplePipeline();
+        editorPage.saveBranch("master");
         ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
         sseClient.untilEvents(pipeline.buildsFinished);
         sseClient.clear();
@@ -172,6 +174,7 @@ public class GithubEditorTest {
         creationPage.createPipeline(token, organization, repo, true);
         MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
         editorPage.simplePipeline();
+        editorPage.saveBranch("master");
         ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
         sseClient.untilEvents(pipeline.buildsFinished);
         sseClient.clear();
@@ -203,6 +206,7 @@ public class GithubEditorTest {
         creationPage.createPipeline(token, organization, repo, true);
         MultiBranchPipeline pipeline = mbpFactory.pipeline(repo);
         editorPage.simplePipeline();
+        editorPage.saveBranch("master");
         ActivityPage activityPage = pipeline.getActivityPage().checkUrl();
         sseClient.untilEvents(pipeline.buildsFinished);
         sseClient.clear();

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/BitbucketServerTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/BitbucketServerTest.java
@@ -3,13 +3,7 @@ package io.blueocean.ath.offline;
 import com.cdancy.bitbucket.rest.BitbucketClient;
 import com.cdancy.bitbucket.rest.options.CreateRepository;
 import com.google.inject.Inject;
-import io.blueocean.ath.ATHJUnitRunner;
-import io.blueocean.ath.BaseUrl;
-import io.blueocean.ath.CustomJenkinsServer;
-import io.blueocean.ath.Login;
-import io.blueocean.ath.Retry;
-import io.blueocean.ath.WaitUtil;
-import io.blueocean.ath.WebDriverMixin;
+import io.blueocean.ath.*;
 import io.blueocean.ath.api.classic.ClassicJobApi;
 import io.blueocean.ath.pages.blue.ActivityPage;
 import io.blueocean.ath.pages.blue.DashboardPage;
@@ -29,11 +23,13 @@ import java.io.IOException;
 @RunWith(ATHJUnitRunner.class)
 public class BitbucketServerTest implements WebDriverMixin {
 
-    private static Logger LOGGER = Logger.getLogger(BitbucketServerTest.class);
+    private static Logger logger = Logger.getLogger(BitbucketServerTest.class);
     private static final String ENDPOINT_URL = "http://127.0.0.1:7990";
     private static final String BB_PROJECT_KEY = "BLUE";
     private static final String BB_PROJECT_NAME = "BlueOcean";
     private static final String BB_REPO_NAME = "bitbucket-no-jenkinsfile";
+    private static final String BB_USER_ID = "admin";
+    private static final String BB_PASSWORD = "admin";
 
     @Inject
     WaitUtil wait;
@@ -59,8 +55,12 @@ public class BitbucketServerTest implements WebDriverMixin {
     @Inject
     ClassicJobApi jobApi;
 
+    @Inject
+    JenkinsUser jenkinsUser;
+
     @Before
     public void setUp() throws IOException {
+        logger.info("--> setUp");
         cleanupEndpoint(ENDPOINT_URL);
         cleanupCredentials(ENDPOINT_URL);
         jobApi.deletePipeline(BB_REPO_NAME);
@@ -71,7 +71,7 @@ public class BitbucketServerTest implements WebDriverMixin {
     public void testCreationNoJenkinsfile() throws InterruptedException {
         BitbucketClient client = BitbucketClient.builder()
             .endPoint(ENDPOINT_URL)
-            .credentials("admin:admin").build();
+            .credentials((BB_USER_ID + ":" + BB_PASSWORD)).build();
 
         client.api().repositoryApi().delete(BB_PROJECT_KEY, BB_REPO_NAME);
         client.api().repositoryApi().create(BB_PROJECT_KEY, CreateRepository.create(BB_REPO_NAME, true));
@@ -79,29 +79,32 @@ public class BitbucketServerTest implements WebDriverMixin {
         dashboardPage.clickNewPipelineBtn();
 
         click("//span[text()='Bitbucket Server']");
-        LOGGER.info("Selected bitbucket server");
+        logger.info("Selected bitbucket server");
 
         click(".button-add-server");
-        LOGGER.info("Clicked addserver");
+        logger.info("Clicked addserver");
 
         wait.until(By.cssSelector(".text-name input")).sendKeys("bitbucketserver");
         wait.until(By.cssSelector(".text-url input")).sendKeys(ENDPOINT_URL);
         wait.click(By.cssSelector(".button-create-server"));
         wait.click(By.cssSelector(".button-next-step"));
-        wait.sendKeys(By.cssSelector(".text-username input"),"admin");
-        wait.sendKeys(By.cssSelector(".text-password input"),"admin");
+        wait.sendKeys(By.cssSelector(".text-username input"),BB_USER_ID);
+        wait.sendKeys(By.cssSelector(".text-password input"),BB_PASSWORD);
         wait.click(By.cssSelector(".button-create-credential"));
-        LOGGER.info("Bitbucket server created successfully");
+        logger.info("Bitbucket server created successfully");
         // Select project
         creationPage.selectOrganization(BB_PROJECT_NAME);
         creationPage.selectPipelineToCreate(BB_REPO_NAME);
         creationPage.clickCreatePipelineButton();
         editorPage.simplePipeline();
-        wait.tinySleep(5000);
-        activityPage.getRunRowForBranch("master");
+        editorPage.saveBranch("master");
+        // This is here so we don't try to close the browser window too fast
+        wait.tinySleep(3000);
+        activityPage.checkBasicDomElements();
     }
 
     private void cleanupEndpoint(String endpointUrl) throws IOException {
+        logger.info("--> cleanupEndpoint");
         String serverId = DigestUtils.sha256Hex(endpointUrl);
 
         try {
@@ -109,16 +112,17 @@ public class BitbucketServerTest implements WebDriverMixin {
                 .urlPart("serverId", serverId)
                 .status(204)
                 .as(Void.class);
-            LOGGER.info("found and deleted bitbucket server: " + serverId);
+            logger.info("found and deleted bitbucket server: " + serverId);
         } catch (Exception ex) {
-            LOGGER.debug("server not found while attempting to delete bitbucket server: " + serverId);
+            logger.debug("server not found while attempting to delete bitbucket server: " + serverId);
         }
     }
 
     private void cleanupCredentials(String endpointUrl) throws IOException {
+        logger.info("--> cleanupCredentials");
         String serverId = DigestUtils.sha256Hex(endpointUrl);
         String credentialId = "bitbucket-server:" + serverId;
-        jenkins.deleteUserDomainCredential("alice", "blueocean-bitbucket-server-domain", credentialId);
+        jenkins.deleteUserDomainCredential(jenkinsUser.username, "blueocean-bitbucket-server-domain", credentialId);
     }
 
     private HttpRequest httpRequest() {


### PR DESCRIPTION
# Description

See [JENKINS-51372](https://issues.jenkins-ci.org/browse/JENKINS-51372). This PR does several things, in an attempt to reduce, or hopefully eliminate, spurious failures from BitbucketServerTest.

I'm going to label this as DO-NOT-MERGE until I see if these changes actually have a positive effect. The test being deflaked here was never a problem when running locally, or even on other CI systems - just on ci.blueocean.io.

# Primary Changes:

- Moved `saveBranch()` out of the `simplePipeline(String newBranch)` method, so that test cases need to call `saveBranch()` specifically. 
  - Allows for easier readability of the test case code. 
  - Accompanying changes to `GitHubEditorTest.java` are included.
- Added a `wait.until(ExpectedConditions.visibilityOfElementLocated...)` to the `saveBranch()` method, because the test's occasional inability to find a particular `textArea` on the screen is what was causing the problems.
- Added a `@Inject JenkinsUser jenkinsUser`, and accompanying change to `cleanupCredentials(String endpointUrl)`, so that if we do end up having to `Retry` this test, the credentials previously used will be correctly deleted. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: not applicable, because this is test code
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

