### PR TITLE
JDK11 Support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,9 +29,9 @@ node() {
     sh "./acceptance-tests/runner/scripts/start-bitbucket-server.sh"
   }
 
-  docker.image('blueocean_build_env').inside("--net=container:blueo-selenium") {
-    withEnv(['GIT_COMMITTER_EMAIL=me@hatescake.com','GIT_COMMITTER_NAME=Hates','GIT_AUTHOR_NAME=Cake','GIT_AUTHOR_EMAIL=hates@cake.com']) {
-      try {
+  try {
+    docker.image('blueocean_build_env').inside("--net=container:blueo-selenium") {
+      withEnv(['GIT_COMMITTER_EMAIL=me@hatescake.com','GIT_COMMITTER_NAME=Hates','GIT_AUTHOR_NAME=Cake','GIT_AUTHOR_EMAIL=hates@cake.com']) {
         stage('Sanity check dependencies') {
           sh "node ./bin/checkdeps.js"
           sh "node ./bin/checkshrinkwrap.js"
@@ -81,21 +81,20 @@ node() {
             junit 'acceptance-tests/target/surefire-reports/*.xml'
           }
         }
-
-
-      } catch(err) {
-        currentBuild.result = "FAILURE"
-
-        if (err.toString().contains('exit code 143')) {
-          currentBuild.result = "ABORTED"
-        }
-      } finally {
-        stage('Cleanup') {
-          sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-selenium.sh"
-          sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-bitbucket-server.sh"
-          deleteDir()
-        }
       }
+    }
+
+  } catch(err) {
+    currentBuild.result = "FAILURE"
+
+    if (err.toString().contains('exit code 143')) {
+      currentBuild.result = "ABORTED"
+    }
+  } finally {
+    stage('Cleanup') {
+      sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-selenium.sh"
+      sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-bitbucket-server.sh"
+      deleteDir()
     }
   }
 }

--- a/acceptance-tests/runner/scripts/start-bitbucket-server.sh
+++ b/acceptance-tests/runner/scripts/start-bitbucket-server.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -x
 
 SCRIPT_DIR=$(dirname $0)
 $SCRIPT_DIR/stop-bitbucket-server.sh

--- a/acceptance-tests/runner/scripts/start-bitbucket-server.sh
+++ b/acceptance-tests/runner/scripts/start-bitbucket-server.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 SCRIPT_DIR=$(dirname $0)
 $SCRIPT_DIR/stop-bitbucket-server.sh

--- a/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
+++ b/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -x
 
 echo ""
 echo " Stopping old Bitbucket Docker container, if any. This may take a few seconds..."

--- a/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
+++ b/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
@@ -3,7 +3,7 @@ set -e
 
 echo ""
 echo " Stopping old Bitbucket Docker container, if any. This may take a few seconds..."
-docker stop blueo-bitbucket > /dev/null
-docker rm blueo-bitbucket > /dev/null
+docker stop blueo-bitbucket > /dev/null || true
+docker rm blueo-bitbucket > /dev/null || true
 echo "      ... stopped"
 echo ""

--- a/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
+++ b/acceptance-tests/runner/scripts/stop-bitbucket-server.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 echo ""
 echo " Stopping old Bitbucket Docker container, if any. This may take a few seconds..."

--- a/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
@@ -3,6 +3,7 @@ package io.blueocean.ath;
 import com.google.common.base.Function;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
@@ -13,12 +14,13 @@ import org.openqa.selenium.support.ui.FluentWait;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 
 @Singleton
 public class WaitUtil {
     public static int DEFAULT_TIMEOUT = Integer.getInteger("webDriverDefaultTimeout", 20000);
+    public static String DEFAULT_ERROR_MESSAGE = "Error while waiting for something";
     public static final int RETRY_COUNT = 10;
 
     private Logger logger = Logger.getLogger(WaitUtil.class);
@@ -33,8 +35,8 @@ public class WaitUtil {
     public <T> T until(Function<WebDriver, T> function, long timeoutInMS, String errorMessage) {
         try {
             return new FluentWait<>(driver)
-                .pollingEvery(100, TimeUnit.MILLISECONDS)
-                .withTimeout(timeoutInMS, TimeUnit.MILLISECONDS)
+                .pollingEvery(Duration.ofMillis(100))
+                .withTimeout(Duration.ofMillis(timeoutInMS))
                 .ignoring(NoSuchElementException.class)
                 .until((WebDriver driver) -> function.apply(driver));
         } catch(Throwable t) {
@@ -43,10 +45,10 @@ public class WaitUtil {
     }
 
     public <T> T until(Function<WebDriver, T> function, long timeoutInMS) {
-        return until(function, timeoutInMS, "Error while waiting for something");
+        return until(function, timeoutInMS, DEFAULT_ERROR_MESSAGE);
     }
     public <T> T until(Function<WebDriver, T> function) {
-        return until(function, DEFAULT_TIMEOUT);
+        return until(function, DEFAULT_TIMEOUT, DEFAULT_ERROR_MESSAGE);
     }
 
     public <T> T until(Function<WebDriver, T> function, String errorMessage) {
@@ -202,6 +204,14 @@ public class WaitUtil {
         } catch (InterruptedException ex) {
             logger.info("Exception thrown by tinySleep");
         }
+    }
+
+    /**
+     * Wait until the SSE is fully connected so events will propegate properly
+     */
+    public void untilSSEReady() {
+        until( driver -> ((JavascriptExecutor)driver).executeScript("return window.JenkinsBlueOceanCoreJSSSEConnected").equals(true));
+        logger.info("SSE connected");
     }
 
 }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/WaitUtil.java
@@ -210,6 +210,9 @@ public class WaitUtil {
      * Wait until the SSE is fully connected so events will propegate properly
      */
     public void untilSSEReady() {
+        // make sure the variable is defined
+        until( driver -> ((JavascriptExecutor)driver).executeScript("return typeof window.JenkinsBlueOceanCoreJSSSEConnected").equals("boolean"));
+        // then wait until sse is ready
         until( driver -> ((JavascriptExecutor)driver).executeScript("return window.JenkinsBlueOceanCoreJSSSEConnected").equals(true));
         logger.info("SSE connected");
     }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/DashboardPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/DashboardPage.java
@@ -20,6 +20,7 @@ public class DashboardPage implements WebDriverMixin {
     public void open() {
         go("/blue/");
         logger.info("Navigated to dashboard page");
+        wait.untilSSEReady();
     }
 
     public static By getSelectorForJob(String job) {

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/personalization/AbstractFavoritesTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/personalization/AbstractFavoritesTest.java
@@ -12,14 +12,16 @@ import io.blueocean.ath.factory.FreestyleJobFactory;
 import io.blueocean.ath.factory.MultiBranchPipelineFactory;
 import io.blueocean.ath.model.Folder;
 import io.blueocean.ath.pages.blue.FavoritesDashboardPage;
-import io.jenkins.blueocean.util.HttpRequest;
 import org.apache.log4j.Logger;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import java.io.IOException;
 
 /**
@@ -56,10 +58,6 @@ abstract public class AbstractFavoritesTest implements WebDriverMixin {
 
     abstract protected Logger getLogger();
 
-    private HttpRequest httpRequest() {
-        return new HttpRequest(base + "/blue/rest");
-    }
-
     @Before
     public void setUp() throws IOException {
         resources = new ResourceResolver(getClass());
@@ -67,12 +65,8 @@ abstract public class AbstractFavoritesTest implements WebDriverMixin {
         String user = "alice";
         getLogger().info(String.format("deleting any existing favorites for %s", user));
 
-        httpRequest()
-            .Delete("/users/{user}/favorites/")
-            .urlPart("user", user)
-            .auth(user, user)
-            .status(204)
-            .as(Void.class);
+        Client restClient = ClientBuilder.newClient().register(HttpAuthenticationFeature.basic(user, user));
+        restClient.target(base + "/users/" + user + "/favorites/").request().delete();
     }
 
     @After

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketApiTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketApiTest.java
@@ -32,7 +32,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Secret.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "javax.net.SocketFactory"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BitbucketApiTest  extends BbCloudWireMock{
 
     private BitbucketApi api;

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudScmContentProviderTest.java
@@ -40,7 +40,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Stapler.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*","javax.net.SocketFactory"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BitbucketCloudScmContentProviderTest extends BbCloudWireMock{
     @Test
     public void getContent() throws UnirestException, IOException {

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketApiTest.java
@@ -35,7 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Secret.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BitbucketApiTest extends BbServerWireMock {
     private BitbucketApi api;
 

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpointTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpointTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({BitbucketServerApi.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BitbucketServerEndpointTest extends BbServerWireMock {
     private static final String URL = "/organizations/jenkins/scm/bitbucket-server/servers/";
 

--- a/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
+++ b/blueocean-bitbucket-pipeline/src/test/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerScmContentProviderTest.java
@@ -40,7 +40,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Stapler.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BitbucketServerScmContentProviderTest extends BbServerWireMock {
 
     @Test

--- a/blueocean-core-js/src/js/index.ts
+++ b/blueocean-core-js/src/js/index.ts
@@ -60,9 +60,21 @@ export { BlueLogo } from './components/BlueLogo';
 export { ContentPageHeader, SiteHeader } from './components/ContentPageHeader';
 export { ResultPageHeader } from './components/ResultPageHeader';
 
+declare global {
+    interface Window {
+        JenkinsBlueOceanCoreJSSSEConnected: boolean;
+    }
+}
+window.JenkinsBlueOceanCoreJSSSEConnected = false;
+
 // Create and export the SSE connection that will be shared by other
 // Blue Ocean components via this package.
-export const sseConnection = sse.connect('jenkins-blueocean-core-js');
+export const sseConnection = sse.connect('jenkins-blueocean-core-js', function() {
+    // Declare SSE is fully loaded and ready for events.
+    // Mostly used by our ATH to prevent actions from happening
+    // too quickly
+    window.JenkinsBlueOceanCoreJSSSEConnected = true;
+});
 
 // export services as a singleton so all plugins will use the same instance
 

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCacheCloneReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCacheCloneReadSaveRequest.java
@@ -79,13 +79,18 @@ class GitCacheCloneReadSaveRequest extends GitReadSaveRequest {
                 Git activeRepo = getActiveRepository(repository);
                 Repository repo = activeRepo.getRepository();
                 File repoDir = repo.getDirectory().getParentFile();
+                FileInputStream fis = null;
                 try {
                     File f = new File(repoDir, filePath);
                     if (f.canRead()) {
-                        return IOUtils.toByteArray(new FileInputStream(f));
+                        fis = new FileInputStream(f);
+                        return IOUtils.toByteArray(fis);
                     }
                     return null;
                 } finally {
+                    if (fis != null) {
+                        fis.close();
+                    }
                     FileUtils.deleteDirectory(repoDir);
                 }
             }

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
@@ -8,6 +8,7 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.KeyPair;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
@@ -305,6 +306,8 @@ class GitUtils {
         }
     }
 
+    // TODO - remove once https://github.com/spotbugs/spotbugs/issues/756 is resolved
+    @SuppressFBWarnings(value={"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}, justification="JDK11 produces different bytecode - https://github.com/spotbugs/spotbugs/issues/756")
     public static void commit(final Repository repo, final String refName, final String path, final byte[] contents,
             final String name, final String email, final String message, final TimeZone timeZone, final Date when) {
 
@@ -436,6 +439,8 @@ class GitUtils {
         return inCoreIndex;
     }
 
+    // TODO - remove once https://github.com/spotbugs/spotbugs/issues/756 is resolved
+    @SuppressFBWarnings(value={"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}, justification="JDK11 produces different bytecode - https://github.com/spotbugs/spotbugs/issues/756")
     static byte[] readFile(Repository repository, String ref, String filePath) {
         try (ObjectReader reader = repository.newObjectReader()) {
             ObjectId branchRef = repository.resolve(ref); // repository.exactRef(ref);

--- a/blueocean-git-pipeline/src/test/java/io/jenkins/blueocean/blueocean_git_pipeline/GitScmTest.java
+++ b/blueocean-git-pipeline/src/test/java/io/jenkins/blueocean/blueocean_git_pipeline/GitScmTest.java
@@ -25,6 +25,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -38,6 +40,7 @@ import static org.junit.Assert.*;
  * @author Vivek Pandey
  */
 @RunWith(Parameterized.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GitScmTest extends PipelineBaseTest {
     public static final String HTTPS_GITHUB_NO_JENKINSFILE = "https://github.com/vivek/test-no-jenkins-file.git";
     public static final String HTTPS_GITHUB_PUBLIC = "https://github.com/cloudbeers/multibranch-demo.git";

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubApiTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubApiTest.java
@@ -8,6 +8,9 @@ import hudson.ProxyConfiguration;
 import io.jenkins.blueocean.credential.CredentialsUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -22,6 +25,8 @@ import static org.junit.Assert.*;
 /**
  * @author Vivek Pandey
  */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubApiTest extends GithubMockBase {
     @Test
     public void validateGithubToken() throws IOException, UnirestException {

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseApiTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseApiTest.java
@@ -7,6 +7,9 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import io.jenkins.blueocean.credential.CredentialsUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -23,6 +26,9 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author cliffmeyers
  */
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubEnterpriseApiTest extends GithubMockBase {
 
     @Test

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScmContentProviderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScmContentProviderTest.java
@@ -4,6 +4,9 @@ import io.jenkins.blueocean.rest.impl.pipeline.ScmContentProvider;
 import jenkins.branch.MultiBranchProject;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.*;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -11,6 +14,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 /**
  * @author cliffmeyers
  */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubEnterpriseScmContentProviderTest extends GithubMockBase {
 
     @Test

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssueTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssueTest.java
@@ -33,7 +33,10 @@ import static org.mockito.Mockito.when;
 @PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubIssueTest {
 
-    /* Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class) */
+    /*
+     * Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class)
+     * See https://stackoverflow.com/questions/19915270/mockito-stub-abstract-parent-class-method?rq=1
+     */
     public abstract class MockJob extends Job {
 
         @Nonnull

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssueTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubIssueTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
@@ -16,15 +17,35 @@ import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubIssueTest {
+
+    /* Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class) */
+    public abstract class MockJob extends Job {
+
+        @Nonnull
+        @Override
+        public ItemGroup getParent() {
+            return super.getParent();
+        }
+
+        protected MockJob(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+    }
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -38,7 +59,7 @@ public class GithubIssueTest {
 
     @Test
     public void jobNotImplemented() throws Exception {
-        Job job = mock(Job.class);
+        Job job = mock(MockJob.class);
         Collection<BlueIssue> resolved = BlueIssueFactory.resolve(job);
         Assert.assertTrue(resolved.isEmpty());
     }
@@ -46,7 +67,7 @@ public class GithubIssueTest {
     @Test
     public void changeSetEntry() throws Exception {
         MultiBranchProject project = mock(MultiBranchProject.class);
-        Job job = mock(Job.class);
+        Job job = mock(MockJob.class);
         Run run = mock(Run.class);
         ChangeLogSet logSet = mock(ChangeLogSet.class);
         ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
@@ -82,7 +103,7 @@ public class GithubIssueTest {
     @Test
     public void changeSetEntryIsNotGithub() throws Exception {
         MultiBranchProject project = mock(MultiBranchProject.class);
-        Job job = mock(Job.class);
+        Job job = mock(MockJob.class);
         Run run = mock(Run.class);
         ChangeLogSet logSet = mock(ChangeLogSet.class);
         ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
@@ -103,7 +124,7 @@ public class GithubIssueTest {
     @Test
     public void changeSetJobParentNotMultibranch() throws Exception {
         AbstractFolder project = mock(AbstractFolder.class);
-        Job job = mock(Job.class);
+        Job job = mock(MockJob.class);
         Run run = mock(Run.class);
         ChangeLogSet logSet = mock(ChangeLogSet.class);
         ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
@@ -13,8 +13,11 @@ import jenkins.model.ModifiableTopLevelItemGroup;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -24,6 +27,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubOrgFolderPermissionsTest extends GithubMockBase {
 
     @Test

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
@@ -44,7 +44,10 @@ import org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrai
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.TestExtension;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -56,6 +59,8 @@ import static org.junit.Assert.*;
 /**
  * @author Vivek Pandey
  */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubPipelineCreateRequestTest extends GithubMockBase {
     @Test
     public void createPipeline() throws UnirestException, IOException {

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProviderTest.java
@@ -10,9 +10,12 @@ import jenkins.branch.MultiBranchProject;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -24,6 +27,8 @@ import static org.powermock.api.mockito.PowerMockito.*;
 /**
  * @author Vivek Pandey
  */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubScmContentProviderTest extends GithubMockBase{
 
     @Test

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
@@ -149,7 +149,7 @@ public class GithubScmTest {
         String id = githubScm.getCredentialId();
         Assert.assertEquals(githubScm.getId(), id);
 
-        verifyStatic();
+        verifyStatic(HttpRequest.class);
 
         Assert.assertEquals("constructed url", "https://api.github.com/user", urlStringCaptor.getValue());
         Assert.assertEquals("access token passed to github", accessToken.trim(), tokenCaptor.getValue());

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmTest.java
@@ -29,6 +29,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -48,7 +49,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({GithubScm.class, Jenkins.class, Authentication.class, User.class, Secret.class,
     CredentialsMatchers.class, CredentialsProvider.class, Stapler.class, HttpRequest.class})
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class GithubScmTest {
 
     @Mock
@@ -148,8 +149,6 @@ public class GithubScmTest {
 
         String id = githubScm.getCredentialId();
         Assert.assertEquals(githubScm.getId(), id);
-
-        verifyStatic(HttpRequest.class);
 
         Assert.assertEquals("constructed url", "https://api.github.com/user", urlStringCaptor.getValue());
         Assert.assertEquals("access token passed to github", accessToken.trim(), tokenCaptor.getValue());

--- a/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/BlueJiraIssueTest.java
+++ b/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/BlueJiraIssueTest.java
@@ -17,6 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -32,6 +33,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JiraSite.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class BlueJiraIssueTest {
 
     @Rule

--- a/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
+++ b/blueocean-jira/src/test/java/io/jenkins/blueocean/service/embedded/jira/JiraSCMListenerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -33,6 +34,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JiraSite.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class JiraSCMListenerTest {
 
     @Rule

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/BranchMetadataTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/BranchMetadataTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest(Jenkins.class)
 public class BranchMetadataTest {
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.hudson.plugins.folder.Folder;
 import com.google.common.collect.Lists;
 import hudson.ExtensionList;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Job;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMHead;
@@ -14,34 +15,65 @@ import jenkins.scm.impl.mock.MockChangeRequestSCMHead;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.MockFolder;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
-@PrepareForTest(ExtensionList.class)
+@PrepareForTest({ ExtensionList.class })
 public class CachesTest {
 
-    Jenkins jenkins;
-    Job job;
+    /* Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class) */
+    public abstract class MockJob extends Job {
 
+        @Nonnull
+        @Override
+        public ItemGroup getParent() {
+            return super.getParent();
+        }
+
+        protected MockJob(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+    }
+
+    @Mock
+    Jenkins jenkins;
+
+    @Mock
+    MockJob job;
+
+    @Mock
+    Folder folder;
+
+    class MockMockFolder extends MockFolder {
+        protected MockMockFolder(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+    }
     @Before
-    public void setup() {
-        jenkins = mock(Jenkins.class);
+    public void setup() throws IOException {
         when(jenkins.getFullName()).thenReturn("");
 
-        Folder folder = mock(Folder.class);
         when(folder.getParent()).thenReturn(jenkins);
         when(folder.getFullName()).thenReturn("/Repo");
         when(jenkins.getItem("/Repo")).thenReturn(folder);
 
-        job = mock(Job.class);
         when(job.getParent()).thenReturn(folder);
         when(job.getFullName()).thenReturn("cool-branch");
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest(ExtensionList.class)
 public class CachesTest {
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CachesTest.java
@@ -15,7 +15,6 @@ import jenkins.scm.impl.mock.MockChangeRequestSCMHead;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.jvnet.hudson.test.MockFolder;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -23,7 +22,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,7 +36,10 @@ import static org.mockito.Mockito.when;
 @PrepareForTest({ ExtensionList.class })
 public class CachesTest {
 
-    /* Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class) */
+    /*
+     * Totally a dumb subclass so mockito can find the invocation of getParent properly (since parent is protected class)
+     * See https://stackoverflow.com/questions/19915270/mockito-stub-abstract-parent-class-method?rq=1
+     */
     public abstract class MockJob extends Job {
 
         @Nonnull
@@ -61,13 +62,8 @@ public class CachesTest {
     @Mock
     Folder folder;
 
-    class MockMockFolder extends MockFolder {
-        protected MockMockFolder(ItemGroup parent, String name) {
-            super(parent, name);
-        }
-    }
     @Before
-    public void setup() throws IOException {
+    public void setup() {
         when(jenkins.getFullName()).thenReturn("");
 
         when(folder.getParent()).thenReturn(jenkins);

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolderTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/OrganizationFolderTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
  * @author Vivek Pandey
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest({OrganizationFactory.class, OrganizationFolder.class, StaplerRequest.class})
 public class OrganizationFolderTest{
     @Rule

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/Tally.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/Tally.java
@@ -12,13 +12,7 @@ public final class Tally {
      * @param key to increment tally by 1
      */
     public void count(String key) {
-        Integer count = tally.get(key);
-        if (count == null) {
-            count = 1;
-        } else {
-            count++;
-        }
-        tally.put(key, count);
+        tally.put(key, tally.getOrDefault(key, 0) + 1);
     }
 
     /**

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ContainerFilterTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/ContainerFilterTest.java
@@ -29,7 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
  * @author Vivek Pandey
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest(Stapler.class)
 public class ContainerFilterTest extends BaseTest{
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/ArtifactImplTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/ArtifactImplTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import static org.hamcrest.CoreMatchers.is;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest({Run.class,Link.class})
 public class ArtifactImplTest {
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
@@ -52,6 +52,7 @@ import org.kohsuke.stapler.verb.DELETE;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -79,6 +80,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 @PrepareForTest({ Jenkins.class, User.class })
 public class UserImplPermissionTest {
     private TestOrganization testOrganization;
@@ -123,7 +125,7 @@ public class UserImplPermissionTest {
         } catch (NoSuchMethodException e) {
             when(jenkins.hasPermission(Mockito.any())).thenAnswer(new Answer<Boolean>() {
                 public Boolean answer(InvocationOnMock invocation) {
-                    Permission permission = invocation.getArgumentAt(0, Permission.class);
+                    Permission permission = invocation.getArgument(0);
                     Jenkins j = (Jenkins) invocation.getMock();
                     return j.getACL().hasPermission(permission);
                 }

--- a/jenkins-design-language/npm-shrinkwrap.json
+++ b/jenkins-design-language/npm-shrinkwrap.json
@@ -13380,6 +13380,12 @@
       "integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE=",
       "dev": true
     },
+    "mockdate": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.2.tgz",
+      "integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=",
+      "dev": true
+    },
     "module-deps": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",

--- a/jenkins-design-language/npm-shrinkwrap.json
+++ b/jenkins-design-language/npm-shrinkwrap.json
@@ -654,13 +654,13 @@
     "@types/node": {
       "version": "10.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
-      "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA==",
+      "integrity": "sha1-1clsokakGEBJFNGAt/3WJa0Y7KY=",
       "dev": true
     },
     "@types/prop-types": {
       "version": "15.5.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.5.tgz",
-      "integrity": "sha512-mOrlCEdwX3seT3n0AXNt4KNPAZZxcsABUHwBgFXOt+nvFUXkxCAO6UBJHPrDxWEa2KDMil86355fjo8jbZ+K0Q==",
+      "integrity": "sha1-FwON0yLCMl9dplCpTV+ZdJQ2JeM=",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -669,7 +669,7 @@
     "@types/react": {
       "version": "16.4.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.14.tgz",
-      "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
+      "integrity": "sha1-R8YEyORu1nS730qr+Cs0uQQcagQ=",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -679,7 +679,7 @@
     "@types/react-dom": {
       "version": "16.0.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.7.tgz",
-      "integrity": "sha512-vaq4vMaJOaNgFff1t3LnHYr6vRa09vRspMkmLdXtFZmO1fwDI2snP+dpOkwrtlU8UC8qsqemCu4RmVM2OLq/fA==",
+      "integrity": "sha1-VND4Z6drkFl+hDIDDSl5gvJcILo=",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4865,7 +4865,7 @@
     "csstype": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw==",
+      "integrity": "sha1-v5I11YchQezPstFtgpk8axSRef8=",
       "dev": true
     },
     "csurf": {
@@ -18793,7 +18793,7 @@
     "typescript": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "integrity": "sha1-SFOz4nXs2qJ/eP2kbcJzp+t/wcg=",
       "dev": true
     },
     "ua-parser-js": {

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -90,6 +90,7 @@
     "harp": "0.24.0",
     "jest": "19.0.2",
     "less": "2.7.2",
+    "mockdate": "^2.0.2",
     "normalize.css": "5.0.0",
     "octicons": "4.4.0",
     "react-addons-test-utils": "15.4.2",

--- a/jenkins-design-language/package.json
+++ b/jenkins-design-language/package.json
@@ -90,7 +90,7 @@
     "harp": "0.24.0",
     "jest": "19.0.2",
     "less": "2.7.2",
-    "mockdate": "^2.0.2",
+    "mockdate": "2.0.2",
     "normalize.css": "5.0.0",
     "octicons": "4.4.0",
     "react-addons-test-utils": "15.4.2",

--- a/jenkins-design-language/test/js/components/ReadableDate-spec.jsx
+++ b/jenkins-design-language/test/js/components/ReadableDate-spec.jsx
@@ -2,8 +2,12 @@ import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
+import MockDate from 'mockdate';
 
 import { ReadableDate } from '../../../src/js/components';
+
+beforeEach(() => MockDate.set('2017-02-01'));
+afterEach(() => MockDate.reset());
 
 describe("ReadableDate", () => {
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     <frontend-version>1.6</frontend-version>
     <node.version>6.4.0</node.version>
     <npm.version>3.10.3</npm.version>
-    <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
-    <findbugs.failOnError>true</findbugs.failOnError>
+    <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
     <powermock.version>2.0.0-RC.4</powermock.version>
     <mockito.version>2.23.4</mockito.version>
     <guava.version>11.0.1</guava.version>
@@ -900,14 +900,14 @@
                   <version>2.10.4</version>
               </plugin>
               <plugin>
-                  <groupId>org.codehaus.mojo</groupId>
-                  <artifactId>findbugs-maven-plugin</artifactId>
-                  <version>${findbugs-maven-plugin.version}</version>
+                  <groupId>com.github.spotbugs</groupId>
+                  <artifactId>spotbugs-maven-plugin</artifactId>
+                  <version>${spotbugs-maven-plugin.version}</version>
                   <configuration>
                       <effort>Max</effort>
                       <threshold>Default</threshold>
                       <xmlOutput>true</xmlOutput>
-                      <findbugsXmlOutput>false</findbugsXmlOutput>
+                      <spotbugsXmlOutput>false</spotbugsXmlOutput>
                   </configuration>
               </plugin>
               <plugin>
@@ -1021,10 +1021,10 @@
           </configuration>
       </plugin>
 
-        <!-- run findbugs on all modules -->
+        <!-- run spotbugs on all modules -->
         <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
         </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.22</version>
+            <version>3.0-java11-alpha-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.28</version>
+    <version>3.32</version>
   </parent>
 
   <groupId>io.jenkins.blueocean</groupId>
@@ -27,24 +27,26 @@
     <revision>1.11.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.121.1</jenkins.version> <!-- Should be kept in sync with the version resulting from Dockerfile FROM statement-->
+    <jenkins.version>2.156</jenkins.version> <!-- Should be kept in sync with the version resulting from Dockerfile FROM statement-->
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <frontend-version>1.6</frontend-version>
     <node.version>6.4.0</node.version>
     <npm.version>3.10.3</npm.version>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
-    <powermock.version>1.6.6</powermock.version>
+    <powermock.version>2.0.0-RC.4</powermock.version>
+    <mockito.version>2.23.4</mockito.version>
     <guava.version>11.0.1</guava.version>
     <jacoco.version>0.8.2</jacoco.version>
     <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
     <jacoco.line.coverage>0.70</jacoco.line.coverage>
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
-    <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
     <scm-api.version>2.2.8</scm-api.version>
     <git.version>3.8.0</git.version>
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
+    <plugin.minimumJavaVersion>11</plugin.minimumJavaVersion>
   </properties>
 
   <scm>
@@ -185,7 +187,7 @@
       </dependency>
       <dependency>
           <groupId>org.powermock</groupId>
-          <artifactId>powermock-api-mockito</artifactId>
+          <artifactId>powermock-api-mockito2</artifactId>
           <scope>test</scope>
       </dependency>
       <dependency>
@@ -581,7 +583,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -696,7 +698,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
 
@@ -789,7 +791,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <!--We need 1.x version untile powermock has decent support for mockito2-->
-            <version>1.10.19</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -816,7 +818,13 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
@@ -1005,7 +1013,7 @@
               <!--
               The following line is the one that's a must. Without it, with get jacoco complexity failures.
               -->
-              <argLine>-Djava.awt.headless=true ${argLine}</argLine>
+              <argLine>-Djava.awt.headless=true --illegal-access=permit ${argLine}</argLine>
               <rerunFailingTestsCount>0</rerunFailingTestsCount>
               <systemPropertyVariables>
                   <jacoco-agent.destfile>${project.build.directory}/code-coverage/jacoco.exec</jacoco-agent.destfile>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <revision>1.11.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.156</jenkins.version> <!-- Should be kept in sync with the version resulting from Dockerfile FROM statement-->
+    <jenkins.version>2.121.1</jenkins.version> <!-- Should be kept in sync with the version resulting from Dockerfile FROM statement-->
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <frontend-version>1.6</frontend-version>
     <node.version>6.4.0</node.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1013,7 +1013,7 @@
               <!--
               The following line is the one that's a must. Without it, with get jacoco complexity failures.
               -->
-              <argLine>-Djava.awt.headless=true --illegal-access=permit ${argLine}</argLine>
+              <argLine>-Djava.awt.headless=true ${argLine}</argLine>
               <rerunFailingTestsCount>0</rerunFailingTestsCount>
               <systemPropertyVariables>
                   <jacoco-agent.destfile>${project.build.directory}/code-coverage/jacoco.exec</jacoco-agent.destfile>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.0-java11-alpha-1</version>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <git.version>3.8.0</git.version>
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
     <plugin.minimumJavaVersion>11</plugin.minimumJavaVersion>
-    <workflow-support.version>3.1</workflow-support.version>
+    <workflow-support.version>3.2</workflow-support.version>
   </properties>
 
   <scm>
@@ -370,7 +370,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.16</version>
+            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.0</version>
+            <version>3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.22</version>
+            <version>3.1</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.32</version>
+    <version>3.36</version>
   </parent>
 
   <groupId>io.jenkins.blueocean</groupId>
@@ -32,8 +32,6 @@
     <frontend-version>1.6</frontend-version>
     <node.version>6.4.0</node.version>
     <npm.version>3.10.3</npm.version>
-    <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
-    <spotbugs.failOnError>true</spotbugs.failOnError>
     <powermock.version>2.0.0-RC.4</powermock.version>
     <mockito.version>2.23.4</mockito.version>
     <guava.version>11.0.1</guava.version>
@@ -901,17 +899,6 @@
                   <version>2.10.4</version>
               </plugin>
               <plugin>
-                  <groupId>com.github.spotbugs</groupId>
-                  <artifactId>spotbugs-maven-plugin</artifactId>
-                  <version>${spotbugs-maven-plugin.version}</version>
-                  <configuration>
-                      <effort>Max</effort>
-                      <threshold>Default</threshold>
-                      <xmlOutput>true</xmlOutput>
-                      <spotbugsXmlOutput>false</spotbugsXmlOutput>
-                  </configuration>
-              </plugin>
-              <plugin>
                   <groupId>org.jacoco</groupId>
                   <artifactId>jacoco-maven-plugin</artifactId>
                   <version>${jacoco.version}</version>
@@ -1021,12 +1008,6 @@
               </systemPropertyVariables>
           </configuration>
       </plugin>
-
-        <!-- run spotbugs on all modules -->
-        <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <git.version>3.8.0</git.version>
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
     <plugin.minimumJavaVersion>11</plugin.minimumJavaVersion>
+    <workflow-support.version>3.1</workflow-support.version>
   </properties>
 
   <scm>
@@ -381,12 +382,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.1</version>
+            <version>${workflow-support.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.1</version>
+            <version>${workflow-support.version}</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Description

Upgrade code to support JDK11 compilation and runtime.

Most of the changes are just to the tests, upgrading to mockito/powermock2, adding a few powermock ignores for jdk11 internals.

One minor change because findbugs was complaining about an unused variable, just rewrote it to not use the variable.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

cc @jenkinsci/java11-support 