### PR TITLE
Test deps no longer seem to be packaged with org.jenkins-ci.main:jenkins-war:executable-war:2.121.1:test so include them manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ acceptance-tests/live.properties
 src/main/groovy/pipeline.gdsl
 nb-configuration.xml
 nbactions.xml
-
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,76 @@
           <version>${jacoco.version}</version>
           <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+          <version>2.2</version>
+          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>ssh-cli-auth</artifactId>
+          <version>1.4</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>sshd</artifactId>
+          <version>2.4</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>slave-installer</artifactId>
+          <version>1.6</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>windows-slave-installer</artifactId>
+          <version>1.9.2</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>launchd-slave-installer</artifactId>
+          <version>1.2</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>upstart-slave-installer</artifactId>
+          <version>1.1</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>systemd-slave-installer</artifactId>
+          <version>1.1</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.ui</groupId>
+          <artifactId>jquery-detached</artifactId>
+          <version>1.2.1</version>
+          <scope>test</scope>
+          <classifier>core-assets</classifier>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.ui</groupId>
+          <artifactId>bootstrap</artifactId>
+          <version>1.3.2</version>
+          <scope>test</scope>
+          <classifier>core-assets</classifier>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.ui</groupId>
+          <artifactId>handlebars</artifactId>
+          <version>1.1.1</version>
+          <scope>test</scope>
+          <classifier>core-assets</classifier>
+      </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
Not quite fully ready to merge

# Description

Jenkins PCT is failing with cb's version of 2.150.2 mostly due to package loading issues:

```
target/surefire-reports/TEST-io.jenkins.blueocean.rest.impl.pipeline.MultiBranchTest.xml
116:   0.106 [id=3615]  WARNING hudson.ExtensionFinder$Sezpoz#scout: Failed to scout org.jenkinsci.plugins.gitserver.ssh.SshCommandFactoryImpl
117:java.lang.ClassNotFoundException: org.jenkinsci.main.modules.sshd.SshCommandFactory
122:Caused: java.lang.NoClassDefFoundError: org/jenkinsci/main/modules/sshd/SshCommandFactory
154:   0.109 [id=3615]  WARNING hudson.ExtensionFinder$Sezpoz#_find: Failed to load org.jenkinsci.plugins.gitserver.ssh.SshCommandFactoryImpl
155:java.lang.ClassNotFoundException: org.jenkinsci.main.modules.sshd.SshCommandFactory
160:Caused: java.lang.NoClassDefFoundError: org/jenkinsci/main/modules/sshd/SshCommandFactory
193:   0.123 [id=3615]  WARNING hudson.ExtensionFinder$Sezpoz#_find: Failed to load org.jenkinsci.plugins.gitserver.ssh.SshCommandFactoryImpl
```

So instead of depending on an upstream version to import them, manually import them.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

