### PR TITLE
Enable release-drafter support

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+name-template: v$NEXT_PATCH_VERSION 🌈
+tag-template: blueocean-parent-$NEXT_PATCH_VERSION
+categories:
+  - title: 🚀 Features
+    label: enhancement
+  - title: 🐛 Bug Fixes
+    label: bug
+template: |
+  ## What’s Changed
+
+  $CHANGES


### PR DESCRIPTION
Trying out release-drafter like https://github.com/jenkinsci/bitbucket-branch-source-plugin/releases has

It should be easier to maintain than using the wiki. I'll copy the release notes from the wiki over manually as a start to see if we like it.