### PR TITLE
Display separate stages in scripted parallel pipelines

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeTest.java
@@ -42,22 +42,17 @@ import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -2737,6 +2732,99 @@ public class PipelineNodeTest extends PipelineBaseTest {
     }
 
     @Test
+    public void declarativeParallelPipeline() throws Exception {
+        String script = "pipeline {\n"
+            + "  agent none\n"
+            + "  stages {\n"
+            + "    stage('Run Tests') {\n"
+            + "      parallel {\n"
+            + "        stage('Internal') {\n"
+            + "          agent {\n"
+            + "            label \"master\"\n"
+            + "          }\n"
+            + "          stages {\n"
+            + "            stage('Prep') {\n"
+            + "              steps {\n"
+            + "                echo \"Prep internal\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "            stage('Run') {\n"
+            + "              steps {\n"
+            + "                echo \"Run internal\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        }\n"
+            + "        stage('Prod') {\n"
+            + "          agent {\n"
+            + "            label \"master\"\n"
+            + "          }\n"
+            + "          stages {\n"
+            + "            stage('Prep') {\n"
+            + "              steps {\n"
+            + "                echo \"Prep prod\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "            stage('Run') {\n"
+            + "              steps {\n"
+            + "                echo \"Run prod\"\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+        WorkflowJob job1 = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
+        job1.setDefinition(new CpsFlowDefinition(script, false));
+        WorkflowRun b1 = job1.scheduleBuild2(0).get();
+        WorkflowRun run = j.waitForCompletion(b1);
+        j.assertBuildStatus(Result.SUCCESS, run);
+
+        PipelineNodeGraphVisitor pipelineNodeGraphVisitor = new PipelineNodeGraphVisitor(run);
+        List<FlowNodeWrapper> wrappers = pipelineNodeGraphVisitor.getPipelineNodes();
+
+        assertEquals(7, wrappers.size());
+    }
+
+    @Test
+    public void scriptedParallelPipeline() throws Exception {
+        String script = "node() {\n"
+            + "  parallel(\n"
+            + "    'Internal': {\n"
+            + "      stage('Prep') {\n"
+            + "        echo \"Prep internal\"\n"
+            + "      }\n"
+            + "      stage('Run') {\n"
+            + "        echo \"Run internal\"\n"
+            + "      }\n"
+            + "    },\n"
+            + "    'Prod': {\n"
+            + "      stage('Prep') {\n"
+            + "        echo \"Prep prod\"\n"
+            + "      }\n"
+            + "      stage('Run') {\n"
+            + "        echo \"Run prod\"\n"
+            + "      }\n"
+            + "    }\n"
+            + "  )\n"
+            + "}";
+
+        WorkflowJob job1 = j.jenkins.createProject(WorkflowJob.class, "pipeline1");
+        job1.setDefinition(new CpsFlowDefinition(script, false));
+        WorkflowRun b1 = job1.scheduleBuild2(0).get();
+        WorkflowRun run = j.waitForCompletion(b1);
+        j.assertBuildStatus(Result.SUCCESS, run);
+
+        PipelineNodeGraphVisitor pipelineNodeGraphVisitor = new PipelineNodeGraphVisitor(run);
+        List<FlowNodeWrapper> wrappers = pipelineNodeGraphVisitor.getPipelineNodes();
+
+        assertEquals(7, wrappers.size());
+    }
+
+    @Test
     public void orphanParallels1() throws Exception {
         String script = "parallel('branch1':{\n" +
             "        node {\n" +
@@ -2766,7 +2854,7 @@ public class PipelineNodeTest extends PipelineBaseTest {
         PipelineNodeGraphVisitor pipelineNodeGraphVisitor = new PipelineNodeGraphVisitor(run);
         List<FlowNodeWrapper> wrappers = pipelineNodeGraphVisitor.getPipelineNodes();
 
-        Assert.assertEquals(3, wrappers.size());
+        assertEquals(7, wrappers.size());
     }
 
     @Test
@@ -2812,7 +2900,7 @@ public class PipelineNodeTest extends PipelineBaseTest {
 
         List<Map> nodes = get("/organizations/jenkins/pipelines/pipeline1/runs/1/nodes/", List.class);
 
-        Assert.assertEquals(6, nodes.size());
+        assertEquals(12, nodes.size());
 
         for (int i = 0; i < nodes.size(); i++) {
             Map n = nodes.get(i);
@@ -2833,20 +2921,47 @@ public class PipelineNodeTest extends PipelineBaseTest {
             if (i == 2) {
                 assertEquals("branch1", n.get("displayName"));
                 assertEquals(1, edges.size());
-                assertEquals(nodes.get(5).get("id"), edges.get(0).get("id"));
+                assertEquals(nodes.get(6).get("id"), edges.get(0).get("id"));
             }
             if (i == 3) {
                 assertEquals("branch2", n.get("displayName"));
                 assertEquals(1, edges.size());
-                assertEquals(nodes.get(5).get("id"), edges.get(0).get("id"));
+                assertEquals(nodes.get(10).get("id"), edges.get(0).get("id"));
             }
             if (i == 4) {
                 assertEquals("branch3", n.get("displayName"));
                 assertEquals(1, edges.size());
-                assertEquals(nodes.get(5).get("id"), edges.get(0).get("id"));
+                assertEquals(nodes.get(8).get("id"), edges.get(0).get("id"));
             }
             if (i == 5) {
                 assertEquals("stage2", n.get("displayName"));
+                assertEquals(0, edges.size());
+            }
+            if (i == 6) {
+                assertEquals("Setup", n.get("displayName"));
+                assertEquals(1, edges.size());
+                assertEquals(nodes.get(7).get("id"), edges.get(0).get("id"));
+            }
+            if (i == 7) {
+                assertEquals("Unit and Integration Tests", n.get("displayName"));
+                assertEquals(0, edges.size());
+            }
+            if (i == 8) {
+                assertEquals("Setup", n.get("displayName"));
+                assertEquals(1, edges.size());
+                assertEquals(nodes.get(9).get("id"), edges.get(0).get("id"));
+            }
+            if (i == 9) {
+                assertEquals("Unit and Integration Tests", n.get("displayName"));
+                assertEquals(0, edges.size());
+            }
+            if (i == 10) {
+                assertEquals("Setup", n.get("displayName"));
+                assertEquals(1, edges.size());
+                assertEquals(nodes.get(11).get("id"), edges.get(0).get("id"));
+            }
+            if (i == 11) {
+                assertEquals("Unit and Integration Tests", n.get("displayName"));
                 assertEquals(0, edges.size());
             }
         }


### PR DESCRIPTION
# Description

Fix to show separate stages inside parallel block when using scripted pipeline.

Before change
![Screen Shot 2019-09-05 at 14 31 17](https://user-images.githubusercontent.com/226476/64382194-de92c100-cfe9-11e9-95ec-e4fd6c8f98e9.png)

After change
![Screen Shot 2019-09-05 at 14 24 01](https://user-images.githubusercontent.com/226476/64382198-e488a200-cfe9-11e9-8f59-1b04e7a25e56.png)

Create a scripted pipeline using the example similar to below and you should see separate stage buttons in the parallel section related to each stage instead of one monolithic one.
```
node() {
  parallel(
    'Internal': {
      stage('Prep') {
        echo "Prep internal"
      }
      stage('Run') {
        echo "Run internal"
      }
    },
    'Prod': {
      stage('Prep') {
        echo "Prep prod"
      }
      stage('Run') {
        echo "Run prod"
      }
    }
  )
}
```

possible related jira tickets:
- https://issues.jenkins-ci.org/browse/JENKINS-55438
- https://issues.jenkins-ci.org/browse/JENKINS-53162
- https://issues.jenkins-ci.org/browse/JENKINS-55438

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

