### PR TITLE
address error.responseBody is undefined

### DIFF
--- a/blueocean-dashboard/src/main/js/components/karaoke/components/InputStep.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/InputStep.jsx
@@ -88,9 +88,13 @@ export default class InputStep extends Component {
         const parameters = this.parameterService.parametersToSubmitArray();
 
         parameterApi.submitInputParameter(href, id, parameters).catch(error => {
-            if (error.responseBody.message) {
+            if (error.responseBody && error.responseBody.message) {
                 this.setState({
                     responseErrorMsg: error.responseBody.message,
+                });
+            } else if (error) {
+                this.setState({
+                    responseErrorMsg: error.message,
                 });
             }
         });


### PR DESCRIPTION
When confirming on the user input step, this error is thrown: `TypeError: error.responseBody is undefinedjenkins-js-extension.js:95465:21`.

This code should handle an error in the case that there is no `responseBody` in the `error` object.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

