### PR TITLE
[JENKINS-58684] Revert sse-gateway to 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sse-gateway</artifactId>
-            <version>1.18</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
As reported in JENKINS-58684, sse-gateway 1.18 fixed mem leak but
introduced thread leak. Thread leak looks pretty severe so we are going
to revert sse-gateway to 1.17 while a new fix in sse-gateway is worked
at.

# Description

See [JENKINS-58684](https://issues.jenkins-ci.org/browse/JENKINS-58684).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

