### PR TITLE
[JENKINS-51716] Prevent non numeric run id from throwing exception when a run is actually found

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
@@ -56,39 +56,31 @@ public class RunContainerImpl extends BlueRunContainer {
     public BlueRun get(String name) {
         RunList<? extends hudson.model.Run> runList = job.getBuilds();
 
-        hudson.model.Run run = null;
-        if (name != null) {
-            for (hudson.model.Run r : runList) {
-                if (r.getId().equals(name)) {
-                    run = r;
-                    break;
-                }
-            }
-
-            if (run == null) {
-                int number;
-                try {
-                    number = Integer.parseInt(name);
-                } catch (NumberFormatException e) {
-                    throw new NotFoundException(String.format("Run %s not found in organization %s and pipeline %s",
-                            name, pipeline.getOrganizationName(), job.getName()));
-                }
-                for (BlueQueueItem item : QueueUtil.getQueuedItems(pipeline.getOrganization(), job)) {
-                    if (item.getExpectedBuildNumber() == number) {
-                        return item.toRun();
-                    }
-                }
-            }
-
-            if (run == null) {
-                throw new NotFoundException(
-                    String.format("Run %s not found in organization %s and pipeline %s",
-                        name, pipeline.getOrganizationName(), job.getName()));
-            }
-        } else {
-            run = runList.getLastBuild();
+        if (name == null) {
+            return BlueRunFactory.getRun(runList.getLastBuild(), pipeline);
         }
-        return BlueRunFactory.getRun(run, pipeline);
+
+        for (hudson.model.Run r : runList) {
+            if (r.getId().equals(name)) {
+                return BlueRunFactory.getRun(r, pipeline);
+            }
+        }
+
+        int number;
+        try {
+            number = Integer.parseInt(name);
+        } catch (NumberFormatException e) {
+            throw new NotFoundException(String.format("Run %s not found in organization %s and pipeline %s",
+                    name, pipeline.getOrganizationName(), job.getName()));
+        }
+        for (BlueQueueItem item : QueueUtil.getQueuedItems(pipeline.getOrganization(), job)) {
+            if (item.getExpectedBuildNumber() == number) {
+                return item.toRun();
+            }
+        }
+        throw new NotFoundException(
+            String.format("Run %s not found in organization %s and pipeline %s",
+                name, pipeline.getOrganizationName(), job.getName()));
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/RunContainerImpl.java
@@ -65,16 +65,18 @@ public class RunContainerImpl extends BlueRunContainer {
                 }
             }
 
-            int number;
-            try {
-                number = Integer.parseInt(name);
-            } catch (NumberFormatException e) {
-                throw new NotFoundException(String.format("Run %s not found in organization %s and pipeline %s",
-                    name, pipeline.getOrganizationName(), job.getName()));
-            }
-            for (BlueQueueItem item : QueueUtil.getQueuedItems(pipeline.getOrganization(), job)) {
-                if (item.getExpectedBuildNumber() == number) {
-                    return item.toRun();
+            if (run == null) {
+                int number;
+                try {
+                    number = Integer.parseInt(name);
+                } catch (NumberFormatException e) {
+                    throw new NotFoundException(String.format("Run %s not found in organization %s and pipeline %s",
+                            name, pipeline.getOrganizationName(), job.getName()));
+                }
+                for (BlueQueueItem item : QueueUtil.getQueuedItems(pipeline.getOrganization(), job)) {
+                    if (item.getExpectedBuildNumber() == number) {
+                        return item.toRun();
+                    }
                 }
             }
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/FreeStylePipelineTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/FreeStylePipelineTest.java
@@ -1,0 +1,87 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.util.RunList;
+import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.hal.Links;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Job.class, FreeStyleProject.class, FreeStyleBuild.class })
+@PowerMockIgnore({"javax.crypto.*", "javax.security.*", "javax.net.ssl.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
+public class FreeStylePipelineTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-51716")
+    public void findNonNumericRun() throws Exception {
+        FreeStyleProject freestyle = Mockito.spy(j.createProject(FreeStyleProject.class, "freestyle"));
+
+        FreeStyleBuild build1 = Mockito.mock(FreeStyleBuild.class);
+        FreeStyleBuild build2 = Mockito.mock(FreeStyleBuild.class);
+
+        Mockito.when(build1.getId()).thenReturn("build1");
+        Mockito.when(build1.getParent()).thenReturn(freestyle);
+        Mockito.when(build1.getNextBuild()).thenReturn(build2);
+
+        Mockito.when(build2.getId()).thenReturn("build2");
+        Mockito.when(build2.getParent()).thenReturn(freestyle);
+        Mockito.when(build2.getPreviousBuild()).thenReturn(build1);
+
+        RunList<FreeStyleBuild> runs = RunList.fromRuns(Arrays.asList(build1, build2));
+        Mockito.doReturn(runs).when(freestyle).getBuilds();
+        Mockito.doReturn(build2).when(freestyle).getLastBuild();
+
+        FreeStylePipeline freeStylePipeline = (FreeStylePipeline) BluePipelineFactory.resolve(freestyle);
+        assertNotNull(freeStylePipeline);
+        BlueRun blueRun = freeStylePipeline.getLatestRun();
+        assertNotNull(blueRun);
+        Links links = blueRun.getLinks();
+        assertNotNull(links);
+        assertNotNull(links.get("self"));
+    }
+
+    @Test
+    public void findModernRun() throws Exception {
+        FreeStyleProject freestyle = Mockito.spy(j.createProject(FreeStyleProject.class, "freestyle"));
+
+        FreeStyleBuild build1 = Mockito.mock(FreeStyleBuild.class);
+        FreeStyleBuild build2 = Mockito.mock(FreeStyleBuild.class);
+
+        Mockito.when(build1.getParent()).thenReturn(freestyle);
+        Mockito.when(build1.getNextBuild()).thenReturn(build2);
+
+        Mockito.when(build2.getParent()).thenReturn(freestyle);
+        Mockito.when(build2.getPreviousBuild()).thenReturn(build1);
+
+        RunList<FreeStyleBuild> runs = RunList.fromRuns(Arrays.asList(build1, build2));
+        Mockito.doReturn(runs).when(freestyle).getBuilds();
+        Mockito.doReturn(build2).when(freestyle).getLastBuild();
+
+        FreeStylePipeline freeStylePipeline = (FreeStylePipeline) BluePipelineFactory.resolve(freestyle);
+        assertNotNull(freeStylePipeline);
+        BlueRun blueRun = freeStylePipeline.getLatestRun();
+        assertNotNull(blueRun);
+        Links links = blueRun.getLinks();
+        assertNotNull(links);
+        assertNotNull(links.get("self"));
+    }
+
+}


### PR DESCRIPTION
# Description

See [JENKINS-51716](https://issues.jenkins-ci.org/browse/JENKINS-51716).

Super hard to test manually, since you need to have runs that have non numeric id. I believe jenkins has deprecated id, so most jobs will be null or a number.

If you can get that, then testing is just hitting any rest interface that returns the run. The front page will try and return the latest run for a job.

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

