### PR TITLE
validate 'run.causes' is set before checking length

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
@@ -184,7 +184,7 @@ class RunDetailsHeader extends Component {
         );
 
         const cause = run => {
-            const lastCause = (run && run.causes.length > 0 && run.causes[run.causes.length - 1]) || null;
+            const lastCause = (run && run.causes && run.causes.length > 0 && run.causes[run.causes.length - 1]) || null;
             if (lastCause && lastCause.upstreamProject) {
                 const activityUrl = `${UrlConfig.getJenkinsRootURL()}/${lastCause.upstreamUrl}display/redirect?provider=blueocean`;
                 const runUrl = `${UrlConfig.getJenkinsRootURL()}/${lastCause.upstreamUrl}${lastCause.upstreamBuild}/display/redirect?provider=blueocean`;

--- a/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
@@ -64,7 +64,7 @@ export default class RunMessageCell extends Component {
                 </span>
             );
         } else if (showCauses) {
-            const lastCause = (run && run.causes.length > 0 && run.causes[run.causes.length - 1]) || null;
+            const lastCause = (run && run.causes && run.causes.length > 0 && run.causes[run.causes.length - 1]) || null;
             const cause = (lastCause && lastCause.shortDescription) || null;
 
             if (lastCause && lastCause.upstreamProject) {

--- a/blueocean-dashboard/src/test/js/run-message-cell-spec.js
+++ b/blueocean-dashboard/src/test/js/run-message-cell-spec.js
@@ -76,7 +76,7 @@ describe('RunMessageCell', () => {
         };
 
         const cell = render(<RunMessageCell run={run} t={t} />);
-        expect(cell.text()).to.equal('-');
+        expect(cell.text()).to.equal('–');
     });
 
 });

--- a/blueocean-dashboard/src/test/js/run-message-cell-spec.js
+++ b/blueocean-dashboard/src/test/js/run-message-cell-spec.js
@@ -67,4 +67,16 @@ describe('RunMessageCell', () => {
         const cell = render(<RunMessageCell run={null} t={t} />);
         expect(cell.text()).to.equal('–');
     });
+
+    // https://issues.jenkins-ci.org/browse/JENKINS-59131
+    it('displays nothing with null causes', () => {
+
+        const run = {
+            causes: null
+        };
+
+        const cell = render(<RunMessageCell run={run} t={t} />);
+        expect(cell.text()).to.equal('-');
+    });
+
 });


### PR DESCRIPTION
# Description

See [JENKINS-59131](https://issues.jenkins-ci.org/browse/JENKINS-59131).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

This is mostly a bandaid (not sure if it should ever be possible for the `run` object to exist without a `causes` member) but similar checks are done in other places; e.g.

https://github.com/kevinushey/blueocean-plugin/blob/9819a3048d01a0f0979cb9d8346b4ad0145dc3c4/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx#L31

so I believe it makes sense to validate that `run.causes` exists in these places as well.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

