### PR TITLE
Rejuvenate logging levels

### DIFF
--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/Property.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/Property.java
@@ -252,7 +252,7 @@ public abstract class Property implements Comparable<Property> {
                             buffer.finished();
                         } catch (IOException x) {
                             if (x.getCause() instanceof InvocationTargetException) {
-                                LOGGER.log(Level.WARNING, "skipping export of " + e, x);
+                                LOGGER.log(Level.SEVERE, "skipping export of " + e, x);
                             }
                         }
                         buffer.commit(writer);
@@ -268,7 +268,7 @@ public abstract class Property implements Comparable<Property> {
                             buffer.finished();
                         } catch (IOException x) {
                             if (x.getCause() instanceof InvocationTargetException) {
-                                LOGGER.log(Level.WARNING, "skipping export of " + e, x);
+                                LOGGER.log(Level.SEVERE, "skipping export of " + e, x);
                             }
                         }
                         buffer.commit(writer);

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCacheCloneReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCacheCloneReadSaveRequest.java
@@ -105,7 +105,7 @@ class GitCacheCloneReadSaveRequest extends GitReadSaveRequest {
                 Git activeRepo = getActiveRepository(repository);
                 Repository repo = activeRepo.getRepository();
                 File repoDir = repo.getDirectory().getParentFile();
-                log.fine("Repo cloned to: " + repoDir.getCanonicalPath());
+                log.finest("Repo cloned to: " + repoDir.getCanonicalPath());
                 try {
                     File f = new File(repoDir, filePath);
                     if (!f.exists() || f.canWrite()) {

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCloneReadSaveRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitCloneReadSaveRequest.java
@@ -91,7 +91,7 @@ class GitCloneReadSaveRequest extends GitReadSaveRequest {
         try {
             git.clone(gitSource.getRemote(), "origin", true, null);
 
-            log.fine("Repository " + gitSource.getRemote() + " cloned to: " + repositoryPath.getCanonicalPath());
+            log.finest("Repository " + gitSource.getRemote() + " cloned to: " + repositoryPath.getCanonicalPath());
         } catch(GitException e) {
             // check if this is an empty repository
             boolean isEmptyRepo = false;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubServerContainer.java
@@ -103,7 +103,7 @@ public class GithubServerContainer extends ScmServerEndpointContainer {
                         isGithubCloud = code == 200 && responseBody.containsKey("current_user_url");
                         isGithubEnterprise = code == 401 && responseBody.containsKey("message");
                     } catch (IOException ioe) {
-                        LOGGER.log(Level.INFO, "Could not parse response body from Github");
+                        LOGGER.log(Level.SEVERE, "Could not parse response body from Github");
                     }
 
                     if (!isGithubCloud && !isGithubEnterprise) {
@@ -112,7 +112,7 @@ public class GithubServerContainer extends ScmServerEndpointContainer {
                 }
             } catch (Throwable e) {
                 errors.add(new ErrorMessage.Error(GithubServer.API_URL, ErrorMessage.Error.ErrorCodes.INVALID.toString(), e.toString()));
-                LOGGER.log(Level.INFO, "Could not connect to Github", e);
+                LOGGER.log(Level.SEVERE, "Could not connect to Github", e);
             }
         }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/PipelineBranchRunStatePreloader.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/PipelineBranchRunStatePreloader.java
@@ -90,12 +90,12 @@ public class PipelineBranchRunStatePreloader extends RESTFetchPreloader {
                                 return null;
                             }
                         } else {
-                            LOGGER.log(Level.FINE, String.format("Unable to find run %s on branch named %s on pipeline named '%s'.", runId, branchName, pipelineFullName));
+                            LOGGER.log(Level.FINEST, String.format("Unable to find run %s on branch named %s on pipeline named '%s'.", runId, branchName, pipelineFullName));
                             return null;
                         }
                     }
                 } else {
-                    LOGGER.log(Level.FINE, String.format("Unable to find branch named %s on pipeline named '%s'.", branchName, pipelineFullName));
+                    LOGGER.log(Level.FINEST, String.format("Unable to find branch named %s on pipeline named '%s'.", branchName, pipelineFullName));
                     return null;
                 }
             } catch (Exception e) {
@@ -103,7 +103,7 @@ public class PipelineBranchRunStatePreloader extends RESTFetchPreloader {
                 return null;
             }
         } else {
-            LOGGER.log(Level.FINE, String.format("Unable to find pipeline named '%s'.", pipelineFullName));
+            LOGGER.log(Level.FINEST, String.format("Unable to find pipeline named '%s'.", pipelineFullName));
             return null;
         }
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/PipelineStatePreloader.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/preload/PipelineStatePreloader.java
@@ -69,7 +69,7 @@ public class PipelineStatePreloader extends RESTFetchPreloader {
                         return null;
                     }
                 } else {
-                    LOGGER.log(Level.FINE, String.format("Unable to preload pipeline '%s'. Failed to convert to Blue Ocean Resource.", pipelineJobItem.getUrl()));
+                    LOGGER.log(Level.FINEST, String.format("Unable to preload pipeline '%s'. Failed to convert to Blue Ocean Resource.", pipelineJobItem.getUrl()));
                     return null;
                 }
             }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/NullAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/NullAnalytics.java
@@ -25,6 +25,6 @@ public class NullAnalytics extends AbstractAnalytics {
 
     @Override
     protected void doTrack(String name, Map<String, Object> allProps) {
-        LOGGER.log(Level.FINE, "Analytics are disabled");
+        LOGGER.log(Level.FINEST, "Analytics are disabled");
     }
 }


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings . We can vary these settings and rerun our if you desire. The settings we are using in this pull request are:

- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- Never lower the logging level of logging statements within if statements (setting 3).
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels (setting 4).
- The greatest number of commits evaluated: 5000 (setting 5).

The head at time of analysis was: c11a7c7ee9cef47e675a547e3756e8fa4d8f9097

This experiment was done in conjunction with @saledouble and @ponder-lab. 