### PR TITLE
[JENKINS-54889] Avoid NPE with graphlistener (null check on value before adding to the map)

### DIFF
--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/PipelineEventListener.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/PipelineEventListener.java
@@ -71,8 +71,12 @@ public class PipelineEventListener implements GraphListener {
         // test whether we have a stage node
         if (PipelineNodeUtil.isStage(flowNode)) {
             List<String> branch = getBranch(flowNode);
-            currentStageName.put(flowNode.getExecution(), flowNode.getDisplayName());
-            currentStageId.put(flowNode.getExecution(), flowNode.getId());
+            if(flowNode.getExecution()!=null && flowNode.getDisplayName()!=null) {
+                currentStageName.put(flowNode.getExecution(), flowNode.getDisplayName());
+            }
+            if(flowNode.getExecution()!=null && flowNode.getId()!=null) {
+                currentStageId.put( flowNode.getExecution(), flowNode.getId() );
+            }
             publishEvent(newMessage(PipelineEventChannel.Event.pipeline_stage, flowNode, branch));
         } else if (flowNode instanceof StepStartNode) {
             if (flowNode.getAction(BodyInvocationAction.class) != null) {

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/PipelineEventListener.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/PipelineEventListener.java
@@ -71,10 +71,10 @@ public class PipelineEventListener implements GraphListener {
         // test whether we have a stage node
         if (PipelineNodeUtil.isStage(flowNode)) {
             List<String> branch = getBranch(flowNode);
-            if(flowNode.getExecution()!=null && flowNode.getDisplayName()!=null) {
+            if(flowNode.getDisplayName()!=null) {
                 currentStageName.put(flowNode.getExecution(), flowNode.getDisplayName());
             }
-            if(flowNode.getExecution()!=null && flowNode.getId()!=null) {
+            if(flowNode.getId()!=null) {
                 currentStageId.put( flowNode.getExecution(), flowNode.getId() );
             }
             publishEvent(newMessage(PipelineEventChannel.Event.pipeline_stage, flowNode, branch));


### PR DESCRIPTION
Signed-off-by: olivier lamy <olamy@apache.org>

# Description

See [JENKINS-54889](https://issues.jenkins-ci.org/browse/JENKINS-54889).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

