### PR TITLE
JENKINS-55605 - Remove restriction that prevented clicking/url updating on unfinished nodes, or parallel nodes

### DIFF
--- a/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
@@ -270,15 +270,11 @@ export default class Pipeline extends Component {
                 pathArray.shift();
                 nextPath = `/${pathArray.join('/')}`;
             }
-            // check whether we have a parallel node or seq parallel nodes
-            const isParallel = nextNode.isParallel || (nextNode.firstParent && nextNode.parent != nextNode.firstParent);
 
-            // see whether we need to update the state
-            if (nextNode.state === 'FINISHED' || isParallel) {
-                nextPath = `${nextPath}/${id}`; // only allow node param in finished nodes
-            }
+            nextPath = `${nextPath}/${id}`;
+
             // see whether we need to update the karaoke mode
-            if ((nextNode.state === 'FINISHED' || isParallel) && this.karaoke) {
+            if (nextNode.state === 'FINISHED' && this.karaoke) {
                 logger.debug('turning off karaoke since we do not need it anymore because focus is on a finished node.');
                 this.stopKaraoke();
             }


### PR DESCRIPTION
# Description

User commented they were unable to click on stages that were finished but on parallel stages. I felt like we should be able to click on any node nomatter the state.

I'm still looking into why the restriction is in place, but this draft PR will allow ATH to run while I investigate.

See [JENKINS-55605](https://issues.jenkins-ci.org/browse/JENKINS-55605).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

