### PR TITLE
[JENKINS-54268] Reenable building on ci.jenkins.io too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 #!groovy
 
+if (JENKINS_URL == 'https://ci.jenkins.io/') {
+    buildPlugin()
+    return
+}
+
 // only 20 builds
 properties([buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20'))])
 


### PR DESCRIPTION
Context: this PR is a separate and more focused followup on https://github.com/jenkinsci/blueocean-plugin/pull/1818 where we discussed reintroducing a `Jenkinsfile` to build both on https://ci.jenkins.io too.

This PR uses a hint from @jglick given in the PR linked above to have a single `Jenkinsfile` able to behave in both https://ci.jenkins.io and https://ci.blueocean.io

Goal is:
* Keep having the dogfooding build on https://ci.blueocean.io for obvious reasons
* Get also the benefit of incremental releases (aka JEP-305) for Blue Ocean from https://ci.jenkins.io without having to deploy another complex and redundant setup on https://ci.blueocean.io


# Description

See [JENKINS-54268](https://issues.jenkins-ci.org/browse/JENKINS-54268).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

