### PR TITLE
remove all the version requirements from blueocean-executor since its defined in the parent pom

### DIFF
--- a/blueocean-executor-info-plugin/pom.xml
+++ b/blueocean-executor-info-plugin/pom.xml
@@ -25,56 +25,46 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.44</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
         </dependency>
 
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-pipeline-api-impl</artifactId>
-            <version>${revision}${changelist}</version>
         </dependency>
 
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean</artifactId>
-            <version>${revision}${changelist}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-rest</artifactId>
-            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.blueocean</groupId>
             <artifactId>blueocean-web</artifactId>
-            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.14</version>
         </dependency>
     </dependencies>
 
@@ -93,28 +83,26 @@
 
     <build>
         <plugins>
-                    <!-- run upstream dependency fetches for all js plugins -->
-                    <plugin>
-                        <groupId>io.jenkins.blueocean</groupId>
-                        <artifactId>blueocean-maven-plugin</artifactId>
-                        <version>0.0.2</version>
-                        <executions>
-                            <execution>
-                                <id>upstream-dependencies</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>process-node-dependencies</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>package</id>
-                                <goals>
-                                    <goal>package-blueocean-resources</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
+            <!-- run upstream dependency fetches for all js plugins -->
+            <plugin>
+                <groupId>io.jenkins.blueocean</groupId>
+                <artifactId>blueocean-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>upstream-dependencies</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>process-node-dependencies</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>package</id>
+                        <goals>
+                            <goal>package-blueocean-resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
# Description

Release spit out:
```
    [WARNING] Rule 5: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
    Failed while enforcing RequireUpperBoundDeps. The error(s) are [
    Require upper bound dependencies error for io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT paths to dependency are:
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-events:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-events:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-github-pipeline:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-github-pipeline:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-git-pipeline:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-git-pipeline:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-bitbucket-pipeline:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-bitbucket-pipeline:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-pipeline-editor:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-editor:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
    , 
    Require upper bound dependencies error for io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT paths to dependency are:
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean-web:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-pipeline-scm-api:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-scm-api:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.1.5
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean-pipeline-api-impl:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-rest-impl:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest-impl:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-i18n:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-i18n:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-config:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-config:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-pipeline-editor:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-pipeline-editor:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-io.jenkins.blueocean:blueocean-jira:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-jira:1.12.0-SNAPSHOT
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.12.0-SNAPSHOT
    and
    +-io.jenkins.blueocean:blueocean-executor-info:1.12.0
      +-io.jenkins.blueocean:blueocean:1.12.0-SNAPSHOT
        +-org.jenkins-ci.plugins:blueocean-display-url:2.2.0
          +-io.jenkins.blueocean:blueocean-rest:1.12.0 (managed) <-- io.jenkins.blueocean:blueocean-rest:1.1.5
```