### PR TITLE
JENKINS-55497 - Add ChangeSet information to its own unique container

### DIFF
--- a/blueocean-core-js/src/js/services/ActivityService.js
+++ b/blueocean-core-js/src/js/services/ActivityService.js
@@ -99,6 +99,21 @@ export class ActivityService extends BunkerService {
     }
 
     /**
+     * Fetch a pager for changeSet
+     *
+     * @param href (eg: myRun._links.changeSet.href )
+     */
+    changeSetPager(href) {
+        return this.pagerService.getPager({
+            key: href,
+            /**
+             * Lazily generate the pager incase its needed.
+             */
+            lazyPager: () => new Pager(href, 100, this),
+        });
+    }
+
+    /**
      * Fetches artifacts for a given run.
      *
      * @param {string} runHref The href of the run to fetcfh artifacts for.

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -129,7 +129,6 @@ RunDetailsChanges.propTypes = {
 };
 
 RunDetailsChanges.contextTypes = {
-    config: PropTypes.object.isRequired,
-    params: PropTypes.object,
+    params: PropTypes.object.isRequired,
     activityService: PropTypes.object.isRequired,
 };

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -50,8 +50,6 @@ export default class RunDetailsChanges extends Component {
             branch: this.isMultiBranch && props.params.branch,
             runId: props.params.runId,
         });
-        console.log('context', this.context);
-        die();
         this.pager = this.context.activityService.changeSetPager(`${this.href}changeSet`);
     }
 

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -4,8 +4,7 @@ import { CommitId, PlaceholderTable, ReadableDate, JTable, TableHeaderRow, Table
 import Icon from './placeholder/Icon';
 import { PlaceholderDialog } from './placeholder/PlaceholderDialog';
 import LinkifiedText from './LinkifiedText';
-import { Paths, ShowMoreButton } from '@jenkins-cd/blueocean-core-js';
-const { rest: RestPaths } = Paths;
+import { ShowMoreButton } from '@jenkins-cd/blueocean-core-js';
 
 function NoChangesPlaceholder(props) {
     const { t } = props;
@@ -44,19 +43,19 @@ export default class RunDetailsChanges extends Component {
     }
 
     _fetchChangeSet(props) {
-        this.href = RestPaths.run({
-            organization: props.params.organization,
-            pipeline: props.params.pipeline,
-            branch: this.isMultiBranch && props.params.branch,
-            runId: props.params.runId,
-        });
-        this.pager = this.context.activityService.changeSetPager(`${this.href}changeSet`);
+        if (props.result && props.result._links && props.result._links && props.result._links.self) {
+            this.pager = this.context.activityService.changeSetPager(`${props.result._links.self.href}changeSet/`);
+        }
     }
 
     render() {
         const { t, locale } = this.props;
 
-        if (!this.pager || this.pager.pendingD) {
+        if (!this.pager) {
+            return null;
+        }
+
+        if (this.pager.pendingD) {
             return <NoChangesPlaceholder t={t} />;
         }
 
@@ -88,8 +87,8 @@ export default class RunDetailsChanges extends Component {
 
         return (
             <div>
-                {changeSetSplitBySource.map(changeSet => (
-                    <JTable columns={columns} className="changeset-table">
+                {changeSetSplitBySource.map((changeSet, changeSetIdx) => (
+                    <JTable columns={columns} className="changeset-table" key={changeSetIdx}>
                         <TableHeaderRow />
                         {changeSet.map(commit => (
                             <TableRow key={commit.commitId}>

--- a/blueocean-dashboard/src/main/js/components/placeholder/PlaceholderDialog.jsx
+++ b/blueocean-dashboard/src/main/js/components/placeholder/PlaceholderDialog.jsx
@@ -14,12 +14,11 @@ function createContent(content) {
     // use 'linkElement' as is, or build a link if the text and href were supplied
     const link =
         linkElement ||
-        (linkText &&
-            linkHref && (
-                <a className="btn" target="_blank" href={linkHref}>
-                    {linkText}
-                </a>
-            ));
+        (linkText && linkHref && (
+            <a className="btn" target="_blank" href={linkHref}>
+                {linkText}
+            </a>
+        ));
 
     return [icon && React.cloneElement(icon, { className: 'icon' }), <h1 className="title">{title}</h1>, message && <p className="message">{message}</p>, link];
 }

--- a/blueocean-dashboard/src/test/js/run-details-changes-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-changes-spec.js
@@ -40,16 +40,12 @@ describe('RunDetailsChanges', () => {
     it('renders nothing with no data', () => {
         const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext() });
 
-        const output = wrapper.html();
-
-        // Class names we expect to see
-        assert(output.match('RunDetailsEmpty'), 'output should contain "RunDetailsEmpty"');
-        assert(output.match('NoChanges'), 'output should contain "NoChanges"');
-        assert(output.match('PlaceholderTable'), 'output should contain "PlaceholderTable"');
+        assert.equal(wrapper.html(), null, 'output should be empty');
     });
 
     it('renders empty changeset', () => {
-        const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext([]) });
+        const runs = latestRuns.map(run => run.latestRun);
+        const wrapper = mount(<RunDetailsChanges t={t} params={params} result={runs[0]} />, { context: buildContext([]) });
 
         const output = wrapper.html();
 
@@ -61,7 +57,7 @@ describe('RunDetailsChanges', () => {
 
     it('renders a valid changeset', () => {
         const runs = latestRuns.map(run => run.latestRun);
-        const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext(runs[0].changeSet) });
+        const wrapper = mount(<RunDetailsChanges t={t} params={params} result={runs[0]} />, { context: buildContext(runs[0].changeSet) });
         const output = wrapper.html();
 
         // Class names we expect to see

--- a/blueocean-dashboard/src/test/js/run-details-changes-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-changes-spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { render } from 'enzyme';
 import { i18nTranslator } from '@jenkins-cd/blueocean-core-js';
 
 import { latestRuns } from './data/runs/latestRuns';
@@ -11,19 +11,36 @@ const t = i18nTranslator('blueocean-dashboard');
 import { mockExtensionsForI18n } from './mock-extensions-i18n';
 mockExtensionsForI18n();
 
+const params = {
+    organization: 'jenkins',
+    pipeline: 'asdf',
+};
+
+function buildContext(changeSetPagerData) {
+    return {
+        activityService: {
+            changeSetPager() {
+                return {
+                    data: changeSetPagerData,
+                };
+            },
+        },
+    };
+}
+
 describe('RunDetailsChanges', () => {
     beforeAll(() => mockExtensionsForI18n());
 
     it('renders nothing with no data', () => {
-        let wrapper = render(<RunDetailsChanges t={t} />);
+        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { buildContext() });
 
         assert.equal(wrapper.html(), '', 'output should be empty');
     });
 
     it('renders empty changeset', () => {
-        let wrapper = render(<RunDetailsChanges t={t} result={{ changeSet: [] }} />);
+        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext([]) });
 
-        let output = wrapper.html();
+        const output = wrapper.html();
 
         // Class names we expect to see
         assert(output.match('RunDetailsEmpty'), 'output should contain "RunDetailsEmpty"');
@@ -32,9 +49,9 @@ describe('RunDetailsChanges', () => {
     });
 
     it('renders a valid changeset', () => {
-        let runs = latestRuns.map(run => (run.latestRun));
-        let wrapper = render(<RunDetailsChanges t={t} result={runs[0]}/>);
-        let output = wrapper.html();
+        const runs = latestRuns.map(run => run.latestRun);
+        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext(runs.changeSet) });
+        const output = wrapper.html();
 
         // Class names we expect to see
         assert(output.match('JTable'), 'output should contain "JTable"');

--- a/blueocean-dashboard/src/test/js/run-details-changes-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-changes-spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import React from 'react';
-import { render } from 'enzyme';
+import { mount } from 'enzyme';
 import { i18nTranslator } from '@jenkins-cd/blueocean-core-js';
 
 import { latestRuns } from './data/runs/latestRuns';
@@ -18,6 +18,12 @@ const params = {
 
 function buildContext(changeSetPagerData) {
     return {
+        params: {
+            organization: 'jenkins',
+            pipeline: 'job1',
+            branch: 'master',
+            runId: '2',
+        },
         activityService: {
             changeSetPager() {
                 return {
@@ -32,13 +38,18 @@ describe('RunDetailsChanges', () => {
     beforeAll(() => mockExtensionsForI18n());
 
     it('renders nothing with no data', () => {
-        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext() });
+        const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext() });
 
-        assert.equal(wrapper.html(), '', 'output should be empty');
+        const output = wrapper.html();
+
+        // Class names we expect to see
+        assert(output.match('RunDetailsEmpty'), 'output should contain "RunDetailsEmpty"');
+        assert(output.match('NoChanges'), 'output should contain "NoChanges"');
+        assert(output.match('PlaceholderTable'), 'output should contain "PlaceholderTable"');
     });
 
     it('renders empty changeset', () => {
-        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext([]) });
+        const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext([]) });
 
         const output = wrapper.html();
 
@@ -50,7 +61,7 @@ describe('RunDetailsChanges', () => {
 
     it('renders a valid changeset', () => {
         const runs = latestRuns.map(run => run.latestRun);
-        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext(runs.changeSet) });
+        const wrapper = mount(<RunDetailsChanges t={t} params={params} />, { context: buildContext(runs[0].changeSet) });
         const output = wrapper.html();
 
         // Class names we expect to see

--- a/blueocean-dashboard/src/test/js/run-details-changes-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-changes-spec.js
@@ -32,7 +32,7 @@ describe('RunDetailsChanges', () => {
     beforeAll(() => mockExtensionsForI18n());
 
     it('renders nothing with no data', () => {
-        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { buildContext() });
+        const wrapper = render(<RunDetailsChanges t={t} params={params} />, { context: buildContext() });
 
         assert.equal(wrapper.html(), '', 'output should be empty');
     });

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/BlueRunChangesetPreloader.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/BlueRunChangesetPreloader.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.blueocean.preload;
+
+import hudson.Extension;
+import hudson.model.Item;
+import io.jenkins.blueocean.commons.stapler.Export;
+import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.model.BlueChangeSetEntry;
+import io.jenkins.blueocean.rest.model.BluePipeline;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.rest.model.Container;
+import io.jenkins.blueocean.rest.model.Resource;
+import io.jenkins.blueocean.service.embedded.rest.ChangeSetResource;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class BlueRunChangesetPreloader extends RESTFetchPreloader {
+
+    private static final Logger LOGGER = Logger.getLogger(PipelineActivityStatePreloader.class.getName());
+
+    @Override
+    protected FetchData getFetchData(@Nonnull BlueUrlTokenizer blueUrl) {
+
+        if (!blueUrl.lastPartIs(BlueUrlTokenizer.UrlPart.PIPELINE_RUN_DETAIL_TAB, "changes")) {
+            // Not interested in it
+            return null;
+        }
+
+        BluePipeline pipeline = getPipeline(blueUrl);
+
+        if (pipeline == null) {
+            // Not interested in it
+            return null;
+        }
+
+        // It's a pipeline page. Let's prefetch the pipeline activity and add them to the page,
+        // saving the frontend the overhead of requesting them.
+
+        Container<BlueRun> activitiesContainer = pipeline.getRuns();
+        if(activitiesContainer==null){
+            return null;
+        }
+        BlueRun run = activitiesContainer.get(blueUrl.getPart(BlueUrlTokenizer.UrlPart.PIPELINE_RUN_DETAIL_ID));
+        Container<BlueChangeSetEntry> changeSetEntries = run.getChangeSet();
+
+        try {
+            return new FetchData(
+                    changeSetEntries.getLink().getHref(),
+                    Export.toJson(changeSetEntries)
+            );
+        } catch (IOException e) {
+            LOGGER.log(Level.FINE, String.format("Unable to preload changelog data '%s'. Failed to convert to Blue Ocean Resource.", changeSetEntries.getLink().getHref()));
+            return null;
+        }
+    }
+
+    private BluePipeline getPipeline(BlueUrlTokenizer blueUrl) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) { return null; }
+        String pipelineFullName = blueUrl.getPart(BlueUrlTokenizer.UrlPart.PIPELINE);
+
+        try {
+            Item pipelineJob = jenkins.getItemByFullName(pipelineFullName);
+            return (BluePipeline) BluePipelineFactory.resolve(pipelineJob);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, String.format("Unable to find Job named '%s'.", pipelineFullName), e);
+            return null;
+        }
+    }
+}

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImpl.java
@@ -76,10 +76,5 @@ public class PipelineImpl extends AbstractPipelineImpl {
         public PipelineRunSummary(BlueRun blueRun, Run run, Reachable parent, BlueOrganization organization) {
             super(blueRun, run, parent, organization);
         }
-
-        @Override
-        public Container<BlueChangeSetEntry> getChangeSet() {
-            return blueRun.getChangeSet();
-        }
     }
 }

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineRunImpl.java
@@ -23,6 +23,7 @@ import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.Container;
 import io.jenkins.blueocean.rest.model.Containers;
 import io.jenkins.blueocean.service.embedded.rest.AbstractRunImpl;
+import io.jenkins.blueocean.service.embedded.rest.ChangeSetContainerImpl;
 import io.jenkins.blueocean.service.embedded.rest.ChangeSetResource;
 import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import io.jenkins.blueocean.service.embedded.rest.StoppableRun;
@@ -67,41 +68,6 @@ public class PipelineRunImpl extends AbstractRunImpl<WorkflowRun> {
     @Exported(name = PullRequest.PULL_REQUEST, inline = true)
     public PullRequest getPullRequest() {
         return PullRequest.get(run.getParent());
-    }
-
-    @Override
-    @Nonnull
-    public Container<BlueChangeSetEntry> getChangeSet() {
-        // If this run is a replay then return the changesets from the original run
-        ReplayCause replayCause = run.getCause(ReplayCause.class);
-        if (replayCause != null) {
-            Run run = this.run.getParent().getBuildByNumber(replayCause.getOriginalNumber());
-            if (run == null) {
-                return Containers.empty(getLink());
-            }
-            BlueRun blueRun = BlueRunFactory.getRun(run, parent);
-            if (blueRun == null) {
-                return Containers.empty(getLink());
-            }
-            return blueRun.getChangeSet();
-        } else {
-            Map<String, BlueChangeSetEntry> m = new LinkedHashMap<>();
-            int cnt = 0;
-            int checkoutCount = 0;
-            for (ChangeLogSet<? extends Entry> cs : run.getChangeSets()) {
-                for (ChangeLogSet.Entry e : cs) {
-                    cnt++;
-                    String id = e.getCommitId();
-                    if (id == null)
-                    {
-                        id = String.valueOf( cnt );
-                    }
-                    m.put(id, new ChangeSetResource(organization, e, this).setCheckoutCount(checkoutCount));
-                }
-                checkoutCount++;
-            }
-            return Containers.fromResourceMap(getLink(), m);
-        }
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/preload/BlueRunChangesetPreloaderTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/preload/BlueRunChangesetPreloaderTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.blueocean.preload;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import io.jenkins.blueocean.rest.factory.BluePipelineFactory;
+import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.service.embedded.rest.ChangeSetContainerImpl;
+import io.jenkins.blueocean.service.embedded.rest.FreeStylePipeline;
+import io.jenkins.blueocean.service.embedded.rest.RunSearch;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class BlueRunChangesetPreloaderTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void prefetchUrlIsRight() throws IOException, ExecutionException, InterruptedException {
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        Run run = j.waitForCompletion(project.scheduleBuild2(0).waitForStart());
+
+        FreeStylePipeline freeStylePipeline = (FreeStylePipeline) BluePipelineFactory.resolve(project);
+        assertNotNull(freeStylePipeline);
+        BlueRun blueRun = freeStylePipeline.getLatestRun();
+        assertNotNull(blueRun);
+
+        BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(Jenkins.getInstance());
+
+        ChangeSetContainerImpl container = new ChangeSetContainerImpl(
+                organization,
+                blueRun,
+                run
+        );
+        BlueRunChangesetPreloader preloader = new BlueRunChangesetPreloader();
+        RESTFetchPreloader.FetchData fetchData = preloader.getFetchData(container);
+        assertEquals("/blue/rest/organizations/jenkins/pipelines/project/runs/1/changeSet/?start=0&limit=101", fetchData.getRestUrl());
+    }
+
+}

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImplTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineImplTest.java
@@ -42,8 +42,7 @@ public class PipelineImplTest extends PipelineBaseTest {
         Run r = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
 
         // confirm the changeSet retrieved from the latestRun details for the project is not empty
-        Map<String, Object> projectDetails = get("/organizations/jenkins/pipelines/" + p.getName() + "/");
-        Map<String, Object> runDetails = (Map<String, Object>) projectDetails.get("latestRun");
+        Map<String, Object> runDetails = get("/organizations/jenkins/pipelines/" + p.getName() + "/runs/" + r.getId() + "/");
         List<Object> changeSet = (ArrayList) runDetails.get("changeSet");
         assertTrue(!changeSet.isEmpty());
     }

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -117,7 +117,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -9,6 +9,7 @@ import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.blueocean.commons.ServiceException;
+import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
 import io.jenkins.blueocean.rest.hal.Link;
@@ -31,6 +32,7 @@ import org.apache.commons.lang.BooleanUtils;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.export.Exported;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,9 +71,10 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
         this.organization = organization;
     }
 
-    @Nonnull
+    @Override
+    @Exported(inline = true)
     public Container<BlueChangeSetEntry> getChangeSet() {
-        return Containers.empty(getLink());
+        return new ChangeSetContainerImpl(organization, this, run);
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetContainerImpl.java
@@ -1,0 +1,81 @@
+package io.jenkins.blueocean.service.embedded.rest;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.scm.ChangeLogSet;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueChangeSetEntry;
+import io.jenkins.blueocean.rest.model.BlueOrganization;
+import io.jenkins.blueocean.rest.model.BlueRun;
+import io.jenkins.blueocean.rest.model.Container;
+import jenkins.scm.RunWithSCM;
+import org.jenkinsci.plugins.workflow.cps.replay.ReplayCause;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ChangeSetContainerImpl extends Container<BlueChangeSetEntry> {
+
+    private final BlueOrganization organization;
+    private final BlueRun blueRun;
+    private final Run run;
+
+    public ChangeSetContainerImpl(BlueOrganization organization, BlueRun blueRun, Run run) {
+        super();
+        this.organization = organization;
+        this.blueRun = blueRun;
+        this.run = run;
+    }
+
+    @Override
+    public Link getLink() {
+        return this.blueRun.getLink();
+    }
+
+    @Override
+    public BlueChangeSetEntry get(String name) {
+        for (Iterator i = this.iterator(); i.hasNext(); ) {
+            BlueChangeSetEntry set = (BlueChangeSetEntry) i.next();
+            if (name.equals(set.getCommitId())) {
+                return set;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<BlueChangeSetEntry> iterator() {
+        Run run = this.run;
+        List<BlueChangeSetEntry> changesets = new LinkedList<>();
+        int checkoutCount = 0;
+
+        // If this run is a replay then return the changesets from the original run
+        ReplayCause replayCause = (ReplayCause) run.getCause(ReplayCause.class);
+        while (replayCause != null) {
+            Run originalRun = this.run.getParent().getBuildByNumber(replayCause.getOriginalNumber());
+            if (originalRun != null) {
+                run = originalRun;
+                replayCause = (ReplayCause) run.getCause(ReplayCause.class);
+            }
+        }
+
+        if (run instanceof AbstractBuild) {
+            for (ChangeLogSet<? extends ChangeLogSet.Entry> cs : ((AbstractBuild<?, ?>) run).getChangeSets()) {
+                for (ChangeLogSet.Entry e : cs) {
+                    changesets.add(new ChangeSetResource(this.organization, e, this).setCheckoutCount(checkoutCount));
+                }
+                checkoutCount++;
+            }
+
+        } else if (run instanceof RunWithSCM) {
+            for (ChangeLogSet<? extends ChangeLogSet.Entry> cs : ((RunWithSCM<?, ?>) run).getChangeSets()) {
+                for (ChangeLogSet.Entry e : cs) {
+                    changesets.add(new ChangeSetResource(this.organization, e, this).setCheckoutCount(checkoutCount));
+                }
+                checkoutCount++;
+            }
+        }
+        return changesets.iterator();
+    }
+}

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetContainerImpl.java
@@ -30,7 +30,7 @@ public class ChangeSetContainerImpl extends Container<BlueChangeSetEntry> {
 
     @Override
     public Link getLink() {
-        return this.blueRun.getLink();
+        return this.blueRun.getLink().rel("changeSet");
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
@@ -107,6 +107,6 @@ public class ChangeSetResource extends BlueChangeSetEntry {
 
     @Override
     public Link getLink() {
-        return parent.getLink().rel("changeset/"+getCommitId());
+        return parent.getLink().rel(getCommitId());
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FreeStyleRunImpl.java
@@ -32,24 +32,6 @@ public class FreeStyleRunImpl extends AbstractRunImpl<FreeStyleBuild> {
     }
 
     @Override
-    @Nonnull
-    public Container<BlueChangeSetEntry> getChangeSet() {
-
-        Map<String, BlueChangeSetEntry> m = new LinkedHashMap<>();
-        int cnt=0;
-        for (ChangeLogSet.Entry e : run.getChangeSet()) {
-            cnt++;
-            String id = e.getCommitId();
-            if (id==null)
-            {
-                id = String.valueOf(cnt);
-            }
-            m.put(id, new ChangeSetResource(organization, e, this));
-        }
-        return Containers.fromResourceMap(this.getLink(),m);
-    }
-
-    @Override
     public BlueRun stop(@QueryParameter("blocking") Boolean blocking, @QueryParameter("timeOutInSecs") Integer timeOutInSecs){
         return stop(blocking, timeOutInSecs, new StoppableRun() {
             @Override

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueItemRun.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueItemRun.java
@@ -44,6 +44,7 @@ public interface BlueItemRun {
      */
     @Exported(inline = true)
     @Nonnull
+    @Navigable
     Container<BlueChangeSetEntry> getChangeSet();
 
     /**

--- a/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueRun.java
+++ b/blueocean-rest/src/main/java/io/jenkins/blueocean/rest/model/BlueRun.java
@@ -87,6 +87,7 @@ public abstract class BlueRun extends Resource implements BlueItemRun {
      */
     @Exported(inline = true)
     @Nonnull
+    @Navigable
     public abstract Container<BlueChangeSetEntry> getChangeSet();
 
     /**


### PR DESCRIPTION
UI Element updated to use the preload/pager data
Left all previous data behind, but we should still delete all the
run.changeSet stuff

cc @stuartrowe 
# Description

See [JENKINS-55497](https://issues.jenkins-ci.org/browse/JENKINS-55497).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

