### PR TITLE
BitBucket Server errors not shown properly

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -38,25 +38,27 @@ public class HttpResponse {
             if(getStatus() >= 300){
                 ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
                 if (StringUtils.isEmpty(errorMessage.message)) {
-                    String message = "";
+                    String message;;
                     List<ErrorMessage.Error> errors = new ArrayList<>();
                     try {
                         JSONObject jsonResponse = JSONObject.fromObject(IOUtils.toString(entity.getContent()));
                         JSONArray arr = jsonResponse.getJSONArray("errors");
+                        StringBuilder messageBuilder = new StringBuilder();
                         for (int i = 0; i < arr.size(); i++) {
                             JSONObject err = arr.getJSONObject(i);
                             if (i > 0) {
-                                message += ", ";
+                                messageBuilder.append(", ");
                             }
-                            message += err.getString("message");
+                            messageBuilder.append(err.getString("message"));
 
-                            String details = "";
+                            StringBuilder details = new StringBuilder();
                             JSONArray errorDetails = err.getJSONArray("details");
                             for (int detailIdx = 0; detailIdx < errorDetails.size(); detailIdx++) {
-                                details += errorDetails.getString(detailIdx) + "\n";
+                                details.append(errorDetails.getString(detailIdx)).append("\n");
                             }
-                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details));
+                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details.toString()));
                         }
+                        message = messageBuilder.toString();
                     } catch(Exception e) {
                         logger.error("An error occurred getting BitBucket API error content", e);
                         message = "An unknown error was reported from the BitBucket server";

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -37,7 +37,8 @@ public class HttpResponse {
             HttpEntity entity = response.getEntity();
             if(getStatus() >= 300){
                 ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
-                if (StringUtils.isEmpty(errorMessage.message)) {
+                // WireMock returns "Bad Request" for the status message; it's also pretty nondescript
+                if (StringUtils.isEmpty(errorMessage.message) || "Bad Request".equals(errorMessage.message)) {
                     String message;;
                     List<ErrorMessage.Error> errors = new ArrayList<>();
                     try {

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -1,21 +1,31 @@
 package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
 
+import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Vivek Pandey
  */
 @Restricted(NoExternalUse.class)
 public class HttpResponse {
+    private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
     private final org.apache.http.HttpResponse response;
 
     public HttpResponse(org.apache.http.HttpResponse response) {
@@ -26,8 +36,36 @@ public class HttpResponse {
         try {
             HttpEntity entity = response.getEntity();
             if(getStatus() >= 300){
-                EntityUtils.consume(entity);
-                throw new ServiceException(getStatus(), getStatusLine());
+                ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
+                if (StringUtils.isEmpty(errorMessage.message)) {
+                    String message = "";
+                    List<ErrorMessage.Error> errors = new ArrayList<>();
+                    try {
+                        JSONObject jsonResponse = JSONObject.fromObject(IOUtils.toString(entity.getContent()));
+                        JSONArray arr = jsonResponse.getJSONArray("errors");
+                        for (int i = 0; i < arr.size(); i++) {
+                            JSONObject err = arr.getJSONObject(i);
+                            if (i > 0) {
+                                message += ", ";
+                            }
+                            message += err.getString("message");
+
+                            String details = "";
+                            JSONArray errorDetails = err.getJSONArray("details");
+                            for (int detailIdx = 0; detailIdx < errorDetails.size(); detailIdx++) {
+                                details += errorDetails.getString(detailIdx) + "\n";
+                            }
+                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details));
+                        }
+                    } catch(Exception e) {
+                        logger.error("An error occurred getting BitBucket API error content", e);
+                        message = "An unknown error was reported from the BitBucket server";
+                    }
+                    errorMessage = new ErrorMessage(getStatus(), message).addAll(errors);
+                } else {
+                    EntityUtils.consume(entity);
+                }
+                throw new ServiceException(getStatus(), errorMessage, null);
             }
             return entity == null ? null :entity.getContent();
         } catch (IOException e) {

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
@@ -146,6 +146,41 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
         fail("Should have failed with PreConditionException");
     }
 
+    @Test
+    public void handleSaveErrorsWithEmptyStatusLine() throws UnirestException, IOException {
+        String credentialId = createCredential(BitbucketServerScm.ID);
+        StaplerRequest staplerRequest = mockStapler();
+        MultiBranchProject mbp = mockMbp(credentialId);
+
+        // /rest/api/1.0/projects/PROJ/repos/with-jenkinsfile/browse/Jenkinsfile
+        GitContent content = new GitContent.Builder().autoCreateBranch(true).base64Data("bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K")
+            .branch("master").message("new commit").owner("TESTP").path("Jenkinsfile").repo("pipeline-demo-test").build();
+
+        when(staplerRequest.bindJSON(Mockito.eq(BitbucketScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new BitbucketScmSaveFileRequest(content));
+
+        String request = "{\n" +
+            "  \"content\" : {\n" +
+            "    \"message\" : \"new commit\",\n" +
+            "    \"path\" : \"Jenkinsfile\",\n" +
+            "    \"branch\" : \"master\",\n" +
+            "    \"repo\" : \"pipeline-demo-test\",\n" +
+            "    \"base64Data\" : " + "\"bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K\"" +
+            "  }\n" +
+            "}";
+
+        when(staplerRequest.getReader()).thenReturn(new BufferedReader(new StringReader(request), request.length()));
+
+        try {
+            // Should get mocked response from:
+            // bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
+            new BitbucketServerScmContentProvider()
+                .saveContent(staplerRequest, mbp);
+        } catch (ServiceException e) {
+            assertEquals("File editing canceled for 'Jenkinsfile' on 'master'.", e.getMessage());
+            return;
+        }
+        fail("Should have failed with message: File editing canceled for 'Jenkinsfile' on 'master'.");
+    }
 
     @Test
     public void updateContent() throws UnirestException, IOException {

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
@@ -152,16 +152,15 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
         StaplerRequest staplerRequest = mockStapler();
         MultiBranchProject mbp = mockMbp(credentialId);
 
-        // /rest/api/1.0/projects/PROJ/repos/with-jenkinsfile/browse/Jenkinsfile
         GitContent content = new GitContent.Builder().autoCreateBranch(true).base64Data("bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K")
-            .branch("master").message("new commit").owner("TESTP").path("Jenkinsfile").repo("pipeline-demo-test").build();
+            .branch("master").message("new commit").owner("TESTP").path("SomeFile").repo("pipeline-demo-test").build();
 
         when(staplerRequest.bindJSON(Mockito.eq(BitbucketScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new BitbucketScmSaveFileRequest(content));
 
         String request = "{\n" +
             "  \"content\" : {\n" +
             "    \"message\" : \"new commit\",\n" +
-            "    \"path\" : \"Jenkinsfile\",\n" +
+            "    \"path\" : \"SomeFile\",\n" +
             "    \"branch\" : \"master\",\n" +
             "    \"repo\" : \"pipeline-demo-test\",\n" +
             "    \"base64Data\" : " + "\"bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K\"" +
@@ -172,14 +171,13 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
 
         try {
             // Should get mocked response from:
-            // bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
-            new BitbucketServerScmContentProvider()
-                .saveContent(staplerRequest, mbp);
+            // bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
+            new BitbucketServerScmContentProvider().saveContent(staplerRequest, mbp);
         } catch (ServiceException e) {
-            assertEquals("File editing canceled for 'Jenkinsfile' on 'master'.", e.getMessage());
+            assertEquals("File editing canceled for 'SomeFile' on 'master'.", e.getMessage());
             return;
         }
-        fail("Should have failed with message: File editing canceled for 'Jenkinsfile' on 'master'.");
+        fail("Should have failed with message: File editing canceled for 'SomeFile' on 'master'.");
     }
 
     @Test

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
@@ -1,0 +1,29 @@
+{
+  "id" : "7269cd83-1af6-4134-9161-82360d678dcc",
+  "name" : "bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile",
+  "request" : {
+    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/Jenkinsfile",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "anything" : "anything"
+    } ]
+  },
+  "response" : {
+    "status" : "400",
+    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'Jenkinsfile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'Jenkinsfile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
+    "headers" : {
+      "X-AREQUESTID" : "@L72CV8x1069x1007x0",
+      "X-AUSERID" : "2",
+      "X-AUSERNAME" : "user",
+      "Cache-Control" : "no-cache, no-transform",
+      "Vary" : "X-AUSERNAME,Accept-Encoding",
+      "X-Content-Type-Options" : "nosniff",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Sun, 19 Aug 2018 21:49:54 GMT",
+      "Connection" : "close"
+    }
+  },
+  "uuid" : "7269cd83-1af6-4134-9161-82360d678dcc",
+  "persistent" : true,
+  "insertionIndex" : 68
+}

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
@@ -1,8 +1,8 @@
 {
   "id" : "7269cd83-1af6-4134-9161-82360d678dcc",
-  "name" : "bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile",
+  "name" : "bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile",
   "request" : {
-    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/Jenkinsfile",
+    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/SomeFile",
     "method" : "PUT",
     "bodyPatterns" : [ {
       "anything" : "anything"
@@ -10,7 +10,7 @@
   },
   "response" : {
     "status" : "400",
-    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'Jenkinsfile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'Jenkinsfile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
+    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'SomeFile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'SomeFile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
     "headers" : {
       "X-AREQUESTID" : "@L72CV8x1069x1007x0",
       "X-AUSERID" : "2",

--- a/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
+++ b/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
@@ -85,6 +85,16 @@ class SaveDialog extends React.Component {
                 errorMessage = err.responseBody.message;
             }
         }
+        if (err.responseBody && err.responseBody.errors && err.responseBody.errors.length) {
+            errorMessage = (
+                <div>
+                    <div><strong>{errorMessage}</strong></div>
+                    {err.responseBody.errors.map(e =>
+                        <div><em>{e.code}</em>: {e.message}</div>
+                    )}
+                </div>
+            );
+        }
         this.setState({ saving: false, errorMessage });
     }
 


### PR DESCRIPTION
# Description

Show BitBucket server errors better in some cases, for example attempting to save a Jenkinsfile through the pipeline editor, some errors would return an error code, empty status line and error object, which would not give any information to the end user.

For example:
![image](https://user-images.githubusercontent.com/3009477/44312751-fab9c500-a3ca-11e8-81ba-f1d4814ca310.png)


See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

