### PR TITLE
[JENKINS-53127][DESIGN-249] add labels to parallel sequential stage branches

### DIFF
--- a/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
@@ -86,6 +86,7 @@ function convertJenkinsNodeDetails(jenkinsNode, isCompleted, skewMillis = 0) {
         id: jenkinsNode.id,
         title,
         type: jenkinsNode.type,
+        seqContainerName: '',
     };
     logger.debug('converted node', converted);
     return converted;
@@ -191,6 +192,7 @@ export function convertJenkinsNodeGraph(jenkinsGraph, isCompleted, skewMillis) {
                         if (originalNodeForId[key].firstParent === branchNode.id) {
                             for (var i = 0; i < currentNode.children.length; i++) {
                                 if (currentNode.children[i].id === branchNode.id) {
+                                    convertedNodeForId[key].seqContainerName = branchNode.name;
                                     currentNode.children[i] = convertedNodeForId[key];
                                     if (originalNodeForId[key].edges.length && originalNodeForId[key].edges[0]) {
                                         buildSequentialStages(originalNodeForId, convertedNodeForId, key, currentNode.children[i]);

--- a/jenkins-design-language/src/js/components/TruncatingLabel.jsx
+++ b/jenkins-design-language/src/js/components/TruncatingLabel.jsx
@@ -105,7 +105,7 @@ export class TruncatingLabel extends Component {
         }
 
         return (
-            <div style={mergedStyle} className={'TruncatingLabel ' + className}>
+            <div style={mergedStyle} className={'TruncatingLabel ' + className} title={this.innerText}>
                 {this.innerText}
             </div>
         );

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.ts
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphLayout.ts
@@ -163,6 +163,9 @@ function positionNodes(nodeColumns: Array<NodeColumn>, { nodeSpacingH, parallelS
             xp += Math.round((widestRow - row.length) * parallelSpacingH * 0.5);
 
             for (const node of row) {
+                if (!node.isPlaceholder && node.stage && node.stage.seqContainerName) {
+                    xp += 70;
+                }
                 maxX = Math.max(maxX, xp);
                 node.x = xp;
                 node.y = yp;

--- a/jenkins-design-language/src/js/components/pipeline/PipelineGraphModel.tsx
+++ b/jenkins-design-language/src/js/components/pipeline/PipelineGraphModel.tsx
@@ -58,6 +58,7 @@ export interface StageInfo {
     children: Array<StageInfo>; // Used by the top-most stages with parallel branches
     nextSibling?: StageInfo; // Used within a parallel branch to denote sequential stages
     isSequential?: boolean;
+    seqContainerName: string; //used within a parallel branch to denote the name of the container of the parallel sequential stages
 }
 
 // TODO: Refactor these into a common base, and some discerning "typeof" funcs


### PR DESCRIPTION
# Description
This adds the name of the parallel sequential stages parent stage as a label at the beginning of each "branch"

See [JENKINS-53127](https://issues.jenkins-ci.org/browse/JENKINS-53127) [DESIGN-249].

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

