### PR TITLE
Ensure header is visible on scroll

### DIFF
--- a/jenkins-design-language/less/components/result-status.less
+++ b/jenkins-design-language/less/components/result-status.less
@@ -199,8 +199,11 @@
 .result-item-head {
     display:flex;
     align-items:stretch;
+    background-color: white;
     cursor:pointer;
     border: solid 1px @gray-lighter;
+    position: sticky;
+    top: 0;
 }
 
 .result-item-icon {


### PR DESCRIPTION
# Description

When viewing a long output, the header is not visible, making it hard to know what the command/step was that generated the output without a lot of scrolling. Also, scrolling is required to collapse the item.

This change makes the header stick to the top of the viewport, increasing usability. No unit tests are required for this CSS-only change.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given