### PR TITLE
JENKINS-53019 - Changes tab does not group changes for multiple SCM providers by SCM

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -56,30 +56,42 @@ export default class RunDetailsChanges extends Component {
             JTable.column(100, dateLabel),
         ];
 
+        const changeSetSplitBySource = [];
+        changeSet.map(commit => {
+            if (changeSetSplitBySource[commit.checkoutCount] === undefined) {
+                changeSetSplitBySource[commit.checkoutCount] = [];
+            }
+            changeSetSplitBySource[commit.checkoutCount].push(commit);
+        });
+
         return (
-            <JTable columns={columns} className="changeset-table">
-                <TableHeaderRow />
-                {changeSet.map(commit => (
-                    <TableRow key={commit.commitId}>
-                        <TableCell>
-                            <CommitId commitId={commit.commitId} url={commit.url} />
-                        </TableCell>
-                        <TableCell>{commit.author.fullName}</TableCell>
-                        <TableCell className="multipleLines">
-                            <LinkifiedText text={commit.msg} partialTextLinks={commit.issues} />
-                        </TableCell>
-                        <TableCell>
-                            <ReadableDate
-                                date={commit.timestamp}
-                                liveUpdate
-                                locale={locale}
-                                shortFormat={t('common.date.readable.short', { defaultValue: 'MMM DD h:mma Z' })}
-                                longFormat={t('common.date.readable.long', { defaultValue: 'MMM DD YYYY h:mma Z' })}
-                            />
-                        </TableCell>
-                    </TableRow>
+            <div>
+                {changeSetSplitBySource.map(changeSet => (
+                    <JTable columns={columns} className="changeset-table">
+                        <TableHeaderRow />
+                        {changeSet.map(commit => (
+                            <TableRow key={commit.commitId}>
+                                <TableCell>
+                                    <CommitId commitId={commit.commitId} url={commit.url} />
+                                </TableCell>
+                                <TableCell>{commit.author.fullName}</TableCell>
+                                <TableCell className="multipleLines">
+                                    <LinkifiedText text={commit.msg} partialTextLinks={commit.issues} />
+                                </TableCell>
+                                <TableCell>
+                                    <ReadableDate
+                                        date={commit.timestamp}
+                                        liveUpdate
+                                        locale={locale}
+                                        shortFormat={t('common.date.readable.short', { defaultValue: 'MMM DD h:mma Z' })}
+                                        longFormat={t('common.date.readable.long', { defaultValue: 'MMM DD YYYY h:mma Z' })}
+                                    />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </JTable>
                 ))}
-            </JTable>
+            </div>
         );
     }
 }

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -51,6 +51,7 @@ button.btn-show-more {
 .changeset-table {
     margin-left:auto;
     margin-right:auto;
+    margin-bottom: 20px;
 }
 
 .artifacts-table {

--- a/blueocean-dashboard/src/test/js/data/runs/latestRuns.js
+++ b/blueocean-dashboard/src/test/js/data/runs/latestRuns.js
@@ -30,6 +30,7 @@ export const latestRuns = [{
             'affectedPaths': [
                 'Jenkinsfile'
             ],
+            'checkoutCount': '0',
             'commitId': '21552ff3072684cc1d593376b7cc7023deb15e1c',
             'comment': 'Update Jenkinsfile\n',
             'date': '2016-03-15 00:35:58 +0100',
@@ -49,6 +50,7 @@ export const latestRuns = [{
             'affectedPaths': [
                 'Jenkinsfile'
             ],
+            'checkoutCount': '0',
             'commitId': 'eb92e0df899ff742b002a3ea652f4eb406ea83b8',
             'comment': 'Update Jenkinsfile\n',
             'date': '2016-03-15 00:33:40 +0100',

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -87,6 +87,7 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
         } else {
             Map<String, BlueChangeSetEntry> m = new LinkedHashMap<>();
             int cnt = 0;
+            int checkoutCount = 0;
             for (ChangeLogSet<? extends Entry> cs : run.getChangeSets()) {
                 for (ChangeLogSet.Entry e : cs) {
                     cnt++;
@@ -95,8 +96,9 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
                     {
                         id = String.valueOf( cnt );
                     }
-                    m.put(id, new ChangeSetResource(organization, e, this));
+                    m.put(id, new ChangeSetResource(organization, e, this).setCheckoutCount(checkoutCount));
                 }
+                checkoutCount++;
             }
             return Containers.fromResourceMap(getLink(), m);
         }

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
@@ -1,0 +1,70 @@
+package io.jenkins.blueocean.rest.impl.pipeline;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import hudson.model.Run;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PipelineRunImplTest extends PipelineBaseTest {
+
+    @Rule
+    public GitSampleRepoRule sampleRepo1 = new GitSampleRepoRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
+
+    @Test
+    @Issue("JENKINS-53019")
+    public void testMultipleRepoChangeSet() throws Exception {
+        String jenkinsFile = Resources.toString(Resources.getResource(getClass(), "mulitpleScms.jenkinsfile"), Charsets.UTF_8).replaceAll("%REPO1%", sampleRepo1.toString()).replaceAll("%REPO2%", sampleRepo2.toString());
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "project");
+        p.setDefinition(new CpsFlowDefinition(jenkinsFile, true));
+        p.save();
+
+        sampleRepo1.init();
+        sampleRepo2.init();
+
+        Run r = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(r);
+
+        updateREADME(sampleRepo1);
+        updateREADME(sampleRepo2);
+        updateREADME(sampleRepo2);
+
+        r = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(r);
+
+        System.out.println("----");
+        System.out.println(jenkinsFile);
+        System.out.println("----");
+
+        Map<String, Object> runDetails = get("/organizations/jenkins/pipelines/" + p.getName() + "/runs/" + r.getId() + "/");
+        HashSet<String> commitIds = new HashSet<>();
+        for (Object o : (ArrayList) runDetails.get("changeSet")) {
+            commitIds.add(((Map) o).get("checkoutCount").toString());
+        }
+        assertEquals(commitIds, new HashSet<>(Arrays.asList("0", "1")));
+    }
+
+    private int updateREADMECounter = 0;
+    private void updateREADME(GitSampleRepoRule sampleRepo) throws Exception {
+        updateREADMECounter++;
+        sampleRepo.write("README.md", "README + " + updateREADMECounter + ":" + sampleRepo.toString());
+        sampleRepo.git("add", "README.md");
+        sampleRepo.git("commit", "--all", "--message=README + " + updateREADMECounter + ":" + sampleRepo.toString());
+
+    }
+}

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
@@ -2,6 +2,7 @@ package io.jenkins.blueocean.rest.impl.pipeline;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import hudson.model.Result;
 import hudson.model.Run;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -37,16 +38,15 @@ public class PipelineRunImplTest extends PipelineBaseTest {
         sampleRepo1.init();
         sampleRepo2.init();
 
-        Run r = p.scheduleBuild2(0).waitForStart();
-        j.waitForCompletion(r);
+        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
 
         updateREADME(sampleRepo1);
         updateREADME(sampleRepo2);
         TimeUnit.SECONDS.sleep(1);
         updateREADME(sampleRepo2);
+        TimeUnit.SECONDS.sleep(1);
 
-        r = p.scheduleBuild2(0).waitForStart();
-        j.waitForCompletion(r);
+        Run r = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
 
         Map<String, Object> runDetails = get("/organizations/jenkins/pipelines/" + p.getName() + "/runs/" + r.getId() + "/");
         HashSet<String> commitIds = new HashSet<>();

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImplTest.java
@@ -13,10 +13,10 @@ import org.jvnet.hudson.test.Issue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class PipelineRunImplTest extends PipelineBaseTest {
 
@@ -42,21 +42,19 @@ public class PipelineRunImplTest extends PipelineBaseTest {
 
         updateREADME(sampleRepo1);
         updateREADME(sampleRepo2);
+        TimeUnit.SECONDS.sleep(1);
         updateREADME(sampleRepo2);
 
         r = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(r);
-
-        System.out.println("----");
-        System.out.println(jenkinsFile);
-        System.out.println("----");
 
         Map<String, Object> runDetails = get("/organizations/jenkins/pipelines/" + p.getName() + "/runs/" + r.getId() + "/");
         HashSet<String> commitIds = new HashSet<>();
         for (Object o : (ArrayList) runDetails.get("changeSet")) {
             commitIds.add(((Map) o).get("checkoutCount").toString());
         }
-        assertEquals(commitIds, new HashSet<>(Arrays.asList("0", "1")));
+        assertEquals(3, ((ArrayList) runDetails.get("changeSet")).size());
+        assertEquals(new HashSet<>(Arrays.asList("0", "1")), commitIds);
     }
 
     private int updateREADMECounter = 0;

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
@@ -1,0 +1,44 @@
+pipeline {
+    agent any
+    stages {
+        stage('SCM') {
+            parallel {
+                stage('Master Branch') {
+                    steps {
+                        script {
+                            checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo1' ]],
+                                submoduleCfg: [],
+                                userRemoteConfigs:[[ name: 'origin', url: '%REPO1%' ]]
+                            ])
+                        }
+                    }
+                }
+                stage('Justreadme Project Branch') {
+                    steps {
+                        script {
+                            checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo2' ]],
+                                submoduleCfg: [],
+                                userRemoteConfigs:[[ name: 'origin', url: '%REPO2%' ]]
+                            ])
+                        }
+                    }
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                script {
+                    echo "build step"
+                    sh "ls"
+                }
+            }
+        }
+        stage('Results') {
+            steps {
+                script {
+                    echo "results step"
+                }
+            }
+        }
+    }
+}

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
@@ -2,25 +2,23 @@ pipeline {
     agent any
     stages {
         stage('SCM') {
-            parallel {
-                stage('Master Branch') {
-                    steps {
-                        script {
-                            checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo1' ]],
-                                submoduleCfg: [],
-                                userRemoteConfigs:[[ name: 'origin', url: '%REPO1%' ]]
-                            ])
-                        }
+            stage('Master Branch') {
+                steps {
+                    script {
+                        checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo1' ]],
+                            submoduleCfg: [],
+                            userRemoteConfigs:[[ name: 'origin', url: '%REPO1%' ]]
+                        ])
                     }
                 }
-                stage('Justreadme Project Branch') {
-                    steps {
-                        script {
-                            checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo2' ]],
-                                submoduleCfg: [],
-                                userRemoteConfigs:[[ name: 'origin', url: '%REPO2%' ]]
-                            ])
-                        }
+            }
+            stage('Justreadme Project Branch') {
+                steps {
+                    script {
+                        checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo2' ]],
+                            submoduleCfg: [],
+                            userRemoteConfigs:[[ name: 'origin', url: '%REPO2%' ]]
+                        ])
                     }
                 }
             }

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/mulitpleScms.jenkinsfile
@@ -1,25 +1,23 @@
 pipeline {
     agent any
     stages {
-        stage('SCM') {
-            stage('Master Branch') {
-                steps {
-                    script {
-                        checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo1' ]],
-                            submoduleCfg: [],
-                            userRemoteConfigs:[[ name: 'origin', url: '%REPO1%' ]]
-                        ])
-                    }
+        stage('Master Branch') {
+            steps {
+                script {
+                    checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo1' ]],
+                        submoduleCfg: [],
+                        userRemoteConfigs:[[ name: 'origin', url: '%REPO1%' ]]
+                    ])
                 }
             }
-            stage('Justreadme Project Branch') {
-                steps {
-                    script {
-                        checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo2' ]],
-                            submoduleCfg: [],
-                            userRemoteConfigs:[[ name: 'origin', url: '%REPO2%' ]]
-                        ])
-                    }
+        }
+        stage('Justreadme Project Branch') {
+            steps {
+                script {
+                    checkout([ $class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[ $class: 'RelativeTargetDirectory', relativeTargetDir: 'repo2' ]],
+                        submoduleCfg: [],
+                        userRemoteConfigs:[[ name: 'origin', url: '%REPO2%' ]]
+                    ])
                 }
             }
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
@@ -34,8 +34,8 @@ import java.util.Collection;
 public class ChangeSetResource extends BlueChangeSetEntry {
     private final ChangeLogSet.Entry changeSet;
     private final Reachable parent;
-
     private final BlueOrganization organization;
+    private int checkoutCount;
 
     public ChangeSetResource(@Nonnull BlueOrganization organization, Entry changeSet, Reachable parent) {
         this.organization = organization;
@@ -92,6 +92,17 @@ public class ChangeSetResource extends BlueChangeSetEntry {
     @Override
     public Collection<BlueIssue> getIssues() {
         return BlueIssueFactory.resolve(changeSet);
+    }
+
+    @Override
+    public Integer getCheckoutCount() {
+        return this.checkoutCount;
+    }
+
+    @Override
+    public BlueChangeSetEntry setCheckoutCount(int checkoutCount) {
+        this.checkoutCount = checkoutCount;
+        return this;
     }
 
     @Override

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueChangeSetEntry.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueChangeSetEntry.java
@@ -21,6 +21,7 @@ public abstract class BlueChangeSetEntry extends Resource {
     public static final String AFFECTED_PATHS = "affectedPaths";
     public static final String URL = "url";
     public static final String ISSUES = "issues";
+    public static final String CHECKOUT_COUNT = "checkoutCount";
 
     /**
      * Returns a human readable display name of the commit number, revision number, and such thing
@@ -96,4 +97,9 @@ public abstract class BlueChangeSetEntry extends Resource {
      */
     @Exported(name = ISSUES, skipNull = true, inline = true)
     public abstract Collection<BlueIssue> getIssues();
+
+    @Exported(name = CHECKOUT_COUNT)
+    public abstract Integer getCheckoutCount();
+
+    public abstract BlueChangeSetEntry setCheckoutCount(int checkoutCount);
 }


### PR DESCRIPTION
Add a commit count field to be able to figure out which repo/instance it is

# Description

See [JENKINS-53019](https://issues.jenkins-ci.org/browse/JENKINS-53019).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

