### PR TITLE
JENKINS-53352 - fix test whitespace rendering

### DIFF
--- a/blueocean-dashboard/src/main/less/testing.less
+++ b/blueocean-dashboard/src/main/less/testing.less
@@ -86,7 +86,7 @@
 
       .line-content {
         display: inline-block;
-        white-space: normal;
+        white-space: pre-wrap;
         margin-left: 1em;
       }
     }


### PR DESCRIPTION
# Description

See [JENKINS-53352](https://issues.jenkins-ci.org/browse/JENKINS-53352).

White-space has significance in test output, preserve the white-space. `pre-wrap` also ensures that lines wrap as needed.

Manual testing was done by changing the relevant .css directly in Jenkins.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

