### PR TITLE
[JENKINS-54410] Modify LoginPage.login() to work with old and new login screens

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
@@ -24,7 +24,15 @@ public class LoginPage implements WebDriverMixin {
         open();
         find("#j_username").sendKeys(admin.username);
         find("input[name=j_password]").sendKeys(admin.password);
-        find("//button[contains(text(), 'log')]").click();
+
+        if (find("//button[contains(text(), 'log')]").isPresent()) {
+            logger.info("Logging in via pre-2.128 style log in page");
+            find("//button[contains(text(), 'log')]").click();
+        } else {
+            logger.info("Logging in via post-2.128 style log in page");
+            find("input[name=Submit]").click();
+        }
+
         find("//a[contains(@href, 'logout')]").isDisplayed();
         logger.info("Logged in as " + admin.username);
     }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
@@ -24,7 +24,6 @@ public class LoginPage implements WebDriverMixin {
         open();
         find("#j_username").sendKeys(admin.username);
         find("input[name=j_password]").sendKeys(admin.password);
-
         // JENKINS-50477 introduced a new login screen, which was released in core 2.128.
         // This allows us to log in with both login screens - starting with the new style.
         if (find("input[name=Submit]").isPresent()) {
@@ -33,7 +32,6 @@ public class LoginPage implements WebDriverMixin {
         } else {
             logger.info("Logging in via pre-2.128 style log in page");
             find("//button[contains(text(), 'log')]").click();
-
         }
 
         find("//a[contains(@href, 'logout')]").isDisplayed();

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java
@@ -25,12 +25,15 @@ public class LoginPage implements WebDriverMixin {
         find("#j_username").sendKeys(admin.username);
         find("input[name=j_password]").sendKeys(admin.password);
 
-        if (find("//button[contains(text(), 'log')]").isPresent()) {
-            logger.info("Logging in via pre-2.128 style log in page");
-            find("//button[contains(text(), 'log')]").click();
-        } else {
+        // JENKINS-50477 introduced a new login screen, which was released in core 2.128.
+        // This allows us to log in with both login screens - starting with the new style.
+        if (find("input[name=Submit]").isPresent()) {
             logger.info("Logging in via post-2.128 style log in page");
             find("input[name=Submit]").click();
+        } else {
+            logger.info("Logging in via pre-2.128 style log in page");
+            find("//button[contains(text(), 'log')]").click();
+
         }
 
         find("//a[contains(@href, 'logout')]").isDisplayed();


### PR DESCRIPTION
# Description

See [JENKINS-54410](https://issues.jenkins-ci.org/browse/JENKINS-54410).

A new login screen was introduced in Jenkins 2.128, via [JENKINS-50447](https://issues.jenkins-ci.org/browse/JENKINS-50447). The existing `LoginPage.login` is incompatible with this new screen - it's [looking for a `log in` button to click on](https://github.com/jenkinsci/blueocean-plugin/blob/d7aac46curl67a09907a4955fed366475110d6cc0e2/acceptance-tests/src/main/java/io/blueocean/ath/pages/classic/LoginPage.java#L27), but there  isn't one. It now says `Submit`.

This PR is a simple way of having both login screens work. We check for the presence of the "new style" button, and  if we find it, we click it. If we don't find it, we go on like we always have.

Old login screen:

![image](https://user-images.githubusercontent.com/21689198/47888479-16096d80-de1b-11e8-8f4f-8f2a7d4acdcf.png)


New login screen:

![image](https://user-images.githubusercontent.com/21689198/47888350-7055fe80-de1a-11e8-982f-9d34803fd2c5.png)

To verify:

1. Start a Jenkins older than 2.128, and run whatever your favorite ATH test happens to be that includes a login from the classic UI, for example, `mvn test -Dprofile=live -Dtest=GithubEditorTest#testEditor`, from your `blueocean-plugin/acceptance-tests` folder. The test should run through the old login screen and work. 

2. Stop that Jenkins, and start again, with a version greater than 2.128. Repeat the rest of the steps, and this time, it will run through the new login screen.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

