### PR TITLE
[SUREFIRE-1588] Workarounds for CI systems building Blue Ocean on Debian/Ubuntu

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <node.version>6.4.0</node.version>
         <npm.version>3.10.3</npm.version>
+        <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
     </properties>
 
 

--- a/acceptance-tests/run.sh
+++ b/acceptance-tests/run.sh
@@ -48,6 +48,7 @@ while true; do
     sleep 10
 done
 
+
 EXECUTION="env JENKINS_JAVA_OPTS=\"${JENKINS_JAVA_OPTS}\" ${ATH_SERVER_HOST} ${ATH_SERVER_PORT} BROWSER=phantomjs LOCAL_SNAPSHOTS=${LOCAL_SNAPSHOTS} ${PLUGINS} PLUGINS_DIR=../runtime-plugins/runtime-deps/target/plugins-combined PATH=\"./node:./node/npm/bin:./node_modules/.bin:${PATH}\" mvn -Dhudson.model.UsageStatistics.disabled=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dmaven.test.failure.ignore ${MAVEN_SETTINGS} test ${PROFILES} ${TEST_TO_RUN}"
 
 echo ""

--- a/acceptance-tests/run.sh
+++ b/acceptance-tests/run.sh
@@ -48,8 +48,7 @@ while true; do
     sleep 10
 done
 
-
-EXECUTION="env JENKINS_JAVA_OPTS=\"${JENKINS_JAVA_OPTS}\" ${ATH_SERVER_HOST} ${ATH_SERVER_PORT} BROWSER=phantomjs LOCAL_SNAPSHOTS=${LOCAL_SNAPSHOTS} ${PLUGINS} PLUGINS_DIR=../runtime-plugins/runtime-deps/target/plugins-combined PATH=\"./node:./node/npm/bin:./node_modules/.bin:${PATH}\" mvn -Dhudson.model.UsageStatistics.disabled=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dmaven.test.failure.ignore ${MAVEN_SETTINGS} test ${PROFILES} ${TEST_TO_RUN}"
+EXECUTION="env JENKINS_JAVA_OPTS=\"${JENKINS_JAVA_OPTS}\" ${ATH_SERVER_HOST} ${ATH_SERVER_PORT} BROWSER=phantomjs LOCAL_SNAPSHOTS=${LOCAL_SNAPSHOTS} ${PLUGINS} PLUGINS_DIR=../runtime-plugins/runtime-deps/target/plugins-combined PATH=\"./node:./node/npm/bin:./node_modules/.bin:${PATH}\" mvn -Dhudson.model.UsageStatistics.disabled=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dmaven.test.failure.ignore ${MAVEN_SETTINGS} test ${PROFILES} ${TEST_TO_RUN}"
 
 echo ""
 echo "> ${EXECUTION}"

--- a/acceptance-tests/run.sh
+++ b/acceptance-tests/run.sh
@@ -48,7 +48,7 @@ while true; do
     sleep 10
 done
 
-EXECUTION="env JENKINS_JAVA_OPTS=\"${JENKINS_JAVA_OPTS}\" ${ATH_SERVER_HOST} ${ATH_SERVER_PORT} BROWSER=phantomjs LOCAL_SNAPSHOTS=${LOCAL_SNAPSHOTS} ${PLUGINS} PLUGINS_DIR=../runtime-plugins/runtime-deps/target/plugins-combined PATH=\"./node:./node/npm/bin:./node_modules/.bin:${PATH}\" mvn -Dhudson.model.UsageStatistics.disabled=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dmaven.test.failure.ignore ${MAVEN_SETTINGS} test ${PROFILES} ${TEST_TO_RUN}"
+EXECUTION="env JENKINS_JAVA_OPTS=\"${JENKINS_JAVA_OPTS}\" ${ATH_SERVER_HOST} ${ATH_SERVER_PORT} BROWSER=phantomjs LOCAL_SNAPSHOTS=${LOCAL_SNAPSHOTS} ${PLUGINS} PLUGINS_DIR=../runtime-plugins/runtime-deps/target/plugins-combined PATH=\"./node:./node/npm/bin:./node_modules/.bin:${PATH}\" mvn -Dhudson.model.UsageStatistics.disabled=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -Dmaven.test.failure.ignore ${MAVEN_SETTINGS} test ${PROFILES} ${TEST_TO_RUN}"
 
 echo ""
 echo "> ${EXECUTION}"

--- a/acceptance-tests/runner/runtime/pom.xml
+++ b/acceptance-tests/runner/runtime/pom.xml
@@ -24,6 +24,7 @@
     <jenkins.acceptance.testharness.version>1.30</jenkins.acceptance.testharness.version>
     <node.version>6.4.0</node.version>
     <npm.version>3.10.3</npm.version>
+    <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
   </properties>
 
   <repositories>


### PR DESCRIPTION
# Description

See [SUREFIRE-1588](https://issues.apache.org/jira/browse/SUREFIRE-1588).

This is a (hopefully temporary) workaround for [SUREFIRE-1588](https://issues.apache.org/jira/browse/SUREFIRE-1588). What happens, in brief, is that when built on a Debian/Ubuntu based system, the build of Blue Ocean can fail in various ways. These changes represent a workaround for that, until the SUREFIRE-1588 fix propogates to the myriad docker containers and other build infra on which Blue Ocean gets tested and built.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

