### PR TITLE
[JENKINS-52130] Replace Object.values because it doesn't work in older browsers

### DIFF
--- a/blueocean-dashboard/src/main/js/credentials/git/GitCredentialsPickerPassword.tsx
+++ b/blueocean-dashboard/src/main/js/credentials/git/GitCredentialsPickerPassword.tsx
@@ -32,7 +32,10 @@ enum RadioOption {
     CREATE_NEW = 'createNew',
 }
 
-const radioOptions = Object.values(RadioOption);
+let radioOptions: string[] = [];
+Object.keys(RadioOption).forEach(function(key) {
+    radioOptions.push(RadioOption[key]);
+});
 
 function getErrorMessage(state: ManagerState) {
     if (state === ManagerState.INVALID_CREDENTIAL) {


### PR DESCRIPTION
# Description
Replace the use of Object.values because it breaks the whole app in older versions of browsers

See [JENKINS-52130](https://issues.jenkins-ci.org/browse/JENKINS-52130).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

