### PR TITLE
[JENKINS-52944] Pass milliseconds to TimeDuration

### DIFF
--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -21,7 +21,7 @@ export default class TestCaseResultRow extends Component {
 
     render() {
         const { testCase, translation, locale = 'en' } = this.props;
-        const duration = TimeDuration.format(testCase.duration, translation, locale);
+        const duration = TimeDuration.format(testCase.duration * 1000, translation, locale);
         const showTestCase = testCase.errorStackTrace || testCase.errorDetails || testCase.hasStdLog;
         let statusIndicator = null;
         switch (testCase.status) {


### PR DESCRIPTION
# Description

testCase.duration is in seconds, but we must pass milliseconds to TimeDuration.format().

See [JENKINS-52944](https://issues.jenkins-ci.org/browse/JENKINS-52944).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given