### PR TITLE
Fix response json data of API get SCM repositories in an organization

### DIFF
--- a/blueocean-rest/README.md
+++ b/blueocean-rest/README.md
@@ -2145,7 +2145,10 @@ curl -v -u xxx:yyy http://localhost:8080/jenkins/blue/rest/organizations/jenkins
         "push" : false,
         "pull" : true
       },
-      ...],
+      "private": true,
+      "fullName": "CloudBees-community/bees-cli-router-plugin"
+    },
+    ...],
     "lastPage" : 5,
     "nextPage" : 4,
     "pageSize" : 10


### PR DESCRIPTION
Signed-off-by: soulseen <sunzhu@yunify.com>

# Description
the api of get SCM repositories in an organization:
```
curl -v -u xxx:yyy http://localhost:8080/jenkins/blue/rest/organizations/jenkins/scm/github/organizations/CloudBees-community/repositories/?credentialId=github&pageSize=10&pageNumber=3
```
The json response in filed `item` missing `}`,like this:
```
"items" : [ {
      "_class" : "io.jenkins.blueocean.blueocean_github_pipeline.GithubRepository",
      "_links" : {
        "self" : {
          "_class" : "io.jenkins.blueocean.rest.hal.Link",
          "href" : "/organizations/jenkins/scm/github/organizations/CloudBees-community/repositories/bees-cli-router-plugin/"
        }
      },
      "defaultBranch" : "master",
      "description" : "CloudBees SDK \"router:*\" plugin",
      "name" : "bees-cli-router-plugin",
      "permissions" : {
        "admin" : false,
        "push" : false,
        "pull" : true
      },
      ...]
```
and In my actual use, the response data also have `private` and `fullName ` filed in `item`.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

