### PR TITLE
[JENKINS-52825] - Add blueocean-executor-info-plugin to the blueoceanmeta package as a dependancy

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>blueocean-jira</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blueocean-executor-info-plugin</artifactId>
+        </dependency>
+
         <!-- Bundled plugins for improved out of the box experience -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
# Description

See [JENKINS-52825](https://issues.jenkins-ci.org/browse/JENKINS-52825).

As per craig on gitter, new plugin should be installed by default.

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

