### PR TITLE
[JENKINS-58085] Fix issue where stages are shown as waiting to start when they are running/completed

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeGraphVisitor.java
@@ -687,7 +687,8 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
         boolean graphsAreCompatible = true;
 
-        Map<String, FlowNodeWrapper> newNodes = new HashMap<>(previousNodes.size()); // indexed by id
+        // A map from the ID of a node from previousNodes to the corresponding node for the current build.
+        Map<String, FlowNodeWrapper> newNodes = new HashMap<>(previousNodes.size());
 
         // Start with the currently-executing nodes
         for (FlowNodeWrapper currentNodeWrapper : nodes) {
@@ -710,14 +711,14 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
 
                 // New wrapper object based on current execution
                 FlowNodeWrapper newNodeWrapper = new FlowNodeWrapper(
-                    oldNodeWrapper.getNode(), // Use old node because we want to show the final id not intermediary
+                    currentNodeWrapper.getNode(),
                     currentNodeWrapper.getStatus(),
                     currentNodeWrapper.getTiming(),
                     currentNodeWrapper.getInputStep(),
                     run
                 );
 
-                newNodes.put(nodeId, newNodeWrapper);
+                newNodes.put(oldNodeWrapper.getId(), newNodeWrapper);
 
             } else {
                 // Node does not exist in previous graph, user probably changed pipleine definition.
@@ -729,9 +730,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         // Walk the old graph, create new wrappers for any stages not yet started
         if (graphsAreCompatible) {
             for (FlowNodeWrapper oldNodeWrapper : previousNodes) {
-                final String nodeId = oldNodeWrapper.getId();
+                final String oldNodeId = oldNodeWrapper.getId();
 
-                if (!newNodes.containsKey(nodeId)) {
+                if (!newNodes.containsKey(oldNodeId)) {
                     FlowNodeWrapper newNodeWrapper = new FlowNodeWrapper(
                         oldNodeWrapper.getNode(),
                         new NodeRunStatus(null, null),
@@ -740,7 +741,7 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
                         run
                     );
 
-                    newNodes.put(nodeId, newNodeWrapper);
+                    newNodes.put(oldNodeId, newNodeWrapper);
                 }
             }
         }
@@ -748,9 +749,9 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
         // Re-create edges and parentage based on previous run
         if (graphsAreCompatible) {
             for (FlowNodeWrapper oldNodeWrapper : previousNodes) {
-                final String nodeId = oldNodeWrapper.getId();
+                final String oldNodeId = oldNodeWrapper.getId();
 
-                FlowNodeWrapper newNodeWrapper = newNodes.get(nodeId);
+                FlowNodeWrapper newNodeWrapper = newNodes.get(oldNodeId);
 
                 for (FlowNodeWrapper oldEdge : oldNodeWrapper.edges) {
                     FlowNodeWrapper newEdge = newNodes.get(oldEdge.getId());
@@ -773,8 +774,8 @@ public class PipelineNodeGraphVisitor extends StandardChunkVisitor implements No
             // code that makes too many assumptions
 
             for (FlowNodeWrapper oldNodeWrapper : previousNodes) {
-                final String nodeId = oldNodeWrapper.getId();
-                FlowNodeWrapper newNodeWrapper = newNodes.get(nodeId);
+                final String oldNodeId = oldNodeWrapper.getId();
+                FlowNodeWrapper newNodeWrapper = newNodes.get(oldNodeId);
                 newList.add(new PipelineNodeImpl(newNodeWrapper, () -> parent, run));
             }
 

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/unionDifferentNodeIdsSameStructure.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/unionDifferentNodeIdsSameStructure.jenkinsfile
@@ -1,0 +1,13 @@
+stage('first') {
+    // Changes the number of nodes in this stage on every build, so any code that
+    // relies on matching Node IDs across builds will break.
+    for (int i = 0; i < currentBuild.number; i++) {
+        echo "${i}"
+    }
+}
+stage('second') {
+    semaphore 'second'
+}
+stage('third') {
+    semaphore 'third'
+}


### PR DESCRIPTION
# Description

See [JENKINS-58085](https://issues.jenkins-ci.org/browse/JENKINS-58085)/[JENKINS-53816](https://issues.jenkins-ci.org/browse/JENKINS-53816) and some tickets linked from those.

This PR tweaks the fix for JENKINS-53816 added in #1961.

In some cases, when a build's flow graph changes from one build to the next (because the Pipeline was changed, or perhaps due to the result of a `when` condition or some dynamic Pipeline behavior in a Scripted Pipeline), but stays similar enough that Blue Ocean considers the overall graph structure the same, the node ID for one of the nodes in the current Pipeline would use the node ID for what Blue Ocean thought the corresponding node was in previous builds. If the node ID for that node was not actually the same in both builds, the new node would be shown as having never started, and would not have any steps associated with it (because the API calls for that node ID would be for some other node entirely, perhaps one that wasn't actually a stage, so it had no children). Once the build completed, the node ID would be replaced with the actual node ID from the build, and things would be displayed correctly.

I'm not sure if this covers all of the issues users describe in JENKINS-58085/JENKINS-53816, but it fixes at least one problem I found. Just opening a draft PR for now while I try to come up with a regression test for the bug.

<details>
<summary>Here is the Pipeline I was using for testing</summary>

```
pipeline {
    agent none
    stages {
        stage("Before Parallel") {
            steps {
                echo "starting"
                sleep 15
                echo "done"
            }
        }
        stage("Parallel") {
            parallel {
                stage("Par 1") {
                    stages {
                        stage("Par 1 - Seq 1") {
                            steps {
                                echo "starting"
                                sleep 5
                                echo "done"
                            }
                        }
                        stage("Par 1 - Seq 2") {
                            steps {
                                echo "starting"
                                sleep 10
                                echo "done"
                            }
                        }
                    }
                }
                stage("Par 2") {
                    // Comment and uncomment this `when` from one build to the next to see the bug I am trying to fix.
                    when {
                        expression { true == true }
                    }
                    stages {
                        stage("Par 2 - Seq 1") {
                            steps {
                                echo "starting"
                                sleep 10
                                echo "done"
                            }
                        }
                        stage("Par 2 - Seq 2") {
                            steps {
                                echo "starting"
                                sleep 10
                                echo "done"
                            }
                        }
                    }
                }
                stage("Par 3") {
                    steps {
                        echo "starting"
                        sleep 5
                        echo "done"
                    }
                }
            }
        }
        stage("After Parallel") {
            steps {
                echo "starting"
                sleep 15
                echo "done"
            }
        }
    }
}
```
</details>

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

