### PR TITLE
[JENKINS-52494] Upgrade selenium container to pick up newer chrome, selenium

### DIFF
--- a/acceptance-tests/runner/scripts/start-selenium.sh
+++ b/acceptance-tests/runner/scripts/start-selenium.sh
@@ -6,7 +6,7 @@ $SCRIPT_DIR/stop-selenium.sh
 echo ""
 echo " Starting Selenium Docker container..."
 echo ""
-docker run -d --name blueo-selenium -p 15900:5900 -p 7990:7990 -p 7999:7999 -p 4444:4444 -e no_proxy=localhost selenium/standalone-chrome-debug:3.6.0-bromine > /dev/null
+docker run -d --name blueo-selenium -p 15900:5900 -p 7990:7990 -p 7999:7999 -p 4444:4444 -e no_proxy=localhost selenium/standalone-chrome-debug:3.13.0-argon > /dev/null
 
 # Output the containers bridge network IP to file
 SELENIUM_IP=`docker inspect -f '{{ .NetworkSettings.IPAddress }}' blueo-selenium`


### PR DESCRIPTION
# Description

See [JENKINS-52494](https://issues.jenkins-ci.org/browse/JENKINS-52494). The idea here is to make a quick change to the Selenium container we use, which will being with it upgrades to Chrome, Chromedriver, and Selenium. This is probably better for test coverage anyway, but more to the point, I'd like to see if it helps with any of the flaky tests we've got.

I've seen this work in another ci setting, so I'm filing a temporary PR to watch it work on ci.blueocean.io.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: Not applicable, as this is a test plumbing change
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

