### PR TITLE
[JENKINS-53175] avoid js throwing error in case a run request returns a 404

### DIFF
--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -156,16 +156,19 @@ export class DefaultSSEHandler {
                     pager.insert(href);
                 }
             }
-            this.pipelineService.updateLatestRun(run);
 
-            /*
-                Check to see if the TestSummary has been loaded and if so then reload it. Otherwise don't because
-                it's expensive to calculate.
-             */
+            if (run) {
+                this.pipelineService.updateLatestRun(run);
 
-            const testResultUrl = run._links.blueTestSummary && run._links.blueTestSummary.href;
-            if (this.activityService.hasItem(testResultUrl)) {
-                this.activityService.fetchTestSummary(testResultUrl, { useCache: false, disableLoadingIndicator: true });
+                /*
+                    Check to see if the TestSummary has been loaded and if so then reload it. Otherwise don't because
+                    it's expensive to calculate.
+                 */
+
+                const testResultUrl = run._links.blueTestSummary && run._links.blueTestSummary.href;
+                if (this.activityService.hasItem(testResultUrl)) {
+                    this.activityService.fetchTestSummary(testResultUrl, { useCache: false, disableLoadingIndicator: true });
+                }
             }
         });
     }


### PR DESCRIPTION
# Description
This will stop the UI from becoming unresponsive if a run request returns a 404

See [JENKINS-53175](https://issues.jenkins-ci.org/browse/JENKINS-53175).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

