### PR TITLE
[JENKINS-56301] add missing referrer and robots meta tags

### DIFF
--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -27,7 +27,11 @@
 
             <title>Jenkins</title>
 
+            <j:if test="${!isMSIE}">
+                <meta name="referrer" content="same-origin"></meta>
+            </j:if>
             <j:if test="${isMSIE}">
+                <meta name="referrer" content="never"></meta>
                 <meta http-equiv="X-UA-Compatible" content="IE=edge"></meta>
                 <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1"></meta>
                 <script src="${resURL}/plugin/blueocean-web/scripts/ie-detect.js"></script>
@@ -35,6 +39,9 @@
                 <st:adjunct includes="org.jenkins.ui.jsmodules.blueocean-web.iepolyfills"/>
                 <st:adjunct includes="org.jenkinsci.plugins.ssegateway.sse.EventSource" />
             </j:if>
+
+            <meta name="robots" content="index, nofollow"></meta>
+
             <j:set var="assetsPath" value="${resURL}/plugin/blueocean-web/assets" />
 
             <!-- Inject headers from other extensions. See BluePageDecorator.java -->


### PR DESCRIPTION
Adds referrer and robots meta tags that will not send the referrer url so we don't send job/branch names to third parties.

Tested on Chrome, Firefox, IE and Edge.

See [JENKINS-56301](https://issues.jenkins-ci.org/browse/JENKINS-56301).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

