### PR TITLE
JENKINS-53900 Missing stage graph nodes

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author Vivek Pandey
- * <p>
+ * 
  * Run your Jenkins instance with <code>-DNODE-DUMP-ENABLED</code> to turn on the logging when diagnosing bugs! You'll
  * also need to have a logging config that enables debug for (at least) this class. Use
  * <code>-Djava.util.logging.config.file=./logging.properties</code> to set a custom logging properties file from the


### PR DESCRIPTION
# Description

Example pipeline script here: https://gist.github.com/sophistifunk/717c9578af709e959f35d2d5bd6ab30b

Single-child sequential stage list, if the last branch of a parallel container, does not get correct graph edges applied.

See [JENKINS-53900](https://issues.jenkins-ci.org/browse/JENKINS-53900).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

