### PR TITLE
Disable building on Windows, and skip tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,10 @@
 #!groovy
 
 if (JENKINS_URL == 'https://ci.jenkins.io/') {
-    buildPlugin()
+    buildPlugin(
+      platforms: ['linux'],
+      tests: [skip: true]
+    )
     return
 }
 


### PR DESCRIPTION
Followup of https://github.com/jenkinsci/blueocean-plugin/pull/1838

Tests are now configured to be skipped on https://ci.jenkins.io, since this build is only used for Incrementals, so let's save resources on ci.j.i.
Actual build *with* tests is still done on https://ci.blueocean.io

# Description

See [JENKINS-54268](https://issues.jenkins-ci.org/browse/JENKINS-54268).

This PR is expected to:
* succeed on http://ci.jenkins.io
* only build on Linux
* publish Blue Ocean plugins in Incrementals repository (https://repo.jenkins-ci.org/incrementals/)

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

