### PR TITLE
[JENKINS-49050] Add support for sequential parallel stages

### DIFF
--- a/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
@@ -94,8 +94,8 @@ function convertJenkinsNodeDetails(jenkinsNode, isCompleted, skewMillis = 0) {
 function buildSequentialStages(originalNodes, convertedNodes, sequentialNodeKey, currentNode) {
     const nextSequentialNodeId = originalNodes[sequentialNodeKey].edges[0] ? originalNodes[sequentialNodeKey].edges[0].id : '';
 
+    currentNode.isSequential = true;
     if (nextSequentialNodeId) {
-        currentNode.isSequential = true;
         if (originalNodes[sequentialNodeKey].edges.length && originalNodes[nextSequentialNodeId].firstParent == currentNode.id) {
             currentNode.nextSibling = convertedNodes[nextSequentialNodeId];
 
@@ -150,7 +150,9 @@ export function convertJenkinsNodeGraph(jenkinsGraph, isCompleted, skewMillis) {
     // Follow the graph and build our results
     let currentNode = firstNode;
     while (currentNode) {
-        results.push(currentNode);
+        if (!currentNode.isSequential) {
+            results.push(currentNode);
+        }
 
         let nextNode = null;
         const originalNode = originalNodeForId[currentNode.id];
@@ -184,7 +186,9 @@ export function convertJenkinsNodeGraph(jenkinsGraph, isCompleted, skewMillis) {
                         if (originalNodeForId[key].firstParent === branchNode.id) {
                             currentNode.children[0] = convertedNodeForId[key];
 
-                            buildSequentialStages(originalNodeForId, convertedNodeForId, key, currentNode.children[0]);
+                            if (originalNodeForId[key].edges[0]) {
+                                buildSequentialStages(originalNodeForId, convertedNodeForId, key, currentNode.children[0]);
+                            }
                         }
                     });
 

--- a/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
@@ -92,13 +92,15 @@ function convertJenkinsNodeDetails(jenkinsNode, isCompleted, skewMillis = 0) {
 }
 
 function buildSequentialStages(originalNodes, convertedNodes, sequentialNodeKey, currentNode) {
-    const nextSequentialNodeId = originalNodes[sequentialNodeKey].edges[0].id;
+    const nextSequentialNodeId = originalNodes[sequentialNodeKey].edges[0] ? originalNodes[sequentialNodeKey].edges[0].id : '';
 
-    currentNode.isSequential = true;
-    if (originalNodes[sequentialNodeKey].edges.length && originalNodes[nextSequentialNodeId].firstParent == currentNode.id) {
-        currentNode.nextSibling = convertedNodes[nextSequentialNodeId];
+    if (nextSequentialNodeId) {
+        currentNode.isSequential = true;
+        if (originalNodes[sequentialNodeKey].edges.length && originalNodes[nextSequentialNodeId].firstParent == currentNode.id) {
+            currentNode.nextSibling = convertedNodes[nextSequentialNodeId];
 
-        buildSequentialStages(originalNodes, convertedNodes, currentNode.nextSibling.id, currentNode.nextSibling);
+            buildSequentialStages(originalNodes, convertedNodes, currentNode.nextSibling.id, currentNode.nextSibling);
+        }
     }
 }
 
@@ -267,7 +269,6 @@ export default class PipelineRunGraph extends Component {
         }
 
         const id = this.props.selectedStage.id;
-
         let selectedStage = null;
 
         // Find selected stage by id

--- a/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
@@ -323,12 +323,16 @@ export default class Pipeline extends Component {
                 let nodeRestartId = this.pager.currentNode.restartable ? this.pager.currentNode.id : '';
                 let nodeRestartTitle = this.pager.currentNode.restartable ? title : '';
 
-                if (this.pager.currentNode.restartable == false && this.pager.currentNode.type == 'PARALLEL') {
-                    const currentNodeParent = this.pager.nodes.data.model.filter(node => node.id == this.pager.currentNode.parent)[0];
+                if (this.pager.currentNode.restartable == false) {
+                    let currentNodeParent = this.pager.nodes.data.model.filter(node => node.id == this.pager.currentNode.firstParent)[0];
 
-                    if (currentNodeParent.restartable) {
-                        nodeRestartId = currentNodeParent.id;
-                        nodeRestartTitle = currentNodeParent.title;
+                    while (currentNodeParent) {
+                        if (currentNodeParent && currentNodeParent.restartable) {
+                            nodeRestartId = currentNodeParent.id;
+                            nodeRestartTitle = currentNodeParent.title;
+                            break;
+                        }
+                        currentNodeParent = this.pager.nodes.data.model.filter(node => node.id == currentNodeParent.firstParent)[0];
                     }
                 }
 

--- a/blueocean-dashboard/src/main/js/components/karaoke/services/pagers/PipelinePager.js
+++ b/blueocean-dashboard/src/main/js/components/karaoke/services/pagers/PipelinePager.js
@@ -4,6 +4,8 @@ import { logging } from '@jenkins-cd/blueocean-core-js';
 import { prefixIfNeeded } from '../../urls/prefixIfNeeded';
 import { KaraokeApi } from '../../index';
 
+import { convertJenkinsNodeGraph } from '../../../PipelineRunGraph';
+
 const logger = logging.logger('io.jenkins.blueocean.dashboard.karaoke.Pager.Pipeline');
 
 /**
@@ -111,7 +113,9 @@ export class PipelinePager {
                     } else {
                         // Actually we should only come here on a not running job
                         logger.debug('Actually we should only come here on a not running job');
-                        const lastNode = logData.data.model[logData.data.model.length - 1];
+                        const convertedNodes = convertJenkinsNodeGraph(logData.data.model, result.isFinished, 0);
+                        const lastNode = logData.data.model.filter(node => node.id === convertedNodes[convertedNodes.length - 1].id)[0];
+
                         this.currentNode = lastNode;
                     }
                     this.currentStepsUrl = prefixIfNeeded(this.currentNode._links.steps.href);

--- a/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
+++ b/blueocean-dashboard/src/main/js/util/logDisplayHelper.js
@@ -66,6 +66,7 @@ export const getNodesInformation = nodes => {
             logUrl: hasLogs ? logActions[0]._links.self.href : undefined,
             isParallel,
             parent,
+            firstParent: item.firstParent || undefined,
             isRunning,
             isCompleted,
             computedResult,

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraph.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraph.jsx
@@ -572,7 +572,7 @@ export class PipelineGraph extends Component {
      */
     stageIsSelected(stage?: StageInfo) {
         const { selectedStage } = this.state;
-        return selectedStage && selectedStage === stage;
+        return selectedStage && stage && selectedStage.id === stage.id;
     }
 
     /**
@@ -585,16 +585,18 @@ export class PipelineGraph extends Component {
 
             if (children && selectedStage) {
                 for (const childStage of children) {
-                    let testee = childStage;
-                    while (testee) {
-                        if (testee === selectedStage) {
+                    let currentStage = childStage;
+
+                    while (currentStage) {
+                        if (currentStage.id === selectedStage.id) {
                             return true;
                         }
-                        testee = testee.nextSibling;
+                        currentStage = currentStage.nextSibling;
                     }
                 }
             }
         }
+
         return false;
     }
 

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.jsx
@@ -219,7 +219,7 @@ function createSmallLabels(columns: Array<NodeColumn>) {
         for (const row of column.rows) {
             for (const node of row) {
                 // We add small labels to parallel nodes only so skip others
-                if (!node.stage || node.stage.type !== 'PARALLEL') {
+                if (!node.stage || (node.stage.type !== 'PARALLEL' && node.stage.isSequential !== true)) {
                     continue;
                 }
                 const label: LabelInfo = {


### PR DESCRIPTION
# Description
This adds the ability to view sequential parallel stages in the PipelineGraph. [Here](https://github.com/NicuPascu/app-store-demo/blob/sequential_parallel_stages/Jenkinsfile) is an example Jenkinsfile that can be used for testing.

See [JENKINS-49050](https://issues.jenkins-ci.org/browse/JENKINS-49050).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

