### PR TITLE
Swap code owners with the jenkinsci group so it matches who has access to the project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 # See: https://github.com/blog/2392-introducing-code-owners for details
 
-# Everything else
-* @vivek @kzantow @sophistifunk @NicuPascu @scherler @imeredith @halkeye
-
-# We need to keep tight control on dependencies
-pom.xml    @vivek @jennbriden @olamy @kzantow @sophistifunk @NicuPascu @scherler @imeredith @halkeye
-
-# Jenkins design language is used outside of blue ocean repo, so want to watch changes closely for approval
-jenkins-design-language/*   @kzantow @sophistifunk @NicuPascu @scherler @imeredith @halkeye
+* @jenkinsci/blueocean-plugin-developers


### PR DESCRIPTION
Old and new maintainers:

@halkeye
@imeredith
@jenkinsci/blueocean-plugin-developers
@jennbriden
@kzantow
@NicuPascu
@olamy
@scherler
@sophistifunk
@vivek

What do you think?