### PR TITLE
[JENKINS-50532] Handle results for multi level parallelization

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -70,7 +70,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
     private FlowNodeWrapper nextStage;
 
-    private FlowNode parallelEnd;
+    private Stack<FlowNode> parallelEnds = new Stack<>();
 
     public final Map<String, FlowNodeWrapper> nodeMap = new LinkedHashMap<>();
 
@@ -85,6 +85,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
     private final ArrayDeque<FlowNode> pendingInputSteps = new ArrayDeque<>();
 
+    private final Stack<FlowNode> pendingBranchEndNodes = new Stack<>();
     private final Stack<FlowNode> parallelBranchEndNodes = new Stack<>();
     private final Stack<FlowNode> parallelBranchStartNodes = new Stack<>();
 
@@ -160,7 +161,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         captureOrphanParallelBranches();
 
         //if block stage node push it to stack as it may have nested stages
-        if (parallelEnd == null &&
+        if (parallelEnds.isEmpty() &&
             endNode instanceof StepEndNode
             && !PipelineNodeUtil.isSyntheticStage(((StepEndNode) endNode).getStartNode()) //skip synthetic stages
             && PipelineNodeUtil.isStage(((StepEndNode) endNode).getStartNode())) {
@@ -201,7 +202,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         boolean parallelNestedStages = false;
 
         // it's nested stages inside parallel so let's collect them later
-        if (parallelEnd != null) {
+        if (!parallelEnds.isEmpty()){
             // nested stages not supported in scripted pipeline.
             if (!isDeclarative()) {
                 return;
@@ -270,10 +271,10 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             }
         } else {
             if (parallelNestedStages) {
-                if (parallelBranchEndNodes.isEmpty()) {
+                if (pendingBranchEndNodes.isEmpty() ){
                     logger.debug("skip parsing stage {} but parallelBranchEndNodes is empty", stage);
                 } else {
-                    String endId = parallelBranchEndNodes.peek().getId();
+                    String endId = pendingBranchEndNodes.peek().getId();
                     Stack<FlowNodeWrapper> stack = stackPerEnd.get(endId);
                     if (stack == null) {
                         stack = new Stack<>();
@@ -310,9 +311,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                                branchNode.getDisplayName(), branchNode.getDisplayFunctionName()));
         }
 
-        if (nestedbranches.size() != parallelBranchEndNodes.size()) {
-            logger.debug(String.format("nestedBranches size: %s not equal to parallelBranchEndNodes: %s",
-                                       nestedbranches.size(), parallelBranchEndNodes.size()));
+        if (!pendingBranchEndNodes.isEmpty()) {
+            logger.debug("Found parallelBranchEndNodes, but the corresponding branchStartNode yet");
+            parallelEnds.pop();
             return;
         }
 
@@ -335,7 +336,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                     }
                 } else {
                     GenericStatus genericStatus =
-                        StatusAndTiming.computeChunkStatus2(run, parallelStartNode, branchStartNode, endNode, parallelEnd);
+                        StatusAndTiming.computeChunkStatus2(run, parallelStartNode, branchStartNode, endNode, parallelEnds.peek());
                     status = new NodeRunStatus(genericStatus);
                 }
             } else {
@@ -420,8 +421,8 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             nodeMap.put(p.getId(), p);
         }
 
-        //reset parallelEnd node for next parallel block
-        this.parallelEnd = null;
+        //Removes parallelEnd node for next parallel block
+        this.parallelEnds.pop();
     }
 
     @Override
@@ -435,7 +436,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             }
         }
         captureOrphanParallelBranches();
-        this.parallelEnd = parallelEndNode;
+        this.parallelEnds.add(parallelEndNode);
     }
 
     @Override
@@ -448,6 +449,8 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         // Save actions for this branch, so we can add them to the FlowNodeWrapper later
         pendingActionsForBranches.put(branchStartNode, drainPipelineActions());
         nestedbranches.push(branchStartNode);
+        FlowNode endNode = pendingBranchEndNodes.pop();
+        parallelBranchEndNodes.add(endNode);
     }
 
     @Override
@@ -461,7 +464,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                                    ((StepEndNode) branchEndNode).getStartNode().getDisplayFunctionName()));
             }
         }
-        parallelBranchEndNodes.add(branchEndNode);
+        pendingBranchEndNodes.add(branchEndNode);
         parallelBranchStartNodes.add(parallelStartNode);
     }
 


### PR DESCRIPTION
# Description
Syntactically, it is possible to have scripted parallel stages inside a declarative parallel stage. 
However, instead of marking failing stages as red, successful stages were marked as red.
See [JENKINS-50532](https://issues.jenkins-ci.org/browse/JENKINS-50532).

Reason was that the order in `nestedbranches` and `parallelBranchEndNodes` was different when reaching the second level of parallelism (inverted order). A second stack storing intermediately detected end nodes and putting them into the main stack after the corresponding branch start was detected helps to prevent that.

Additionally, with a new level of parallelism, new `parallelEnd` can be nested. Thus, `parallelEnds` has to become a stack.

In order to test this PR run the example pipeline from the ticket or the tests in Jenkins.

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

