### PR TITLE
Allows pre- and post-2.125 versions of Jenkins core to pass

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -21,6 +21,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMSource;
 import jenkins.util.SystemProperties;
+import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -296,7 +297,14 @@ public class AbstractRunImplTest extends PipelineBaseTest {
 
         Assert.assertEquals("QUEUED", latestRun.get("state"));
         Assert.assertEquals("1", latestRun.get("id"));
-        Assert.assertEquals("Jenkins doesn’t have label test", latestRun.get("causeOfBlockage"));
+
+        // Jenkins 2.125 introduced quotes around these labels - see commit 91ddc6. This came
+        // just after the current Jenkins LTS, which is version 2.121.1. So this assert now
+        // tests for the new quoted version, and the old non-quoted version.
+        Assert.assertThat((String)latestRun.get("causeOfBlockage"), anyOf(
+            equalTo("\u2018Jenkins\u2019 doesn’t have label \u2018test\u2019"),
+            equalTo("Jenkins doesn’t have label test")
+        ));
 
         j.createOnlineSlave(Label.get("test"));
 


### PR DESCRIPTION
# Description

See [JENKINS-53197](https://issues.jenkins-ci.org/browse/JENKINS-53197).

When Blue Ocean is built using a version of Jenkins core 1.25 or newer, [this test](https://github.com/jenkinsci/blueocean-plugin/blob/16d42cd0f6d08fedb0660ad6080ef2c8a2b1769e/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java#L282) will fail. That's because [the `assertEquals` on L299](https://github.com/jenkinsci/blueocean-plugin/blob/16d42cd0f6d08fedb0660ad6080ef2c8a2b1769e/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java#L299) is looking for the following string:

> Jenkins doesn’t have label test

But since [this commit to Jenkins core](https://github.com/jenkinsci/jenkins/commit/91ddc6fca78e09efe25ced0409def4cd62c811aa), what we'll get back is:

> ‘Jenkins’ doesn’t have label ‘test’ 

The difference is the single quotes: we've gone from _Jenkins_ to _‘Jenkins’_, and from _test_ to _‘test’_.

# How to test

1. Pull this PR
2. `cd blueocean-pipeline-api-impl`
3. `mvn clean test -Dtest=AbstractRunImplTest#queuedSingleNode`
4. Change `jenkins.version` in `pom.xml` to something newer than 2.121.1. I used 2.138.
5. Re-build and re-run the test. It should pass in both cases.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: N/A, this is a change to test code.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

