### PR TITLE
check good name

### DIFF
--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import hudson.model.Item;
 import hudson.model.User;
+import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.credential.CredentialsUtils;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
@@ -109,6 +110,24 @@ public class GithubPipelineCreateRequestTest extends GithubMockBase {
 
         request.create(organization, organization);
 //        verify(criteria, atLeastOnce()).isJenkinsfileFound();
+    }
+
+    @Test
+    public void shouldFailCreatePipelineNoJenkinsFile() throws UnirestException, IOException{
+        boolean thrown = false;
+        OrganizationImpl organization = new OrganizationImpl("jenkins", j.jenkins);
+        String credentialId = createGithubCredential(user);
+
+        JSONObject config = JSONObject.fromObject(ImmutableMap.of("repoOwner", "vivek", "repository", "empty1"));
+
+        GithubPipelineCreateRequest request = new GithubPipelineCreateRequest(
+            "empty1/empty2", new BlueScmConfig(GithubScm.ID, githubApiUrl, credentialId, config));
+        try {
+            request.create(organization, organization);
+        }catch (ServiceException.BadRequestException e){
+            thrown = true;
+        }
+        assertTrue(thrown);
     }
 
     @Test

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
@@ -251,6 +251,7 @@ public abstract class AbstractMultiBranchCreateRequest extends AbstractPipelineC
         // Validate that name matches rules
         try {
             Jenkins.getInstance().getProjectNamingStrategy().checkName(getName());
+            Jenkins.checkGoodName(name);
         }catch (Failure f){
             errors.add(new Error(ERROR_FIELD_SCM_CONFIG_NAME, Error.ErrorCodes.INVALID.toString(),  getName() + " in not a valid name"));
         }


### PR DESCRIPTION
There are some problems with the name check now, for example, I can create a job named `a/b`