### PR TITLE
JENKINS-48198: Fix crash with unexpected run state

### DIFF
--- a/blueocean-dashboard/src/main/js/components/ActivityDetailsRow.jsx
+++ b/blueocean-dashboard/src/main/js/components/ActivityDetailsRow.jsx
@@ -30,7 +30,7 @@ class ActivityDetailsRow extends Component {
             return null;
         }
 
-        const resultRun = run.result === 'UNKNOWN' ? run.state : run.result;
+        const resultRun = (run.result === 'UNKNOWN' && typeof run.state === 'string') ? run.state : run.result;
         const runDetailsUrl = UrlBuilder.buildRunUrl(pipeline.organization, pipeline.fullName, decodeURIComponent(run.pipeline), run.id, 'pipeline');
         const changesUrl = UrlBuilder.buildRunUrl(pipeline.organization, pipeline.fullName, decodeURIComponent(run.pipeline), run.id, 'changes');
 


### PR DESCRIPTION
It is possible for `run.state` to be `undefined` when `run.result === 'UNKNOWN'` this causes a crash in `LiveStatusIndicator` which tries to do `runResult.toLowerCase()`

The conditions to which this state can occur is unclear so it is really hard to come up with a test case.

# Description

See [JENKINS-48198](https://issues.jenkins-ci.org/browse/JENKINS-48198).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

