### PR TITLE
Backport fixes to 1.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ node() {
           }
           junit '**/target/surefire-reports/TEST-*.xml'
           junit '**/target/jest-reports/*.xml'
+          jacoco execPattern: '**/target/jacoco.exec', classPattern : '**/target/classes', sourcePattern: '**/src/main/java', exclusionPattern: 'src/test*'
           archive '*/target/code-coverage/**/*'
           archive '*/target/*.hpi'
           archive '*/target/jest-coverage/**/*'

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -121,7 +121,12 @@ public class EditorPage {
     public void saveBranch(String branch) {
         logger.info("saveBranch method called");
         wait.click(By.xpath("//*[text()='Save']"));
+        // In some CI infra, we're getting failures probably half the time. Let's
+        // sleep here as a safeguard.
+        wait.tinySleep(1000);
+        logger.info("wait.until the What Changed textarea appears");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("textarea[placeholder=\"What changed?\"]")));
+        logger.info("Entering commit message into What Changed textarea");
         wait.sendKeys(By.cssSelector("textarea[placeholder=\"What changed?\"]"), "ATH made changes and is saving");
         if(!Strings.isNullOrEmpty(branch)) {
             wait.click(By.xpath("//span[text()='Commit to new branch']"));

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/BitbucketServerTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/BitbucketServerTest.java
@@ -98,13 +98,11 @@ public class BitbucketServerTest implements WebDriverMixin {
         creationPage.clickCreatePipelineButton();
         editorPage.simplePipeline();
         editorPage.saveBranch("master");
-        // This is here so we don't try to close the browser window too fast
-        wait.tinySleep(3000);
         activityPage.checkBasicDomElements();
     }
 
     private void cleanupEndpoint(String endpointUrl) throws IOException {
-        logger.info("--> cleanupEndpoint");
+        logger.info("Calling cleanupEndpoint to remove our Bitbucket server from Jenkins");
         String serverId = DigestUtils.sha256Hex(endpointUrl);
 
         try {
@@ -114,12 +112,12 @@ public class BitbucketServerTest implements WebDriverMixin {
                 .as(Void.class);
             logger.info("found and deleted bitbucket server: " + serverId);
         } catch (Exception ex) {
-            logger.debug("server not found while attempting to delete bitbucket server: " + serverId);
+            logger.debug("server not found while attempting to delete Bitbucket server: " + serverId);
         }
     }
 
     private void cleanupCredentials(String endpointUrl) throws IOException {
-        logger.info("--> cleanupCredentials");
+        logger.info("Calling cleanupCredentials to remove the credentials we used with Bitbucket server");
         String serverId = DigestUtils.sha256Hex(endpointUrl);
         String credentialId = "bitbucket-server:" + serverId;
         jenkins.deleteUserDomainCredential(jenkinsUser.username, "blueocean-bitbucket-server-domain", credentialId);

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -38,25 +38,27 @@ public class HttpResponse {
             if(getStatus() >= 300){
                 ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
                 if (StringUtils.isEmpty(errorMessage.message)) {
-                    String message = "";
+                    String message;;
                     List<ErrorMessage.Error> errors = new ArrayList<>();
                     try {
                         JSONObject jsonResponse = JSONObject.fromObject(IOUtils.toString(entity.getContent()));
                         JSONArray arr = jsonResponse.getJSONArray("errors");
+                        StringBuilder messageBuilder = new StringBuilder();
                         for (int i = 0; i < arr.size(); i++) {
                             JSONObject err = arr.getJSONObject(i);
                             if (i > 0) {
-                                message += ", ";
+                                messageBuilder.append(", ");
                             }
-                            message += err.getString("message");
+                            messageBuilder.append(err.getString("message"));
 
-                            String details = "";
+                            StringBuilder details = new StringBuilder();
                             JSONArray errorDetails = err.getJSONArray("details");
                             for (int detailIdx = 0; detailIdx < errorDetails.size(); detailIdx++) {
-                                details += errorDetails.getString(detailIdx) + "\n";
+                                details.append(errorDetails.getString(detailIdx)).append("\n");
                             }
-                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details));
+                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details.toString()));
                         }
+                        message = messageBuilder.toString();
                     } catch(Exception e) {
                         logger.error("An error occurred getting BitBucket API error content", e);
                         message = "An unknown error was reported from the BitBucket server";

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -37,7 +37,8 @@ public class HttpResponse {
             HttpEntity entity = response.getEntity();
             if(getStatus() >= 300){
                 ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
-                if (StringUtils.isEmpty(errorMessage.message)) {
+                // WireMock returns "Bad Request" for the status message; it's also pretty nondescript
+                if (StringUtils.isEmpty(errorMessage.message) || "Bad Request".equals(errorMessage.message)) {
                     String message;;
                     List<ErrorMessage.Error> errors = new ArrayList<>();
                     try {

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -1,21 +1,31 @@
 package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
 
+import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Vivek Pandey
  */
 @Restricted(NoExternalUse.class)
 public class HttpResponse {
+    private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
     private final org.apache.http.HttpResponse response;
 
     public HttpResponse(org.apache.http.HttpResponse response) {
@@ -26,8 +36,36 @@ public class HttpResponse {
         try {
             HttpEntity entity = response.getEntity();
             if(getStatus() >= 300){
-                EntityUtils.consume(entity);
-                throw new ServiceException(getStatus(), getStatusLine());
+                ErrorMessage errorMessage = new ErrorMessage(getStatus(), getStatusLine());
+                if (StringUtils.isEmpty(errorMessage.message)) {
+                    String message = "";
+                    List<ErrorMessage.Error> errors = new ArrayList<>();
+                    try {
+                        JSONObject jsonResponse = JSONObject.fromObject(IOUtils.toString(entity.getContent()));
+                        JSONArray arr = jsonResponse.getJSONArray("errors");
+                        for (int i = 0; i < arr.size(); i++) {
+                            JSONObject err = arr.getJSONObject(i);
+                            if (i > 0) {
+                                message += ", ";
+                            }
+                            message += err.getString("message");
+
+                            String details = "";
+                            JSONArray errorDetails = err.getJSONArray("details");
+                            for (int detailIdx = 0; detailIdx < errorDetails.size(); detailIdx++) {
+                                details += errorDetails.getString(detailIdx) + "\n";
+                            }
+                            errors.add(new ErrorMessage.Error("", err.getString("exceptionName"), details));
+                        }
+                    } catch(Exception e) {
+                        logger.error("An error occurred getting BitBucket API error content", e);
+                        message = "An unknown error was reported from the BitBucket server";
+                    }
+                    errorMessage = new ErrorMessage(getStatus(), message).addAll(errors);
+                } else {
+                    EntityUtils.consume(entity);
+                }
+                throw new ServiceException(getStatus(), errorMessage, null);
             }
             return entity == null ? null :entity.getContent();
         } catch (IOException e) {

--- a/blueocean-bitbucket-pipeline/src/main/resources/io/jenkins/blueocean/blueocean_bitbucket_pipeline/Messages_zh_CN.properties
+++ b/blueocean-bitbucket-pipeline/src/main/resources/io/jenkins/blueocean/blueocean_bitbucket_pipeline/Messages_zh_CN.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2018, Alauda
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+bbserver.version.validation.error=\u8BE5 Bitbucket \u670D\u52A1\u7248\u672C\u592A\u65E7 ({0}) \u548C Jenkins \u4E0D\u517C\u5BB9\u3002\u8BF7\u5347\u7EA7 Bitbucket \u5230 {1} \u6216\u66F4\u65B0\u3002

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
@@ -146,6 +146,41 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
         fail("Should have failed with PreConditionException");
     }
 
+    @Test
+    public void handleSaveErrorsWithEmptyStatusLine() throws UnirestException, IOException {
+        String credentialId = createCredential(BitbucketServerScm.ID);
+        StaplerRequest staplerRequest = mockStapler();
+        MultiBranchProject mbp = mockMbp(credentialId);
+
+        // /rest/api/1.0/projects/PROJ/repos/with-jenkinsfile/browse/Jenkinsfile
+        GitContent content = new GitContent.Builder().autoCreateBranch(true).base64Data("bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K")
+            .branch("master").message("new commit").owner("TESTP").path("Jenkinsfile").repo("pipeline-demo-test").build();
+
+        when(staplerRequest.bindJSON(Mockito.eq(BitbucketScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new BitbucketScmSaveFileRequest(content));
+
+        String request = "{\n" +
+            "  \"content\" : {\n" +
+            "    \"message\" : \"new commit\",\n" +
+            "    \"path\" : \"Jenkinsfile\",\n" +
+            "    \"branch\" : \"master\",\n" +
+            "    \"repo\" : \"pipeline-demo-test\",\n" +
+            "    \"base64Data\" : " + "\"bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K\"" +
+            "  }\n" +
+            "}";
+
+        when(staplerRequest.getReader()).thenReturn(new BufferedReader(new StringReader(request), request.length()));
+
+        try {
+            // Should get mocked response from:
+            // bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
+            new BitbucketServerScmContentProvider()
+                .saveContent(staplerRequest, mbp);
+        } catch (ServiceException e) {
+            assertEquals("File editing canceled for 'Jenkinsfile' on 'master'.", e.getMessage());
+            return;
+        }
+        fail("Should have failed with message: File editing canceled for 'Jenkinsfile' on 'master'.");
+    }
 
     @Test
     public void updateContent() throws UnirestException, IOException {

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
@@ -152,16 +152,15 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
         StaplerRequest staplerRequest = mockStapler();
         MultiBranchProject mbp = mockMbp(credentialId);
 
-        // /rest/api/1.0/projects/PROJ/repos/with-jenkinsfile/browse/Jenkinsfile
         GitContent content = new GitContent.Builder().autoCreateBranch(true).base64Data("bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K")
-            .branch("master").message("new commit").owner("TESTP").path("Jenkinsfile").repo("pipeline-demo-test").build();
+            .branch("master").message("new commit").owner("TESTP").path("SomeFile").repo("pipeline-demo-test").build();
 
         when(staplerRequest.bindJSON(Mockito.eq(BitbucketScmSaveFileRequest.class), Mockito.any(JSONObject.class))).thenReturn(new BitbucketScmSaveFileRequest(content));
 
         String request = "{\n" +
             "  \"content\" : {\n" +
             "    \"message\" : \"new commit\",\n" +
-            "    \"path\" : \"Jenkinsfile\",\n" +
+            "    \"path\" : \"SomeFile\",\n" +
             "    \"branch\" : \"master\",\n" +
             "    \"repo\" : \"pipeline-demo-test\",\n" +
             "    \"base64Data\" : " + "\"bm9kZXsKICBlY2hvICdoZWxsbyB3b3JsZCEnCn0K\"" +
@@ -172,14 +171,13 @@ public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
 
         try {
             // Should get mocked response from:
-            // bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
-            new BitbucketServerScmContentProvider()
-                .saveContent(staplerRequest, mbp);
+            // bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
+            new BitbucketServerScmContentProvider().saveContent(staplerRequest, mbp);
         } catch (ServiceException e) {
-            assertEquals("File editing canceled for 'Jenkinsfile' on 'master'.", e.getMessage());
+            assertEquals("File editing canceled for 'SomeFile' on 'master'.", e.getMessage());
             return;
         }
-        fail("Should have failed with message: File editing canceled for 'Jenkinsfile' on 'master'.");
+        fail("Should have failed with message: File editing canceled for 'SomeFile' on 'master'.");
     }
 
     @Test

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile-7269cd83-1af6-4134-9161-82360d678dcc.json
@@ -1,0 +1,29 @@
+{
+  "id" : "7269cd83-1af6-4134-9161-82360d678dcc",
+  "name" : "bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile",
+  "request" : {
+    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/Jenkinsfile",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "anything" : "anything"
+    } ]
+  },
+  "response" : {
+    "status" : "400",
+    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'Jenkinsfile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'Jenkinsfile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
+    "headers" : {
+      "X-AREQUESTID" : "@L72CV8x1069x1007x0",
+      "X-AUSERID" : "2",
+      "X-AUSERNAME" : "user",
+      "Cache-Control" : "no-cache, no-transform",
+      "Vary" : "X-AUSERNAME,Accept-Encoding",
+      "X-Content-Type-Options" : "nosniff",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Sun, 19 Aug 2018 21:49:54 GMT",
+      "Connection" : "close"
+    }
+  },
+  "uuid" : "7269cd83-1af6-4134-9161-82360d678dcc",
+  "persistent" : true,
+  "insertionIndex" : 68
+}

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile-7269cd83-1af6-4134-9161-82360d678dcc.json
@@ -1,8 +1,8 @@
 {
   "id" : "7269cd83-1af6-4134-9161-82360d678dcc",
-  "name" : "bitbucket_rest_api_10_projects_proj_repos_with-jenkinsfile_browse_jenkinsfile",
+  "name" : "bitbucket_rest_api_10_projects_testp_repos_pipeline-demo-test_browse_somefile",
   "request" : {
-    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/Jenkinsfile",
+    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/browse/SomeFile",
     "method" : "PUT",
     "bodyPatterns" : [ {
       "anything" : "anything"
@@ -10,7 +10,7 @@
   },
   "response" : {
     "status" : "400",
-    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'Jenkinsfile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'Jenkinsfile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
+    "body" : "{\"errors\":[{\"context\":null,\"message\":\"File editing canceled for 'SomeFile' on 'master'.\",\"exceptionName\":\"com.atlassian.bitbucket.hook.repository.RepositoryHookVetoedException\",\"details\":[\"Branch permissions canceled the editing of 'SomeFile' on 'master'.\",\"Branch refs/heads/master can only be modified through pull requests.\\nCheck your branch permissions configuration with the project administrator.\"],\"trigger\":{\"id\":\"file-edit\",\"abortOnFirstVeto\":false}}]}",
     "headers" : {
       "X-AREQUESTID" : "@L72CV8x1069x1007x0",
       "X-AUSERID" : "2",

--- a/blueocean-core-js/src/js/services/DefaultSSEHandler.js
+++ b/blueocean-core-js/src/js/services/DefaultSSEHandler.js
@@ -156,16 +156,19 @@ export class DefaultSSEHandler {
                     pager.insert(href);
                 }
             }
-            this.pipelineService.updateLatestRun(run);
 
-            /*
-                Check to see if the TestSummary has been loaded and if so then reload it. Otherwise don't because
-                it's expensive to calculate.
-             */
+            if (run) {
+                this.pipelineService.updateLatestRun(run);
 
-            const testResultUrl = run._links.blueTestSummary && run._links.blueTestSummary.href;
-            if (this.activityService.hasItem(testResultUrl)) {
-                this.activityService.fetchTestSummary(testResultUrl, { useCache: false, disableLoadingIndicator: true });
+                /*
+                    Check to see if the TestSummary has been loaded and if so then reload it. Otherwise don't because
+                    it's expensive to calculate.
+                 */
+
+                const testResultUrl = run._links.blueTestSummary && run._links.blueTestSummary.href;
+                if (this.activityService.hasItem(testResultUrl)) {
+                    this.activityService.fetchTestSummary(testResultUrl, { useCache: false, disableLoadingIndicator: true });
+                }
             }
         });
     }

--- a/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
@@ -75,8 +75,11 @@ export class LogConsole extends Component {
     componentWillReceiveProps(nextProps) {
         // eslint-disable-line
         logger.debug('newProps isArray', Array.isArray(nextProps.logArray));
+        if (nextProps.logArray === undefined)
+            return;
+
         // We need a shallow copy of the ObservableArray to "cast" it down to normal array
-        const newArray = nextProps.logArray !== undefined && nextProps.logArray.slice();
+        const newArray = nextProps.logArray.slice();
         const oldArray = this.props.logArray !== undefined && this.props.logArray.slice();
         // if have a new logArray, simply add it to the queue and wait for next tick
         this.queuedLines = this.queuedLines.concat(newArray.slice(oldArray.length));

--- a/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
@@ -75,14 +75,15 @@ export class LogConsole extends Component {
     componentWillReceiveProps(nextProps) {
         // eslint-disable-line
         logger.debug('newProps isArray', Array.isArray(nextProps.logArray));
-        if (nextProps.logArray === undefined)
+        if (nextProps.logArray === undefined) {
             return;
+        }
 
         // We need a shallow copy of the ObservableArray to "cast" it down to normal array
         const newArray = nextProps.logArray.slice();
-        const oldArray = this.props.logArray !== undefined && this.props.logArray.slice();
+        const oldLength = this.props.logArray && this.props.logArray.length || 0;
         // if have a new logArray, simply add it to the queue and wait for next tick
-        this.queuedLines = this.queuedLines.concat(newArray.slice(oldArray.length));
+        this.queuedLines = this.queuedLines.concat(newArray.slice(oldLength));
         clearTimeout(this.timeouts.render);
         this.timeouts.render = setTimeout(() => {
             this._processNextLines();

--- a/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
@@ -21,7 +21,7 @@ export default class TestCaseResultRow extends Component {
 
     render() {
         const { testCase, translation, locale = 'en' } = this.props;
-        const duration = TimeDuration.format(testCase.duration, translation, locale);
+        const duration = TimeDuration.format(testCase.duration * 1000, translation, locale);
         const showTestCase = testCase.errorStackTrace || testCase.errorDetails || testCase.hasStdLog;
         let statusIndicator = null;
         switch (testCase.status) {

--- a/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_zh.properties
+++ b/blueocean-dashboard/src/main/resources/jenkins/plugins/blueocean/dashboard/Messages_zh.properties
@@ -1,311 +1,306 @@
-#历史
-branchdetail.actionbutton.history=\u5386\u53f2
+#\u5386\u53F2
+branchdetail.actionbutton.history=\u5386\u53F2
 # common
 common.date.duration.format=d[d] h[h] m[m] s[s]
 common.date.duration.hint.format=M [month], d [days], h[ hours], m[ minutes], s[ seconds]
 common.date.duration.display.format=d[d] h[h] m[m] s[s]
 common.date.readable.long=MMM DD YYYY h:mma Z
 common.date.readable.short=MMM DD h:mma Z
-#加载中...
-common.pager.loading=\u52a0\u8f7d\u4e2d\u002e\u002e\u002e
-#更多
-common.pager.more=\u66f4\u591a
+#\u52A0\u8F7D\u4E2D...
+common.pager.loading=\u52A0\u8F7D\u4E2D...
+#\u66F4\u591A
+common.pager.more=\u66F4\u591A
 # creation
-#关闭
-creation.core.header.close=\u5173\u95ed
-#创建流水线
-creation.core.header.title=\u521b\u5efa\u6d41\u6c34\u7ebf
-#经典创建方式
-creation.core.header.classic=\u7ecf\u5178\u521b\u5efa\u65b9\u5f0f
-#你没有权限创建Pipelines
-creation.core.intro.invalid_permission_title=\u4f60\u6ca1\u6709\u6743\u9650\u521b\u5efa\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u0073
-#回到Pipelines
-creation.core.intro.invalid_permission_button=\u56de\u5230\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u0073
+#\u5173\u95ED
+creation.core.header.close=\u5173\u95ED
+#\u521B\u5EFA\u6D41\u6C34\u7EBF
+creation.core.header.title=\u521B\u5EFA\u6D41\u6C34\u7EBF
+#\u7ECF\u5178\u521B\u5EFA\u65B9\u5F0F
+creation.core.header.classic=\u7ECF\u5178\u521B\u5EFA\u65B9\u5F0F
+creation.core.intro.invalid_permission_title=\u4F60\u6CA1\u6709\u6743\u9650\u521B\u5EFA\u6D41\u6C34\u7EBF
+#\u56DE\u5230Pipelines
+creation.core.intro.invalid_permission_button=\u56DE\u5230\u6D41\u6C34\u7EBF\u5217\u8868
 creation.core.intro.invalid_security_linkhref=https://wiki.jenkins-ci.org/display/JENKINS/Securing+Jenkins
-#更多
-creation.core.intro.invalid_security_linktext=\u66f4\u591a
-#创建Pipeline需要开启认证
-creation.core.intro.invalid_security_message=\u521b\u5efa\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u9700\u8981\u5f00\u542f\u8ba4\u8bc1
-#关闭Pipeline创建
-creation.core.intro.invalid_security_title=\u5173\u95ed\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u521b\u5efa
-#选择代码仓库
-creation.core.intro.scm_provider=\u9009\u62e9\u4ee3\u7801\u4ed3\u5e93
+#\u66F4\u591A
+creation.core.intro.invalid_security_linktext=\u66F4\u591A
+#\u521B\u5EFAPipeline\u9700\u8981\u5F00\u542F\u8BA4\u8BC1
+creation.core.intro.invalid_security_message=\u521B\u5EFA\u6D41\u6C34\u7EBF\u9700\u8981\u5F00\u542F\u8BA4\u8BC1
+#\u5173\u95EDPipeline\u521B\u5EFA
+creation.core.intro.invalid_security_title=\u5173\u95ED\u6D41\u6C34\u7EBF\u521B\u5EFA
+#\u9009\u62E9\u4EE3\u7801\u4ED3\u5E93
+creation.core.intro.scm_provider=\u9009\u62E9\u4EE3\u7801\u4ED3\u5E93
 # create credential dialog
-#取消
-creation.git.create_credential.button_close=\u53d6\u6d88
-#创建证书
-creation.git.create_credential.button_create=\u521b\u5efa\u8bc1\u4e66
-#创建证书发生错误. 请再尝试一次.
-creation.git.create_credential.error_msg=\u521b\u5efa\u8bc1\u4e66\u53d1\u751f\u9519\u8bef\u002e\u0020\u8bf7\u518d\u5c1d\u8bd5\u4e00\u6b21\u002e
-#证书类型
-creation.git.create_credential.credential_type=\u8bc1\u4e66\u7c7b\u578b
+#\u53D6\u6D88
+creation.git.create_credential.button_close=\u53D6\u6D88
+#\u521B\u5EFA\u8BC1\u4E66
+creation.git.create_credential.button_create=\u521B\u5EFA\u8BC1\u4E66
+#\u521B\u5EFA\u8BC1\u4E66\u53D1\u751F\u9519\u8BEF. \u8BF7\u518D\u5C1D\u8BD5\u4E00\u6B21.
+creation.git.create_credential.error_msg=\u521B\u5EFA\u8BC1\u4E66\u53D1\u751F\u9519\u8BEF\uFF0C\u8BF7\u91CD\u8BD5\u3002
+#\u8BC1\u4E66\u7C7B\u578B
+creation.git.create_credential.credential_type=\u8BC1\u4E66\u7C7B\u578B
 creation.git.create_credential.credential_type_ssh_key=SSH Key
-#用户名和密码
-creation.git.create_credential.credential_type_user_pass=\u7528\u6237\u540d\u548c\u5bc6\u7801
-#请输入一个有效的密码
-creation.git.create_credential.password_error=\u8bf7\u8f93\u5165\u4e00\u4e2a\u6709\u6548\u7684\u5bc6\u7801
-#密码
-creation.git.create_credential.password_title=\u5bc6\u7801
-#请输入一个有效的 SSH 私钥.
-creation.git.create_credential.sshkey_error=\u8bf7\u8f93\u5165\u4e00\u4e2a\u6709\u6548\u7684\u0020\u0053\u0053\u0048\u0020\u79c1\u94a5\u002e
-#SSH 私钥
-creation.git.create_credential.sshkey_title=\u0053\u0053\u0048\u0020\u79c1\u94a5
-#请输入一个有效的用户名
-creation.git.create_credential.username_error=\u8bf7\u8f93\u5165\u4e00\u4e2a\u6709\u6548\u7684\u7528\u6237\u540d
-#用户名
-creation.git.create_credential.username_title=\u7528\u6237\u540d
-#添加证书
-creation.git.create_credential.title=\u6dfb\u52a0\u8bc1\u4e66
+#\u7528\u6237\u540D\u548C\u5BC6\u7801
+creation.git.create_credential.credential_type_user_pass=\u7528\u6237\u540D\u548C\u5BC6\u7801
+#\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684\u5BC6\u7801
+creation.git.create_credential.password_error=\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684\u5BC6\u7801
+#\u5BC6\u7801
+creation.git.create_credential.password_title=\u5BC6\u7801
+#\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684 SSH \u79C1\u94A5.
+creation.git.create_credential.sshkey_error=\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684 SSH \u79C1\u94A5\u3002
+#SSH \u79C1\u94A5
+creation.git.create_credential.sshkey_title=SSH \u79C1\u94A5
+#\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684\u7528\u6237\u540D
+creation.git.create_credential.username_error=\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684\u7528\u6237\u540D
+#\u7528\u6237\u540D
+creation.git.create_credential.username_title=\u7528\u6237\u540D
+#\u6DFB\u52A0\u8BC1\u4E66
+creation.git.create_credential.title=\u6DFB\u52A0\u8BC1\u4E66
 # creation for git
-#创建Pipeline
-creation.git.step1.create_button=\u521b\u5efa\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065
-#正在创建Pipeline...
-creation.git.step1.create_button_progress=\u6b63\u5728\u521b\u5efa\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u002e\u002e\u002e
-#添加
-creation.git.step1.create_credential_button=\u6dfb\u52a0
-#证书
-creation.git.step1.credentials=\u8bc1\u4e66
-#请选择一个有效的证书.
-creation.git.step1.credentials_error_invalid=\u8bf7\u9009\u62e9\u4e00\u4e2a\u6709\u6548\u7684\u8bc1\u4e66\u002e
-creation.git.step1.credentials_placeholder=System Default
-#注意：任何包含Jenkinsfile的仓库将会自动构建
-creation.git.step1.instructions=\u6ce8\u610f\uff1a\u4efb\u4f55\u5305\u542b\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u0066\u0069\u006c\u0065\u7684\u4ed3\u5e93\u5c06\u4f1a\u81ea\u52a8\u6784\u5efa
-#更多Jenkinsfile的介绍.
-creation.git.step1.instructions_link=\u66f4\u591a\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u0066\u0069\u006c\u0065\u7684\u4ecb\u7ecd\u002e
-#请输入一个有效的URL
-creation.git.step1.repo_error_invalid=\u8bf7\u8f93\u5165\u4e00\u4e2a\u6709\u6548\u7684\u0055\u0052\u004c
-#请输入一个URL.
-creation.git.step1.repo_error_required=\u8bf7\u8f93\u5165\u4e00\u4e2a\u0055\u0052\u004c\u002e
-#仓库URL
-creation.git.step1.repo_title=\u4ed3\u5e93\u0055\u0052\u004c
-#连接到Git仓库
-creation.git.step1.title=\u8fde\u63a5\u5230\u0047\u0069\u0074\u4ed3\u5e93
-#保存
-creation.git.step2.button_save=\u4fdd\u5b58
-#执行成功！'{0}'可用
-creation.git.step2.name_available=\u6267\u884c\u6210\u529f\uff01'{0}'\u53ef\u7528
-creation.git.step2.name_required='{0}'\u53ef\u7528. \u9700\u8981\u4e00\u4e2a\u552f\u4e00\u7684\u540d\u5b57.
-creation.git.step2.name_unavailable='{0}'\u4e0d\u53ef\u7528. \u8bf7\u4f7f\u7528\u5176\u4ed6\u540d\u5b57.
-#Pipeline名称
-creation.git.step2.text_name_placeholder=\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u540d\u79f0
-#命名冲突
-creation.git.step2.title=\u547d\u540d\u51b2\u7a81
-#打开
-creation.git.step3.button_open=\u6253\u5f00
-#完成
-creation.git.step3.title_completed=\u5b8c\u6210
-#正在创建Pipeline...
-creation.git.step3.title_pipeline_create=\u6b63\u5728\u521b\u5efa\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u002e\u002e\u002e
+#\u521B\u5EFAPipeline
+creation.git.step1.create_button=\u521B\u5EFA\u6D41\u6C34\u7EBF
+creation.git.step1.create_button_progress=\u6B63\u5728\u521B\u5EFA\u6D41\u6C34\u7EBF...
+#\u6DFB\u52A0
+creation.git.step1.create_credential_button=\u6DFB\u52A0
+#\u8BC1\u4E66
+creation.git.step1.credentials=\u8BC1\u4E66
+#\u8BF7\u9009\u62E9\u4E00\u4E2A\u6709\u6548\u7684\u8BC1\u4E66.
+creation.git.step1.credentials_error_invalid=\u8BF7\u9009\u62E9\u4E00\u4E2A\u6709\u6548\u7684\u8BC1\u4E66\u3002
+creation.git.step1.credentials_placeholder=\u7CFB\u7EDF\u9ED8\u8BA4
+#\u6CE8\u610F\uFF1A\u4EFB\u4F55\u5305\u542BJenkinsfile\u7684\u4ED3\u5E93\u5C06\u4F1A\u81EA\u52A8\u6784\u5EFA
+creation.git.step1.instructions=\u6CE8\u610F\uFF1A\u4EFB\u4F55\u5305\u542B Jenkinsfile \u7684\u4ED3\u5E93\u5C06\u4F1A\u81EA\u52A8\u6784\u5EFA
+#\u66F4\u591AJenkinsfile\u7684\u4ECB\u7ECD.
+creation.git.step1.instructions_link=\u66F4\u591A Jenkinsfile \u7684\u4ECB\u7ECD\u3002
+#\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684URL
+creation.git.step1.repo_error_invalid=\u8BF7\u8F93\u5165\u4E00\u4E2A\u6709\u6548\u7684 URL
+#\u8BF7\u8F93\u5165\u4E00\u4E2AURL.
+creation.git.step1.repo_error_required=\u8BF7\u8F93\u5165\u4E00\u4E2A URL
+#\u4ED3\u5E93URL
+creation.git.step1.repo_title=\u4ED3\u5E93 URL
+#\u8FDE\u63A5\u5230Git\u4ED3\u5E93
+creation.git.step1.title=\u8FDE\u63A5\u5230 Git \u4ED3\u5E93
+#\u4FDD\u5B58
+creation.git.step2.button_save=\u4FDD\u5B58
+#\u6267\u884C\u6210\u529F\uFF01'{0}'\u53EF\u7528
+creation.git.step2.name_available=\u6267\u884C\u6210\u529F\uFF01'{0}'\u53EF\u7528
+creation.git.step2.name_required='{0}'\u53EF\u7528\uFF0C\u9700\u8981\u4E00\u4E2A\u552F\u4E00\u7684\u540D\u79F0\u3002
+creation.git.step2.name_unavailable='{0}'\u4E0D\u53EF\u7528\uFF0C\u8BF7\u4F7F\u7528\u5176\u4ED6\u540D\u79F0\u3002
+creation.git.step2.text_name_placeholder=\u6D41\u6C34\u7EBF\u540D\u79F0
+#\u547D\u540D\u51B2\u7A81
+creation.git.step2.title=\u547D\u540D\u51B2\u7A81
+#\u6253\u5F00
+creation.git.step3.button_open=\u6253\u5F00
+#\u5B8C\u6210
+creation.git.step3.title_completed=\u5B8C\u6210
+#\u6B63\u5728\u521B\u5EFAPipeline...
+creation.git.step3.title_pipeline_create=\u6B63\u5728\u521B\u5EFA\u6D41\u6C34\u7EBF...
 ## github enterprise add server dialog
-#取消
-creation.githubent.add_server.button_cancel=\u53d6\u6d88
-#添加服务
-creation.githubent.add_server.button_create=\u6dfb\u52a0\u670d\u52a1
-#Jenkins需要知道你的GitHub Enterprise 服务器地址.
-creation.githubent.add_server.instructions=\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u9700\u8981\u77e5\u9053\u4f60\u7684\u0047\u0069\u0074\u0048\u0075\u0062\u0020\u0045\u006e\u0074\u0065\u0072\u0070\u0072\u0069\u0073\u0065\u0020\u670d\u52a1\u5668\u5730\u5740\u002e
-#服务地址已存在.
-creation.githubent.add_server.text_name_error_duplicate=\u670d\u52a1\u5730\u5740\u5df2\u5b58\u5728\u002e
-#请输入名字.
-creation.githubent.add_server.text_name_error_required=\u8bf7\u8f93\u5165\u540d\u5b57\u002e
-#我的GitHub服务器
-creation.githubent.add_server.text_name_placeholder=\u6211\u7684\u0047\u0069\u0074\u0048\u0075\u0062\u670d\u52a1\u5668
-#服务名
-creation.githubent.add_server.text_name_title=\u670d\u52a1\u540d
-#URL已经被其他服务使用
-creation.githubent.add_server.text_url_error_duplicate=\u0055\u0052\u004c\u5df2\u7ecf\u88ab\u5176\u4ed6\u670d\u52a1\u4f7f\u7528
-#无法连接到可用的GitHub服务器.
-creation.githubent.add_server.text_url_error_invalid=\u65e0\u6cd5\u8fde\u63a5\u5230\u53ef\u7528\u7684\u0047\u0069\u0074\u0048\u0075\u0062\u670d\u52a1\u5668
-#请输入有效的URL.
-creation.githubent.add_server.text_url_error_required=\u8bf7\u8f93\u5165\u6709\u6548\u7684\u0055\u0052\u004c\u002e
+#\u53D6\u6D88
+creation.githubent.add_server.button_cancel=\u53D6\u6D88
+#\u6DFB\u52A0\u670D\u52A1
+creation.githubent.add_server.button_create=\u6DFB\u52A0\u670D\u52A1
+#Jenkins\u9700\u8981\u77E5\u9053\u4F60\u7684GitHub Enterprise \u670D\u52A1\u5668\u5730\u5740.
+creation.githubent.add_server.instructions=Jenkins \u9700\u8981\u77E5\u9053\u60A8\u7684 GitHub Enterprise \u670D\u52A1\u5668\u5730\u5740\u3002
+#\u670D\u52A1\u5730\u5740\u5DF2\u5B58\u5728.
+creation.githubent.add_server.text_name_error_duplicate=\u670D\u52A1\u5730\u5740\u5DF2\u5B58\u5728\u3002
+#\u8BF7\u8F93\u5165\u540D\u5B57.
+creation.githubent.add_server.text_name_error_required=\u8BF7\u8F93\u5165\u540D\u79F0\u3002
+#\u6211\u7684GitHub\u670D\u52A1\u5668
+creation.githubent.add_server.text_name_placeholder=\u6211\u7684 GitHub \u670D\u52A1\u5668
+#\u670D\u52A1\u540D
+creation.githubent.add_server.text_name_title=\u670D\u52A1\u540D
+#URL\u5DF2\u7ECF\u88AB\u5176\u4ED6\u670D\u52A1\u4F7F\u7528
+creation.githubent.add_server.text_url_error_duplicate=URL \u5DF2\u7ECF\u88AB\u5176\u4ED6\u670D\u52A1\u4F7F\u7528
+creation.githubent.add_server.text_url_error_invalid=\u65E0\u6CD5\u8FDE\u63A5\u5230\u53EF\u7528\u7684 Github \u670D\u52A1\u5668
+#\u8BF7\u8F93\u5165\u6709\u6548\u7684URL.
+creation.githubent.add_server.text_url_error_required=\u8BF7\u8F93\u5165\u6709\u6548\u7684 URL
 creation.githubent.add_server.text_url_placeholder=https://github.example.com
-creation.githubent.add_server.text_url_title=Server URL
-#添加GitHub服务器
-creation.githubent.add_server.title=\u6dfb\u52a0\u0047\u0069\u0074\u0048\u0075\u0062\u670d\u52a1\u5668
-## github enterprise 创建流程
-#添加
-creation.githubent.choose_server.button_add=\u6dfb\u52a0
-#下一步
-creation.githubent.choose_server.button_next=\u4e0b\u4e00\u6b65
-#Jenkins需要知道你的GitHub Enterprise server地址.
-creation.githubent.choose_server.instructions=\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u9700\u8981\u77e5\u9053\u4f60\u7684\u0047\u0069\u0074\u0048\u0075\u0062\u0020\u0045\u006e\u0074\u0065\u0072\u0070\u0072\u0069\u0073\u0065\u0020\u0073\u0065\u0072\u0076\u0065\u0072\u5730\u5740\u002e
-#你的GitHub Server在哪?
-creation.githubent.choose_server.title=\u4f60\u7684\u0047\u0069\u0074\u0048\u0075\u0062\u670d\u52a1\u5668\u5728\u54ea\u003f
+creation.githubent.add_server.text_url_title=\u670D\u52A1\u5730\u5740
+creation.githubent.add_server.title=\u6DFB\u52A0 Github \u670D\u52A1\u5668
+## github enterprise \u521B\u5EFA\u6D41\u7A0B
+#\u6DFB\u52A0
+creation.githubent.choose_server.button_add=\u6DFB\u52A0
+#\u4E0B\u4E00\u6B65
+creation.githubent.choose_server.button_next=\u4E0B\u4E00\u6B65
+#Jenkins\u9700\u8981\u77E5\u9053\u4F60\u7684GitHub Enterprise server\u5730\u5740.
+creation.githubent.choose_server.instructions=Jenkins \u9700\u8981\u77E5\u9053\u60A8\u7684 GitHub Enterprise Server \u5730\u5740\u3002
+#\u4F60\u7684GitHub Server\u5728\u54EA?
+creation.githubent.choose_server.title=\u60A8\u7684 GitHub \u670D\u52A1\u5668\u5728\u54EA?
 
-#开关
-enable=\u5f00\u5173
+#\u5F00\u5173
+enable=\u5F00\u5173
 # home page / dashboard
-#创建流水线
-home.header.button.createpipeline=\u521b\u5efa\u6d41\u6c34\u7ebf
-#流水线
-home.header.dashboard=\u6d41\u6c34\u7ebf
-#分支
-home.pipelineslist.header.branches=\u5206\u652f
-#健康状态
-home.pipelineslist.header.health=\u5065\u5eb7\u72b6\u6001
-#名称
-home.pipelineslist.header.name=\u540d\u79f0
+#\u521B\u5EFA\u6D41\u6C34\u7EBF
+home.header.button.createpipeline=\u521B\u5EFA\u6D41\u6C34\u7EBF
+#\u6D41\u6C34\u7EBF
+home.header.dashboard=\u6D41\u6C34\u7EBF
+#\u5206\u652F
+home.pipelineslist.header.branches=\u5206\u652F
+#\u5065\u5EB7\u72B6\u6001
+home.pipelineslist.header.health=\u5065\u5EB7\u72B6\u6001
+#\u540D\u79F0
+home.pipelineslist.header.name=\u540D\u79F0
 home.pipelineslist.header.pullrequests=PR
-home.pipelinesernatlist.row.failing={0} \u5931\u8d25
-home.pipelineslist.row.passing={0} \u901a\u8fc7
-#创建新的Pipeline
-home.placeholder.linktext=\u521b\u5efa\u65b0\u7684\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065
-#请创建你的第一个Pipeline.
-home.placeholder.message=\u8bf7\u521b\u5efa\u4f60\u7684\u7b2c\u4e00\u4e2a\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u002e
-#欢迎来到Jenkins
-home.placeholder.title=\u6b22\u8fce\u6765\u5230\u004a\u0065\u006e\u006b\u0069\u006e\u0073
-#打开Pipelines
-Open.dashboard=\u6253\u5f00\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u0073
+home.pipelinesernatlist.row.failing={0} \u4E2A\u5931\u8D25
+home.pipelineslist.row.passing={0} \u4E2A\u901A\u8FC7
+#\u521B\u5EFA\u65B0\u7684Pipeline
+home.placeholder.linktext=\u521B\u5EFA\u65B0\u7684\u6D41\u6C34\u7EBF
+#\u8BF7\u521B\u5EFA\u4F60\u7684\u7B2C\u4E00\u4E2APipeline.
+home.placeholder.message=\u8BF7\u521B\u5EFA\u4F60\u7684\u7B2C\u4E00\u4E2A\u6D41\u6C34\u7EBF\u3002
+#\u6B22\u8FCE\u6765\u5230Jenkins
+home.placeholder.title=\u6B22\u8FCE\u6765\u5230 Jenkins
+#\u6253\u5F00Pipelines
+Open.dashboard=\u6253\u5F00\u6D41\u6C34\u7EBF
 # pipeline details
-#立刻运行
-pipelinedetail.activity.button.run=\u7acb\u523b\u8fd0\u884c
-pipelinedetail.activity.header.branch=\u5206\u652f
-pipelinedetail.activity.header.run=\u8fd0\u884c
-pipelinedetail.activity.header.commit=\u63d0\u4ea4
-pipelinedetail.activity.header.completed=\u5b8c\u6210
-#持续时间
-pipelinedetail.activity.header.duration=\u6301\u7eed\u65f6\u95f4
-pipelinedetail.activity.header.message=\u6d88\u606f
-pipelinedetail.activity.header.status=\u72b6\u6001
-pipelinedetail.branches.header.branch=\u5206\u652f
-pipelinedetail.branches.header.commit=\u63d0\u4ea4
-pipelinedetail.branches.header.completed=\u5b8c\u6210
-pipelinedetail.branches.header.health=\u5065\u5eb7\u72b6\u6001
-pipelinedetail.branches.header.message=\u6700\u8fd1\u4e00\u6b21\u6d88\u606f
-pipelinedetail.branches.header.status=\u72b6\u6001
-pipelinedetail.common.tab.activity=\u6d3b\u52a8
-pipelinedetail.common.tab.branches=\u5206\u652f
-pipelinedetail.common.tab.pullrequests=\u0050\u0075\u006c\u006c\u0020\u0052\u0065\u0071\u0075\u0065\u0073\u0074\u0073
+#\u7ACB\u523B\u8FD0\u884C
+pipelinedetail.activity.button.run=\u7ACB\u523B\u8FD0\u884C
+pipelinedetail.activity.header.branch=\u5206\u652F
+pipelinedetail.activity.header.run=\u8FD0\u884C
+pipelinedetail.activity.header.commit=\u63D0\u4EA4
+pipelinedetail.activity.header.completed=\u5B8C\u6210
+#\u6301\u7EED\u65F6\u95F4
+pipelinedetail.activity.header.duration=\u6301\u7EED\u65F6\u95F4
+pipelinedetail.activity.header.message=\u6D88\u606F
+pipelinedetail.activity.header.status=\u72B6\u6001
+pipelinedetail.branches.header.branch=\u5206\u652F
+pipelinedetail.branches.header.commit=\u63D0\u4EA4
+pipelinedetail.branches.header.completed=\u5B8C\u6210
+pipelinedetail.branches.header.health=\u5065\u5EB7\u72B6\u6001
+pipelinedetail.branches.header.message=\u6700\u8FD1\u4E00\u6B21\u6D88\u606F
+pipelinedetail.branches.header.status=\u72B6\u6001
+pipelinedetail.common.tab.activity=\u6D3B\u52A8
+pipelinedetail.common.tab.branches=\u5206\u652F
+pipelinedetail.common.tab.pullrequests=Pull Requests
 pipelinedetail.placeholder.nobranches.linkhref=https://jenkins.io/doc/
-#更多
-pipelinedetail.placeholder.nobranches.linktext=\u66f4\u591a
-#Jenkinsfile是用来定义你的代码仓库和描述Pipeline如何工作的
-pipelinedetail.placeholder.nobranches.message=\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u0066\u0069\u006c\u0065\u662f\u7528\u6765\u5b9a\u4e49\u4f60\u7684\u4ee3\u7801\u4ed3\u5e93\u548c\u63cf\u8ff0\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u5982\u4f55\u5de5\u4f5c\u7684
-#所有的代码分支都没有包含Jenkinsfile
-pipelinedetail.placeholder.nobranches.title=\u6240\u6709\u7684\u4ee3\u7801\u5206\u652f\u90fd\u6ca1\u6709\u5305\u542b\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u0066\u0069\u006c\u0065
-#没有任何正在进行的 Pull Requests
-pipelinedetail.placeholder.nopullrequests.title=\u6ca1\u6709\u4efb\u4f55\u6b63\u5728\u8fdb\u884c\u7684\u0020\u0050\u0075\u006c\u006c\u0020\u0052\u0065\u0071\u0075\u0065\u0073\u0074\u0073
-#这个Pipeline还未运行. 请运行某一个分支
-pipelinedetail.placeholder.noruns.multibranch.branches_title=\u8fd9\u4e2a\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u8fd8\u672a\u8fd0\u884c\u002e\u0020\u8bf7\u8fd0\u884c\u67d0\u4e00\u4e2a\u5206\u652f
-#显示branches
-pipelinedetail.placeholder.noruns.multibranch.branches_linktext=\u663e\u793a\u0062\u0072\u0061\u006e\u0063\u0068\u0065\u0073
-#没有运行中的任务 '{0}'
-pipelinedetail.placeholder.noruns.multibranch.noruns_title=\u6ca1\u6709\u8fd0\u884c\u4e2d\u7684\u4efb\u52a1 '{0}'
-#这个任务还未运行
-pipelinedetail.placeholder.noruns.default.title=\u8fd9\u4e2a\u4efb\u52a1\u8fd8\u672a\u8fd0\u884c
+#\u66F4\u591A
+pipelinedetail.placeholder.nobranches.linktext=\u66F4\u591A
+#Jenkinsfile\u662F\u7528\u6765\u5B9A\u4E49\u4F60\u7684\u4EE3\u7801\u4ED3\u5E93\u548C\u63CF\u8FF0Pipeline\u5982\u4F55\u5DE5\u4F5C\u7684
+pipelinedetail.placeholder.nobranches.message=Jenkinsfile \u662F\u7528\u6765\u5B9A\u4E49\u4F60\u7684\u4EE3\u7801\u4ED3\u5E93\u548C\u63CF\u8FF0\u6D41\u6C34\u7EBF\u662F\u5982\u4F55\u5DE5\u4F5C\u7684
+#\u6240\u6709\u7684\u4EE3\u7801\u5206\u652F\u90FD\u6CA1\u6709\u5305\u542BJenkinsfile
+pipelinedetail.placeholder.nobranches.title=\u6240\u6709\u7684\u4EE3\u7801\u5206\u652F\u90FD\u6CA1\u6709\u5305\u542B Jenkinsfile
+#\u6CA1\u6709\u4EFB\u4F55\u6B63\u5728\u8FDB\u884C\u7684 Pull Requests
+pipelinedetail.placeholder.nopullrequests.title=\u6CA1\u6709\u4EFB\u4F55\u6B63\u5728\u8FD0\u884C\u7684 Pull Requests
+#\u8FD9\u4E2APipeline\u8FD8\u672A\u8FD0\u884C. \u8BF7\u8FD0\u884C\u67D0\u4E00\u4E2A\u5206\u652F
+pipelinedetail.placeholder.noruns.multibranch.branches_title=\u8FD9\u4E2APipeline\u8FD8\u672A\u8FD0\u884C.\u0020\u8BF7\u8FD0\u884C\u67D0\u4E00\u4E2A\u5206\u652F
+#\u663E\u793Abranches
+pipelinedetail.placeholder.noruns.multibranch.branches_linktext=\u663E\u793A\u5206\u652F
+#\u6CA1\u6709\u8FD0\u884C\u4E2D\u7684\u4EFB\u52A1 '{0}'
+pipelinedetail.placeholder.noruns.multibranch.noruns_title=\u6CA1\u6709\u8FD0\u884C\u4E2D\u7684\u4EFB\u52A1 '{0}'
+#\u8FD9\u4E2A\u4EFB\u52A1\u8FD8\u672A\u8FD0\u884C
+pipelinedetail.placeholder.noruns.default.title=\u8BE5\u4EFB\u52A1\u8FD8\u672A\u8FD0\u884C
 pipelinedetail.placeholder.unsupported.branches.linkhref=https://jenkins.io/doc/
-#更多
-pipelinedetail.placeholder.unsupported.branches.linktext=\u66f4\u591a
-#Branch runs只能运行在Multibranch Pipeline job类型下.
-pipelinedetail.placeholder.unsupported.branches.message=\u0042\u0072\u0061\u006e\u0063\u0068\u0020\u0072\u0075\u006e\u0073\u53ea\u80fd\u8fd0\u884c\u5728\u004d\u0075\u006c\u0074\u0069\u0062\u0072\u0061\u006e\u0063\u0068\u0020\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u0020\u006a\u006f\u0062\u7c7b\u578b\u4e0b\u002e
-#Branches不支持
-pipelinedetail.placeholder.unsupported.branches.title=\u0042\u0072\u0061\u006e\u0063\u0068\u0065\u0073\u4e0d\u652f\u6301
+#\u66F4\u591A
+pipelinedetail.placeholder.unsupported.branches.linktext=\u66F4\u591A
+#Branch runs\u53EA\u80FD\u8FD0\u884C\u5728Multibranch Pipeline job\u7C7B\u578B\u4E0B.
+pipelinedetail.placeholder.unsupported.branches.message=\u53EA\u6709\u591A\u5206\u652F\u7684\u6D41\u6C34\u7EBF\u4E2D\u624D\u6709\u5206\u652F\u3002
+#Branches\u4E0D\u652F\u6301
+pipelinedetail.placeholder.unsupported.branches.title=\u4E0D\u652F\u6301\u5206\u652F
 pipelinedetail.placeholder.unsupported.pullrequests.linkhref=https://jenkins.io/doc/
-#更多
-pipelinedetail.placeholder.unsupported.pullrequests.linktext=\u66f4\u591a
-#Pull request只能运行在Multibranch Pipeline job类型.
-pipelinedetail.placeholder.unsupported.pullrequests.message=\u0050\u0075\u006c\u006c\u0020\u0072\u0065\u0071\u0075\u0065\u0073\u0074\u53ea\u80fd\u8fd0\u884c\u5728\u004d\u0075\u006c\u0074\u0069\u0062\u0072\u0061\u006e\u0063\u0068\u0020\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u0020\u006a\u006f\u0062\u7c7b\u578b\u002e
-#不支持Pull请求
-pipelinedetail.placeholder.unsupported.pullrequests.title=\u4e0d\u652f\u6301\u0050\u0075\u006c\u006c\u8bf7\u6c42
-pipelinedetail.pullrequests.header.author=\u4f5c\u8005
+#\u66F4\u591A
+pipelinedetail.placeholder.unsupported.pullrequests.linktext=\u66F4\u591A
+#Pull request\u53EA\u80FD\u8FD0\u884C\u5728Multibranch Pipeline job\u7C7B\u578B.
+pipelinedetail.placeholder.unsupported.pullrequests.message=\u53EA\u6709\u591A\u5206\u652F\u7684\u6D41\u6C34\u7EBF\u4E2D\u624D\u6709 Pull Requests
+#\u4E0D\u652F\u6301Pull\u8BF7\u6C42
+pipelinedetail.placeholder.unsupported.pullrequests.title=\u4E0D\u652F\u6301 Pull Requests
+pipelinedetail.pullrequests.header.author=\u4F5C\u8005
 pipelinedetail.pullrequests.header.run=PR
-pipelinedetail.pullrequests.header.completed=\u5b8c\u6210
-pipelinedetail.pullrequests.header.status=\u72b6\u6001
+pipelinedetail.pullrequests.header.completed=\u5B8C\u6210
+pipelinedetail.pullrequests.header.status=\u72B6\u6001
 pipelinedetail.pullrequests.header.summary=\u6982\u8981
 #run details
-#下载artifact
-rundetail.artifacts.button.download=\u4e0b\u8f7d\u0061\u0072\u0074\u0069\u0066\u0061\u0063\u0074
-#打开artifact
-rundetail.artifacts.button.open=\u6253\u5f00\u0061\u0072\u0074\u0069\u0066\u0061\u0063\u0074
-#全部下载
-rundetail.artifacts.button.downloadAll.text=\u5168\u90e8\u4e0b\u8f7d
-#所有artifact以zip下载
-rundetail.artifacts.button.downloadAll.title=\u6240\u6709\u0061\u0072\u0074\u0069\u0066\u0061\u0063\u0074\u4ee5\u007a\u0069\u0070\u4e0b\u8f7d
-rundetail.artifacts.header.name=\u540d\u5b57
-#规模
-rundetail.artifacts.header.size=\u89c4\u6a21
-#显示100 artifacts
-rundetail.artifacts.limit_title=\u663e\u793a\u0031\u0030\u0030\u0020\u0061\u0072\u0074\u0069\u0066\u0061\u0063\u0074\u0073
-#点击"全部下载"按钮来获取所有 artifacts.
-rundetail.artifacts.limit_message=\u70b9\u51fb\u0026\u0071\u0075\u006f\u0074\u003b\u5168\u90e8\u4e0b\u8f7d\u0026\u0071\u0075\u006f\u0074\u003b\u6309\u94ae\u6765\u83b7\u53d6\u6240\u6709\u0020\u0061\u0072\u0074\u0069\u0066\u0061\u0063\u0074\u0073\u002e
-rundetail.changes.header.author=\u4f5c\u8005
-rundetail.changes.header.commit=\u63d0\u4ea4
-rundetail.changes.header.date=\u65e5\u671f
-rundetail.changes.header.message=\u6d88\u606f
-#没有变更应用于本次运行
-rundetail.changes.placeholder.title=\u6ca1\u6709\u53d8\u66f4\u5e94\u7528\u4e8e\u672c\u6b21\u8fd0\u884c
-rundetail.header.branch=\u5206\u652f
-#{0} 次修改
-rundetail.header.changes.count={0} \u6b21\u4fee\u6539
-#修改人 {0}
-rundetail.header.changes.names=\u4fee\u6539\u4eba {0}
-#没有修改
-rundetail.header.changes.none=\u6ca1\u6709\u4fee\u6539
-rundetail.header.commit=\u63d0\u4ea4
-rundetail.header.tab.artifacts=\u0041\u0072\u0074\u0069\u0066\u0061\u0063\u0074\u0073
-rundetail.header.tab.changes=\u6539\u53d8
-#流水线
-rundetail.header.tab.pipeline=\u6d41\u6c34\u7ebf
-rundetail.header.tab.tests=\u6d4b\u8bd5
-rundetail.input.cancel=\u7ec8\u6b62
-rundetail.pipeline.description=\u63cf\u8ff0
-rundetail.pipeline.logs=\u65e5\u5fd7
-#没有steps
-rundetail.pipeline.nosteps.message.title=\u6ca1\u6709\u0073\u0074\u0065\u0070\u0073
-#这个stage没有steps
-rundetail.pipeline.nosteps.message.description=\u8fd9\u4e2a\u0073\u0074\u0061\u0067\u0065\u6ca1\u6709\u0073\u0074\u0065\u0070\u0073
-#排队中
-rundetail.pipeline.waiting.message.title=\u6392\u961f\u4e2d
-#等待运行开始
-rundetail.pipeline.waiting.message.description=\u7b49\u5f85\u8fd0\u884c\u5f00\u59cb
-#加载中
-rundetail.pipeline.pending.message.title=\u52a0\u8f7d\u4e2d
+#\u4E0B\u8F7Dartifact
+rundetail.artifacts.button.download=\u4E0B\u8F7D\u5236\u54C1
+#\u6253\u5F00artifact
+rundetail.artifacts.button.open=\u6253\u5F00\u5236\u54C1
+#\u5168\u90E8\u4E0B\u8F7D
+rundetail.artifacts.button.downloadAll.text=\u5168\u90E8\u4E0B\u8F7D
+#\u6240\u6709artifact\u4EE5zip\u4E0B\u8F7D
+rundetail.artifacts.button.downloadAll.title=\u6240\u6709\u5236\u54C1\u4EE5 zip \u683C\u5F0F\u4E0B\u8F7D
+rundetail.artifacts.header.name=\u540D\u79F0
+rundetail.artifacts.header.size=\u5927\u5C0F
+#\u663E\u793A100 artifacts
+rundetail.artifacts.limit_title=\u663E\u793A 100 \u4E2A\u5236\u54C1
+#\u70B9\u51FB"\u5168\u90E8\u4E0B\u8F7D"\u6309\u94AE\u6765\u83B7\u53D6\u6240\u6709 artifacts.
+rundetail.artifacts.limit_message=\u70B9\u51FB&quot;\u5168\u90E8\u4E0B\u8F7D&quot;\u6309\u94AE\u6765\u83B7\u53D6\u6240\u6709\u0020artifacts.
+rundetail.changes.header.author=\u4F5C\u8005
+rundetail.changes.header.commit=\u63D0\u4EA4
+rundetail.changes.header.date=\u65E5\u671F
+rundetail.changes.header.message=\u6D88\u606F
+#\u6CA1\u6709\u53D8\u66F4\u5E94\u7528\u4E8E\u672C\u6B21\u8FD0\u884C
+rundetail.changes.placeholder.title=\u8FD9\u6B21\u8FD0\u884C\u6CA1\u6709\u53D8\u66F4
+rundetail.header.branch=\u5206\u652F
+#{0} \u6B21\u4FEE\u6539
+rundetail.header.changes.count={0} \u6B21\u4FEE\u6539
+#\u4FEE\u6539\u4EBA {0}
+rundetail.header.changes.names=\u4FEE\u6539\u4EBA {0}
+#\u6CA1\u6709\u4FEE\u6539
+rundetail.header.changes.none=\u6CA1\u6709\u4FEE\u6539
+rundetail.header.commit=\u63D0\u4EA4
+rundetail.header.tab.artifacts=\u5236\u54C1
+rundetail.header.tab.changes=\u6539\u53D8
+#\u6D41\u6C34\u7EBF
+rundetail.header.tab.pipeline=\u6D41\u6C34\u7EBF
+rundetail.header.tab.tests=\u6D4B\u8BD5
+rundetail.input.cancel=\u7EC8\u6B62
+rundetail.pipeline.description=\u63CF\u8FF0
+rundetail.pipeline.logs=\u65E5\u5FD7
+#\u6CA1\u6709steps
+rundetail.pipeline.nosteps.message.title=\u6CA1\u6709\u6B65\u9AA4
+#\u8FD9\u4E2Astage\u6CA1\u6709steps
+rundetail.pipeline.nosteps.message.description=\u8BE5\u9636\u6BB5\u6CA1\u6709\u6B65\u9AA4
+#\u6392\u961F\u4E2D
+rundetail.pipeline.waiting.message.title=\u6392\u961F\u4E2D
+#\u7B49\u5F85\u8FD0\u884C\u5F00\u59CB
+rundetail.pipeline.waiting.message.description=\u7B49\u5F85\u8FD0\u884C\u5F00\u59CB
+#\u52A0\u8F7D\u4E2D
+rundetail.pipeline.pending.message.title=\u52A0\u8F7D\u4E2D
 rundetail.pipeline.pending.message.description=
-rundetail.pipeline.steps=\u0053\u0074\u0065\u0070\u0073 {0}
-rundetail.tests.duration=\u6301\u7eed\u65f6\u95f4 {0}
-rundetail.tests.failed=\u5931\u8d25 {0}
-rundetail.tests.passed=\u901a\u8fc7 {0}
-rundetail.tests.results.fixed=\u4fee\u590d {0}
+rundetail.pipeline.steps=\u6B65\u9AA4 {0}
+rundetail.tests.duration=\u6301\u7EED\u65F6\u95F4 {0}
+rundetail.tests.failed=\u5931\u8D25\u4E2A\u6570 {0}
+rundetail.tests.passed=\u901A\u8FC7\u4E2A\u6570 {0}
+rundetail.tests.results.fixed=\u4FEE\u590D {0}
 rundetail.tests.results.empty.linkhref=https://jenkins.io/doc/pipeline/tour/tests-and-artifacts/
-#更多
-rundetail.tests.results.empty.linktext=\u66f4\u591a
-#这次运行没有测试存档
-rundetail.tests.results.empty.title=\u8fd9\u6b21\u8fd0\u884c\u6ca1\u6709\u6d4b\u8bd5\u5b58\u6863
-rundetail.tests.results.error.message=\u9519\u8bef
-rundetail.tests.results.error.output=\u6808\u8ddf\u8e2a
-rundetail.tests.results.error.stdout=\u6807\u51c6\u8f93\u51fa
-rundetail.tests.results.error.stderr=\u6807\u51c6\u9519\u8bef
-#已有故障
-rundetail.tests.results.errors.existing.count=\u5df2\u6709\u6545\u969c - {0}
-#新的故障
-rundetail.tests.results.errors.new.count=\u65b0\u7684\u6545\u969c - {0}
-#测试全部通过
-rundetail.tests.results.passing.all=\u6d4b\u8bd5\u5168\u90e8\u901a\u8fc7
-#对本pipeline的所有{0}项测试均已通过
-rundetail.tests.results.passing.count=\u5bf9\u672c\u0070\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u7684\u6240\u6709{0}\u9879\u6d4b\u8bd5\u5747\u5df2\u901a\u8fc7
-#跳过
-rundetail.tests.results.skipped.count=\u8df3\u8fc7 - {0}
-rundetail.tests.results.summary.failing_message={0} \u8fd9\u4e9b\u65b0\u7684\u6d4b\u8bd5\u5931\u8d25\u4e86\u002c {1} \u5df2\u5b58\u5728\u7684\u5931\u8d25\u002c {2} \u8df3\u8fc7.
-#{0} 这些测试失败
-rundetail.tests.results.summary.failing_title={0} \u8fd9\u4e9b\u6d4b\u8bd5\u5931\u8d25
-#这次运行修补了 {0} 测试并且所有对Pipeline的测试 {1} 全部通
-rundetail.tests.results.summary.passing_after_fixes_message=\u8fd9\u6b21\u8fd0\u884c\u4fee\u8865\u4e86 {0} \u6d4b\u8bd5\u5e76\u4e14\u6240\u6709\u5bf9\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u7684\u6d4b\u8bd5 {1} \u5168\u90e8\u901a\u0020 
-#测试全部通过
-rundetail.tests.results.summary.passing_after_fixes_title=\u6d4b\u8bd5\u5168\u90e8\u901a\u8fc7
-#{0} 所有这些测试对Pipeline已通过
-rundetail.tests.results.summary.passing_message={0} \u6240\u6709\u8fd9\u4e9b\u6d4b\u8bd5\u5bf9\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u5df2\u901a\u8fc7
-#测试全部通过
-rundetail.tests.results.summary.passing_title=\u6d4b\u8bd5\u5168\u90e8\u901a\u8fc7
+#\u66F4\u591A
+rundetail.tests.results.empty.linktext=\u67E5\u770B\u66F4\u591A
+#\u8FD9\u6B21\u8FD0\u884C\u6CA1\u6709\u6D4B\u8BD5\u5B58\u6863
+rundetail.tests.results.empty.title=\u8FD9\u6B21\u8FD0\u884C\u6CA1\u6709\u6D4B\u8BD5\u5B58\u6863
+rundetail.tests.results.error.message=\u9519\u8BEF
+rundetail.tests.results.error.output=\u6808\u8DDF\u8E2A
+rundetail.tests.results.error.stdout=\u6807\u51C6\u8F93\u51FA
+rundetail.tests.results.error.stderr=\u6807\u51C6\u9519\u8BEF
+#\u5DF2\u6709\u6545\u969C
+rundetail.tests.results.errors.existing.count=\u5DF2\u6709\u6545\u969C - {0}
+#\u65B0\u7684\u6545\u969C
+rundetail.tests.results.errors.new.count=\u65B0\u7684\u6545\u969C - {0}
+rundetail.tests.results.passed.count=\u901A\u8FC7\u6570 - {0}
+#\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+rundetail.tests.results.passing.all=\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+#\u5BF9\u672Cpipeline\u7684\u6240\u6709{0}\u9879\u6D4B\u8BD5\u5747\u5DF2\u901A\u8FC7
+rundetail.tests.results.passing.count=\u8BE5\u6D41\u6C34\u7EBF\u7684 {0} \u6D4B\u8BD5\u7528\u4F8B\u5168\u90E8\u901A\u8FC7
+#\u8DF3\u8FC7
+rundetail.tests.results.skipped.count=\u8DF3\u8FC7 - {0}
+rundetail.tests.results.summary.failing_message={0} \u4E2A\u65B0\u7684\u6D4B\u8BD5\u5931\u8D25\u4E86, {1} \u4E2A\u5DF2\u5B58\u5728\u7684\u5931\u8D25, {2} \u4E2A\u8DF3\u8FC7\u3002
+#{0} \u8FD9\u4E9B\u6D4B\u8BD5\u5931\u8D25
+rundetail.tests.results.summary.failing_title={0} \u8FD9\u4E9B\u6D4B\u8BD5\u5931\u8D25
+#\u8FD9\u6B21\u8FD0\u884C\u4FEE\u8865\u4E86 {0} \u6D4B\u8BD5\u5E76\u4E14\u6240\u6709\u5BF9Pipeline\u7684\u6D4B\u8BD5 {1} \u5168\u90E8\u901A
+rundetail.tests.results.summary.passing_after_fixes_message=\u8FD9\u6B21\u8FD0\u884C\u4FEE\u590D\u4E86 {0} \u4E2A\u6D4B\u8BD5\uFF0C\u5E76\u4E14\uFF0C\u6D41\u6C34\u7EBF\u7684\u6240\u6709\u6D4B\u8BD5 {1} \u5168\u90E8\u901A\u8FC7
+#\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+rundetail.tests.results.summary.passing_after_fixes_title=\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+#{0} \u6240\u6709\u8FD9\u4E9B\u6D4B\u8BD5\u5BF9Pipeline\u5DF2\u901A\u8FC7
+rundetail.tests.results.summary.passing_message=\u5F88\u597D\uFF01\u8BE5\u6D41\u6C34\u7EBF\u7684\u6240\u6709\u6D4B\u8BD5 {0} \u90FD\u901A\u8FC7\u4E86\u3002
+#\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+rundetail.tests.results.summary.passing_title=\u6D4B\u8BD5\u5168\u90E8\u901A\u8FC7
+rundetail.logToolbar.restartStage=\u91CD\u542F {0}
 # server error display
-#错误码
-servererror.errors.code=\u9519\u8bef\u7801: {0}
-servererror.errors.field=\u0046\u0069\u0065\u006c\u0064: {0}
-servererror.errors.message=\u9519\u8bef\u4fe1\u606f: {0}
-servererror.message=\u9519\u8bef\u4fe1\u606f: {0}
-#发生未知错误. 请再尝试.
-servererror.title=\u53d1\u751f\u672a\u77e5\u9519\u8bef\u002e\u0020\u8bf7\u518d\u5c1d\u8bd5\u002e
-#显示完整日志
-Show.complete.logs=\u663e\u793a\u5b8c\u6574\u65e5\u5fd7
-#这个Pipeline不支持这种输入. \n使用[Jenkins Classic]({0}) 去解决这个input step.
-inputStep.error.message=\u8fd9\u4e2a\u0050\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u4e0d\u652f\u6301\u8fd9\u79cd\u8f93\u5165\u002e\u0020\u005c\u006e\u4f7f\u7528\u005b\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u0020\u0043\u006c\u0061\u0073\u0073\u0069\u0063\u005d\u0028{0}\u0029\u0020\u53bb\u89e3\u51b3\u8fd9\u4e2a\u0069\u006e\u0070\u0075\u0074\u0020\u0073\u0074\u0065\u0070\u002e
-inputStep.error.title=\u9519\u8bef
-lozenge.commit={0} \u0063\u006f\u006d\u006d\u0069\u0074\u0073
+#\u9519\u8BEF\u7801
+servererror.errors.code=\u9519\u8BEF\u7801\uFF1A{0}
+servererror.errors.field=\u5B57\u6BB5\uFF1A{0}
+servererror.errors.message=\u9519\u8BEF\u4FE1\u606F: {0}
+servererror.message=\u9519\u8BEF\u4FE1\u606F: {0}
+#\u53D1\u751F\u672A\u77E5\u9519\u8BEF. \u8BF7\u518D\u5C1D\u8BD5.
+servererror.title=\u53D1\u751F\u672A\u77E5\u9519\u8BEF\u3002\u8BF7\u91CD\u8BD5\u3002
+#\u663E\u793A\u5B8C\u6574\u65E5\u5FD7
+Show.complete.logs=\u663E\u793A\u5B8C\u6574\u65E5\u5FD7
+inputStep.error.message=\u8BE5\u6D41\u6C34\u7EBF\u4E0D\u652F\u6301\u8FD9\u79CD\u8F93\u5165\u3002\u4F7F\u7528[\u7ECF\u5178 Jenkins]({0})\u5904\u7406\u8FD9\u4E2A\u8F93\u5165\u6B65\u9AA4\u3002
+inputStep.error.title=\u9519\u8BEF
+lozenge.commit={0} \u6B21\u63D0\u4EA4

--- a/blueocean-personalization/src/main/resources/jenkins/plugins/blueocean/personalization/Messages_zh.properties
+++ b/blueocean-personalization/src/main/resources/jenkins/plugins/blueocean/personalization/Messages_zh.properties
@@ -1,10 +1,10 @@
-#输入所需
-dashboardCard.input.required=\u8f93\u5165\u6240\u9700
+#\u8F93\u5165\u6240\u9700
+dashboardCard.input.required=\u5FC5\u586B\u9879
 
-#收藏
-dashboardCard.input.favorite=\u6536\u85cf
+#\u6536\u85CF
+dashboardCard.input.favorite=\u6536\u85CF
 
-#收藏失败
-Favoriting.Error=\u6536\u85cf\u5931\u8d25
-#缺少默认分支(比如:master)可选
-no.default.branch.to.favorite=\u7f3a\u5c11\u9ed8\u8ba4\u5206\u652f\u0028\u6bd4\u5982\u003a\u006d\u0061\u0073\u0074\u0065\u0072\u0029\u53ef\u9009
+#\u6536\u85CF\u5931\u8D25
+Favoriting.Error=\u6536\u85CF\u5931\u8D25
+#\u7F3A\u5C11\u9ED8\u8BA4\u5206\u652F(\u6BD4\u5982:master)\u53EF\u9009
+no.default.branch.to.favorite=\u7F3A\u5C11\u9ED8\u8BA4\u5206\u652F(\u6BD4\u5982:master)\u53EF\u6536\u85CF

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/NodeRunStatus.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/NodeRunStatus.java
@@ -30,14 +30,14 @@ public class NodeRunStatus {
             } else {
                 this.result = BlueRun.BlueRunResult.ABORTED;
             }
-            this.state = endNode.isRunning() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
+            this.state = endNode.isActive() ? BlueRun.BlueRunState.RUNNING : BlueRun.BlueRunState.FINISHED;
         } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.QUEUED) {
             this.result = BlueRun.BlueRunResult.UNKNOWN;
             this.state = BlueRun.BlueRunState.QUEUED;
         } else if (QueueItemAction.getNodeState(endNode) == QueueItemAction.QueueState.CANCELLED) {
             this.result = BlueRun.BlueRunResult.ABORTED;
             this.state = BlueRun.BlueRunState.FINISHED;
-        } else if (endNode.isRunning()) {
+        } else if (endNode.isActive()) {
             this.result = BlueRun.BlueRunResult.UNKNOWN;
             this.state = BlueRun.BlueRunState.RUNNING;
         } else if (NotExecutedNodeAction.isExecuted(endNode)) {

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/AbstractRunImplTest.java
@@ -21,6 +21,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMSource;
 import jenkins.util.SystemProperties;
+import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -296,7 +297,14 @@ public class AbstractRunImplTest extends PipelineBaseTest {
 
         Assert.assertEquals("QUEUED", latestRun.get("state"));
         Assert.assertEquals("1", latestRun.get("id"));
-        Assert.assertEquals("Jenkins doesn’t have label test", latestRun.get("causeOfBlockage"));
+
+        // Jenkins 2.125 introduced quotes around these labels - see commit 91ddc6. This came
+        // just after the current Jenkins LTS, which is version 2.121.1. So this assert now
+        // tests for the new quoted version, and the old non-quoted version.
+        Assert.assertThat((String)latestRun.get("causeOfBlockage"), anyOf(
+            equalTo("\u2018Jenkins\u2019 doesn’t have label \u2018test\u2019"),
+            equalTo("Jenkins doesn’t have label test")
+        ));
 
         j.createOnlineSlave(Label.get("test"));
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -15,6 +15,7 @@ import hudson.util.RunList;
 import io.jenkins.blueocean.listeners.NodeDownstreamBuildAction;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipelineNode;
+import io.jenkins.blueocean.rest.model.BlueRun;
 import jenkins.branch.BranchSource;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
@@ -53,6 +54,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static io.jenkins.blueocean.rest.impl.pipeline.PipelineStepImpl.PARAMETERS_ELEMENT;
@@ -2867,6 +2869,50 @@ public class PipelineNodeTest extends PipelineBaseTest {
         assertEquals(FlowNodeWrapper.NodeType.PARALLEL.name(),nodes.get(2).get("type"));
         assertEquals(FlowNodeWrapper.NodeType.STAGE.name(),nodes.get(3).get("type"));
     }
+
+    @Issue( "JENKINS-53311" )
+    @Test
+    public void nodeWrongFinishedStatus() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "p");
+        URL resource = Resources.getResource(getClass(), "JENKINS-53311.jenkinsfile");
+        String jenkinsFile = Resources.toString(resource, Charsets.UTF_8);
+        job.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+
+        WorkflowRun build = job.scheduleBuild2(0).waitForStart();
+
+        long start = System.currentTimeMillis();
+        while ( build.isBuilding() ){
+            List<Map<String,String>> nodes = get("/organizations/jenkins/pipelines/p/runs/1/nodes/", List.class);
+            if(nodes.size()>=4) {
+                Optional<Map<String,String>> optionalMap = findNodeMap(nodes, "Nested B-1" );
+                if(optionalMap.isPresent()){
+                    long now = System.currentTimeMillis();
+                    // the sleep in test file is about 10s so we want to avoid some flaky test
+                    // so if we reach 10s we exit the loop
+                    if( TimeUnit.SECONDS.convert( now - start, TimeUnit.MILLISECONDS ) >= 10) {
+                        continue;
+                    }
+                    LOGGER.debug( "optionalMap: {}", optionalMap );
+                    assertEquals(build.isBuilding() ? BlueRun.BlueRunState.RUNNING.name() : BlueRun.BlueRunState.FINISHED,
+                                 optionalMap.get().get( "state"));
+                }
+            }
+            Thread.sleep( 500 );
+        }
+        List<Map<String,String>> nodes = get("/organizations/jenkins/pipelines/p/runs/1/nodes/", List.class);
+        Optional<Map<String,String>> optionalMap = findNodeMap(nodes, "Nested B-1" );
+        if(optionalMap.isPresent()){
+            assertEquals(BlueRun.BlueRunState.FINISHED.name(), optionalMap.get().get( "state"));
+        }
+        j.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    private Optional<Map<String,String>> findNodeMap(List<Map<String,String>> nodes, String displayName) {
+        return nodes.stream() //
+            .filter( map -> map.get( "displayName" ).equals( displayName ) ) //
+            .findFirst();
+    }
+
 
     private void setupScm(String script) throws Exception {
         // create git repo

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/JENKINS-53311.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/JENKINS-53311.jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+    agent any
+    stages {
+        stage('Parallel') {
+            parallel {
+                stage('Nested A') {
+                    steps {
+                        echo 'A'
+                    }
+                }
+                stage('Nested B') {
+                    stages {
+                        stage('Nested B-1') {
+                            steps {
+                                sleep time: 10, unit: 'SECONDS'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
+++ b/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
@@ -85,6 +85,16 @@ class SaveDialog extends React.Component {
                 errorMessage = err.responseBody.message;
             }
         }
+        if (err.responseBody && err.responseBody.errors && err.responseBody.errors.length) {
+            errorMessage = (
+                <div>
+                    <div><strong>{errorMessage}</strong></div>
+                    {err.responseBody.errors.map(e =>
+                        <div><em>{e.code}</em>: {e.message}</div>
+                    )}
+                </div>
+            );
+        }
         this.setState({ saving: false, errorMessage });
     }
 

--- a/blueocean-pipeline-scm-api/src/main/resources/io/jenkins/blueocean/pipeline/credential/Messages_zh_CN.properties
+++ b/blueocean-pipeline-scm-api/src/main/resources/io/jenkins/blueocean/pipeline/credential/Messages_zh_CN.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2018, Alauda
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+BlueOceanCredentialsProvider.DisplayName=BlueOcean \u6587\u4EF6\u5939\u51ED\u636E
+BlueOceanCredentialsProvider.DomainDescription=Blue Ocean \u6587\u4EF6\u5939\u51ED\u636E\u57DF

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -235,7 +235,7 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
 
     @Override
     public BlueTestSummary getBlueTestSummary() {
-        BlueTestSummary blueTestSummary;
+        BlueTestSummary blueTestSummary = null;
         if (getStateObj() == BlueRunState.FINISHED) {
             try {
                 blueTestSummary =  TEST_SUMMARY.get(run.getExternalizableId(),  () -> {
@@ -248,20 +248,16 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
                 ).orNull();
             } catch (ExecutionException e) {
                 LOGGER.error("Could not load test summary from cache", e);
-                return null;
             }
         } else {
             blueTestSummary =  BlueTestResultFactory.resolve(run, this).summary;
-            if (blueTestSummary == null) {
-                // Just use an empty one while we wait
-                blueTestSummary = new BlueTestSummary(0,0,0,0,0,0,0,this.getLink());
-            }
         }
 
         // .../runs/123/blueTestSummary
         if (blueTestSummary == null)
         {
-            return null;
+            // Just use an empty one while we wait to avoid 404
+            return new BlueTestSummary(0,0,0,0,0,0,0,this.getLink());
         }
         Link link = this.getLink().rel("blueTestSummary");
         blueTestSummary.setLink( link );

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
@@ -2,8 +2,6 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import hudson.console.AnnotatedLargeText;
 import io.jenkins.blueocean.commons.ServiceException;
-import org.kohsuke.stapler.AcceptHeader;
-import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.framework.io.CharSpool;
@@ -33,11 +31,11 @@ public class LogResource{
         this.appenderLogReader = logAppender.getLog();
     }
 
-    public void doIndex(StaplerRequest req, StaplerResponse rsp, @Header("Accept") AcceptHeader accept){
-        writeLog(req,rsp,accept);
+    public void doIndex(StaplerRequest req, StaplerResponse rsp){
+        writeLog(req,rsp);
     }
 
-    private void writeLog(StaplerRequest req, StaplerResponse rsp, AcceptHeader accept) {
+    private void writeLog(StaplerRequest req, StaplerResponse rsp) {
         try {
             String download = req.getParameter("download");
 

--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_zh_CN.properties
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_zh_CN.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2018, Alauda
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+BlueOceanUrlAction.DisplayName=\u6253\u5F00 Blue Ocean

--- a/blueocean-web/src/main/resources/jenkins/plugins/blueocean/web/Messages_zh.properties
+++ b/blueocean-web/src/main/resources/jenkins/plugins/blueocean/web/Messages_zh.properties
@@ -1,57 +1,57 @@
-#配置管理
-administration=\u914d\u7f6e\u7ba1\u7406
-#登录
-login=\u767b\u5f55
-#登出
-logout=\u767b\u51fa
-Not.found.heading=Page not found (404)
-#Jenkins找不到对应页面. 检查URL是否错误或者返回.
-Not.found.message=\u004a\u0065\u006e\u006b\u0069\u006e\u0073\u627e\u4e0d\u5230\u5bf9\u5e94\u9875\u9762\u002e\u0020\u68c0\u67e5\u0055\u0052\u004c\u662f\u5426\u9519\u8bef\u6216\u8005\u8fd4\u56de\u002e
-#取消
-parametrised.pipeline.cancel=\u53d6\u6d88
-parametrised.pipeline.header=\u9700\u8981\u8f93\u5165
-#运行
-parametrised.pipeline.submit=\u8fd0\u884c
-#流水线
-pipelines=\u6d41\u6c34\u7ebf
-#终止
-toast.abort=\u7ec8\u6b62
-#打开
-toast.run.open=\u004f\u0070\u0065\u006e
-#运行
-toast.run=\u8fd0\u884c
-#重运行
-run.rerun=\u91cd\u8fd0\u884c
-toast.run.started=\u542f\u52a8 "{0}" #{1}
-toast.run.stopping=\u505c\u6b62 "{0}" #{1}...
-#停止中...
-toast.stopping=\u505c\u6b62\u4e2d\u002e\u002e\u002e
-#停止
-toast.stop=\u505c\u6b62
-#连接丢失
-Connection.lost.message=\u8fde\u63a5\u4e22\u5931
-#等待中
-Connection.lost.activity=\u7b49\u5f85\u4e2d
-#连接成功
-Connection.ok.message=\u8fde\u63a5\u6210\u529f
-#重载
-Connection.ok.activity=\u91cd\u8f7d
-common.state.aborted = \u7ec8\u6b62\u540e {0}
-common.state.running = \u8fd0\u884c\u65f6 {0}
-common.state.paused = \u8fd0\u884c\u65f6 {0}
-common.state.queued = \u8fd0\u884c\u65f6 {0}
-common.state.success = \u901a\u8fc7 {0}
-common.state.unstable = \u901a\u8fc7 {0} \u4f46\u4e0d\u7a33\u5b9a.
-common.state.failure = \u5931\u8d25 {0}
-common.state.not_built = \u672a\u6784\u5efa
-#未知
-common.state.unknown = \u672a\u77e5
+#\u914D\u7F6E\u7BA1\u7406
+administration=\u914D\u7F6E\u7BA1\u7406
+#\u767B\u5F55
+login=\u767B\u5F55
+#\u767B\u51FA
+logout=\u767B\u51FA
+Not.found.heading=\u627E\u4E0D\u5230\u9875\u9762(404)
+#Jenkins\u627E\u4E0D\u5230\u5BF9\u5E94\u9875\u9762. \u68C0\u67E5URL\u662F\u5426\u9519\u8BEF\u6216\u8005\u8FD4\u56DE.
+Not.found.message=Jenkins \u627E\u4E0D\u5230\u5BF9\u5E94\u9875\u9762\u3002\u68C0\u67E5 URL \u662F\u5426\u9519\u8BEF\u6216\u8005\u8FD4\u56DE\u3002
+#\u53D6\u6D88
+parametrised.pipeline.cancel=\u53D6\u6D88
+parametrised.pipeline.header=\u9700\u8981\u8F93\u5165
+#\u8FD0\u884C
+parametrised.pipeline.submit=\u8FD0\u884C
+#\u6D41\u6C34\u7EBF
+pipelines=\u6D41\u6C34\u7EBF
+#\u7EC8\u6B62
+toast.abort=\u7EC8\u6B62
+#\u6253\u5F00
+toast.run.open=\u6253\u5F00
+#\u8FD0\u884C
+toast.run=\u8FD0\u884C
+#\u91CD\u8FD0\u884C
+run.rerun=\u91CD\u8FD0\u884C
+toast.run.started=\u542F\u52A8 "{0}" #{1}
+toast.run.stopping=\u505C\u6B62 "{0}" #{1}...
+#\u505C\u6B62\u4E2D...
+toast.stopping=\u505C\u6B62\u4E2D...
+#\u505C\u6B62
+toast.stop=\u505C\u6B62
+#\u8FDE\u63A5\u4E22\u5931
+Connection.lost.message=\u8FDE\u63A5\u4E22\u5931
+#\u7B49\u5F85\u4E2D
+Connection.lost.activity=\u7B49\u5F85\u4E2D
+#\u8FDE\u63A5\u6210\u529F
+Connection.ok.message=\u8FDE\u63A5\u6210\u529F
+#\u91CD\u8F7D
+Connection.ok.activity=\u91CD\u8F7D
+common.state.aborted=\u7EC8\u6B62\u540E {0}
+common.state.running=\u8FD0\u884C\u65F6 {0}
+common.state.paused=\u8FD0\u884C\u65F6 {0}
+common.state.queued=\u8FD0\u884C\u65F6 {0}
+common.state.success=\u901A\u8FC7 {0}
+common.state.unstable=\u901A\u8FC7 {0} \u4F46\u4E0D\u7A33\u5B9A\u3002
+common.state.failure=\u5931\u8D25 {0}
+common.state.not_built=\u672A\u6784\u5EFA
+#\u672A\u77E5
+common.state.unknown=\u672A\u77E5
 # the parameterMessage keys assume that you will parse them with a markdown parser
-#"{0}" 输入类型不支持.
-parameter.error.message="{0}" \u8f93\u5165\u7c7b\u578b\u4e0d\u652f\u6301\u002e
-parameter.error.title=\u9519\u8bef
+#"{0}" \u8F93\u5165\u7C7B\u578B\u4E0D\u652F\u6301.
+parameter.error.message="{0}" \u8F93\u5165\u7C7B\u578B\u4E0D\u652F\u6301\u3002
+parameter.error.title=\u9519\u8BEF
 # the parameterMessage keys assume that you will parse them with a markdown parser
-#pipeline使用的输入类型不支持.请使用 [Jenkins Classic]({0}) 参数化构建.
-inputParameter.error.message=\u0070\u0069\u0070\u0065\u006c\u0069\u006e\u0065\u4f7f\u7528\u7684\u8f93\u5165\u7c7b\u578b\u4e0d\u652f\u6301\u002e\u8bf7\u4f7f\u7528 [Jenkins Classic]({0}) \u53c2\u6570\u5316\u6784\u5efa\u002e
-inputParameter.error.title=\u9519\u8bef
-go.to.classic=\u56de\u5230\u7ecf\u5178\u754c\u9762
+#pipeline\u4F7F\u7528\u7684\u8F93\u5165\u7C7B\u578B\u4E0D\u652F\u6301.\u8BF7\u4F7F\u7528 [Jenkins Classic]({0}) \u53C2\u6570\u5316\u6784\u5EFA.
+inputParameter.error.message=\u6D41\u6C34\u7EBF\u4F7F\u7528\u7684\u8F93\u5165\u7C7B\u578B\u4E0D\u652F\u6301\u3002\u8BF7\u4F7F\u7528 [\u7ECF\u5178 Jenkins]({0}) \u53C2\u6570\u5316\u6784\u5EFA\u3002
+inputParameter.error.title=\u9519\u8BEF
+go.to.classic=\u56DE\u5230\u7ECF\u5178\u754C\u9762

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -332,12 +332,12 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-stage-tags-metadata</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-api</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -347,17 +347,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.28</version>
+            <version>2.29</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.23</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -372,23 +372,23 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.19</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.18</version>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.18</version>
+            <version>2.20</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.9</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -403,7 +403,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.8</version> <!-- TODO: Update when released -->
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -418,7 +418,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.44</version>
+            <version>1.46</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <findbugs.failOnError>true</findbugs.failOnError>
     <powermock.version>1.6.6</powermock.version>
     <guava.version>11.0.1</guava.version>
-    <jacoco.version>0.7.9</jacoco.version>
+    <jacoco.version>0.8.2</jacoco.version>
     <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
     <jacoco.line.coverage>0.70</jacoco.line.coverage>
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
@@ -988,13 +988,9 @@
           </configuration>
       </plugin>
 
-      <!--
-      TODO: Remove/review this as part of solving https://issues.jenkins-ci.org/browse/JENKINS-38888
-      See comment below on argLine config.
-      -->
       <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.0</version>
           <configuration>
               <systemProperties>
                   <property>


### PR DESCRIPTION
# Description

Backports these  commits from master over to 1.8 release branch:

* f04175838 [JENKINS-53311] Wrong status of running builds  (#1807)
* 60442a1ba [JENKINS-53132] Moves sleep into saveBranch, more consistent logging (#1803)
* 9944bb936 Update pipeline-related plugins to the latest versions (#1806)
* 7830bf12b Fix test URL overlap
* d3c9cbce7 Add a test
* 116c6baf1 Use StringBuilder for string concatenation
* 69161ff29 BitBucket Server errors not shown properly
* d520a7219 Surefire and jacoco plugins upgrade (#1804)
* 74f11929e avoid js error in case a run request returns a 404 (#1802)
* 39d3a5ee7 Fixes expression and supplement i10n (#1801)
* 6cda2f2e7 remove unsued accept header (#1800)
* 1a34a1c7b [JENKINS-53175] avoid 404 by returning an empty BlueTestSummary (#1799)
* 96a2bb2f9 Allows pre- and post-2.125 versions of Jenkins core to pass (#1798)
* 23702052e upgrade jira plugin to 3.0.1 removing perforce plugin security advisory https://jenkins.io/security/advisory/2018-03-26/#SECURITY-536 (#1797)
* 2fd5f8577 [JENKINS-52944] Pass milliseconds to TimeDuration (#1794)
* b02273dc2 Add braces and simplify/improve oldLength handling
* f28a06b60 handle undefined nextProps.logArray

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

