### PR TITLE
[JENKINS-53320] Job fails because JiraSCMListener times out on too many changes

### DIFF
--- a/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/BlueJiraIssue.java
+++ b/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/BlueJiraIssue.java
@@ -1,12 +1,9 @@
 package io.jenkins.blueocean.service.embedded.jira;
 
-import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -25,8 +22,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -100,19 +97,15 @@ public class BlueJiraIssue extends BlueIssue {
                 return null;
             }
             Collection<String> issueKeys = findIssueKeys(changeSetEntry.getMsg(), site.getIssuePattern());
-            Iterable<BlueIssue> transformed = Iterables.transform(issueKeys, new Function<String, BlueIssue>() {
-                @Override
-                public BlueIssue apply(String input) {
-                return BlueJiraIssue.create(site, action.getIssue(input));
-                }
-            });
+            Iterable<BlueIssue> transformed = Iterables.transform(issueKeys,
+                                                                  s -> BlueJiraIssue.create(site, action.getIssue(s)));
             return ImmutableList.copyOf(Iterables.filter(transformed, Predicates.notNull()));
         }
     }
 
     static Collection<String> findIssueKeys(String input, Pattern pattern) {
         Matcher m = pattern.matcher(input);
-        Set<String> issues = Sets.newHashSet();
+        Set<String> issues = new HashSet();
         while (m.find()) {
             if (m.groupCount() >= 1) {
                 String id = m.group(1);

--- a/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
+++ b/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
@@ -65,7 +65,7 @@ public class JiraSCMListener extends SCMListener {
                 action.addIssues(issuesFromJqlSearch);
             }
             run.save();
-        } catch ( TimeoutException | IOException e ){
+        } catch (Exception e ){ // we do not want to fail the build if an issue happen here
             LOGGER.warn( "skip reccording associated jira issues: {}", e.getMessage() );
             // stack trace in debug mode
             LOGGER.debug( e.getMessage(), e);

--- a/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
+++ b/blueocean-jira/src/main/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListener.java
@@ -66,7 +66,7 @@ public class JiraSCMListener extends SCMListener {
             }
             run.save();
         } catch (Exception e ){ // we do not want to fail the build if an issue happen here
-            LOGGER.warn( "skip reccording associated jira issues: {}", e.getMessage() );
+            LOGGER.warn( "Failure executing Jira query to fetch issues. Skipping recording Jira issues.: {}", e.getMessage() );
             // stack trace in debug mode
             LOGGER.debug( e.getMessage(), e);
         }

--- a/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
+++ b/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -210,15 +211,13 @@ public class JiraSCMListenerTest {
 
 
     private static ChangeLogSet build( String... texts) {
-        List<ChangeLogSet.Entry> entries = new ArrayList();
-        for(String text: texts){
+        List<ChangeLogSet.Entry> entries = Arrays.asList( texts ).stream().map( text -> {
             final ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
             when(entry.getMsg()).thenReturn(text);
-            entries.add( entry );
-        }
+            return  entry;
+        } ).collect( Collectors.toList() );
 
-
-        ChangeLogSet<ChangeLogSet.Entry> set = new ChangeLogSet<ChangeLogSet.Entry>(null, null) {
+        return new ChangeLogSet<ChangeLogSet.Entry>(null, null) {
             @Override
             public boolean isEmptySet() {
                 return false;
@@ -229,8 +228,6 @@ public class JiraSCMListenerTest {
                 return entries.iterator();
             }
         };
-
-        return set;
     }
 
 }

--- a/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
+++ b/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
@@ -1,9 +1,6 @@
 package io.jenkins.blueocean.service.embedded.jira;
 
 import com.atlassian.jira.rest.client.api.domain.Issue;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.jira.JiraBuildAction;
@@ -20,7 +17,13 @@ import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -56,7 +59,7 @@ public class JiraSCMListenerTest {
 
             @Override
             public Iterator<Entry> iterator() {
-                return ImmutableSet.of(entry).iterator();
+                return Collections.singletonList(entry).iterator();
             }
         };
 
@@ -73,8 +76,8 @@ public class JiraSCMListenerTest {
         when(rawIssue.getKey()).thenReturn("TEST-123");
         when(rawIssue.getSummary()).thenReturn("Foo");
 
-        when(session.getIssuesFromJqlSearch("key in ('TEST-123')")).thenReturn(Lists.newArrayList(rawIssue));
-        JiraBuildAction action = new JiraBuildAction(run, Sets.<JiraIssue>newHashSet());
+        when(session.getIssuesFromJqlSearch("key in ('TEST-123')")).thenReturn(Collections.singletonList(rawIssue));
+        JiraBuildAction action = new JiraBuildAction(run, new HashSet());
         when(run.getAction(JiraBuildAction.class)).thenReturn(action);
 
         listener.onChangeLogParsed(run, null,null, set);
@@ -107,7 +110,7 @@ public class JiraSCMListenerTest {
 
             @Override
             public Iterator<Entry> iterator() {
-                return ImmutableSet.of(entry).iterator();
+                return Collections.singletonList(entry).iterator();
             }
         };
 
@@ -124,7 +127,7 @@ public class JiraSCMListenerTest {
         when(rawIssue.getKey()).thenReturn("TEST-123");
         when(rawIssue.getSummary()).thenReturn("Foo");
 
-        when(session.getIssuesFromJqlSearch("key in ('TEST-123')")).thenReturn(Lists.newArrayList(rawIssue));
+        when(session.getIssuesFromJqlSearch("key in ('TEST-123')")).thenReturn(Collections.singletonList(rawIssue));
         when(run.getAction(JiraBuildAction.class)).thenReturn(null);
 
         ArgumentCaptor<JiraBuildAction> actionArgumentCaptor = ArgumentCaptor.forClass(JiraBuildAction.class);
@@ -161,7 +164,7 @@ public class JiraSCMListenerTest {
 
             @Override
             public Iterator<Entry> iterator() {
-                return ImmutableSet.of(entry).iterator();
+                return Collections.singletonList(entry).iterator();
             }
         };
 
@@ -172,7 +175,7 @@ public class JiraSCMListenerTest {
         when(site.getIssuePattern()).thenReturn(JiraSite.DEFAULT_ISSUE_PATTERN);
         when(JiraSite.get(job)).thenReturn(site);
 
-        JiraBuildAction action = new JiraBuildAction(run, Sets.<JiraIssue>newHashSet());
+        JiraBuildAction action = new JiraBuildAction(run, new HashSet());
         when(run.getAction(JiraBuildAction.class)).thenReturn(action);
 
         listener.onChangeLogParsed(run, null,null, set);
@@ -191,7 +194,43 @@ public class JiraSCMListenerTest {
 
     @Test
     public void constructJQLQuery() throws Exception {
-        Assert.assertEquals("key in ('JENKINS-123')", JiraSCMListener.constructJQLQuery(Lists.newArrayList("JENKINS-123")));
-        Assert.assertEquals("key in ('JENKINS-123','FOO-123','VIVEK-123')", JiraSCMListener.constructJQLQuery(Lists.newArrayList("JENKINS-123", "FOO-123", "VIVEK-123")));
+        Assert.assertEquals("key in ('JENKINS-123')",
+                            JiraSCMListener.constructJQLQuery(Collections.singletonList("JENKINS-123")));
+        Assert.assertEquals("key in ('JENKINS-123','FOO-123','VIVEK-123')",
+                            JiraSCMListener.constructJQLQuery( Arrays.asList("JENKINS-123", "FOO-123", "VIVEK-123")));
     }
+
+    @Test
+    public void uniqueIssueKeys() throws Exception {
+        ChangeLogSet<ChangeLogSet.Entry> entries = build( "TST-123", "TST-123", "TST-123", "TST-124",
+                                                          "TST-123", "TST-124", "TST-125");
+        Collection<String> keys = JiraSCMListener.getIssueKeys( entries, JiraSite.DEFAULT_ISSUE_PATTERN );
+        Assert.assertEquals(3, keys.size());
+    }
+
+
+    private static ChangeLogSet build( String... texts) {
+        List<ChangeLogSet.Entry> entries = new ArrayList();
+        for(String text: texts){
+            final ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
+            when(entry.getMsg()).thenReturn(text);
+            entries.add( entry );
+        }
+
+
+        ChangeLogSet<ChangeLogSet.Entry> set = new ChangeLogSet<ChangeLogSet.Entry>(null, null) {
+            @Override
+            public boolean isEmptySet() {
+                return false;
+            }
+
+            @Override
+            public Iterator<Entry> iterator() {
+                return entries.iterator();
+            }
+        };
+
+        return set;
+    }
+
 }


### PR DESCRIPTION
# Description

See [JENKINS-53320](https://issues.jenkins-ci.org/browse/JENKINS-53320).
This pr avoid duplicate keys in the jql query and do not fail the build in case of issue with the jira plugin.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

