### PR TITLE
Bitbucket server problems with @ in username

### DIFF
--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -101,7 +101,7 @@ public class BitbucketServerApi extends BitbucketApi {
     @Override
     public @Nonnull BbServerUser getUser(@Nonnull String userName){
         try {
-            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"users", userName)).getContent();
+            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"users", userName.replace('@','_')).getContent();
             return om.readValue(inputStream, BbServerUser.class);
         } catch (IOException e) {
             throw new ServiceException.UnexpectedErrorException(e.getMessage(), e);

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -101,7 +101,7 @@ public class BitbucketServerApi extends BitbucketApi {
     @Override
     public @Nonnull BbServerUser getUser(@Nonnull String userName){
         try {
-            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"users", userName.replace('@','_')).getContent();
+            InputStream inputStream = request.get(String.format("%s/%s",baseUrl+"users", userName.replace('@','_'))).getContent();
             return om.readValue(inputStream, BbServerUser.class);
         } catch (IOException e) {
             throw new ServiceException.UnexpectedErrorException(e.getMessage(), e);


### PR DESCRIPTION
# Description

The server user data api expects @ to be turned into _ in a username.  If you try to connect to a bitbucket server repository through blueocean with a username containing @ like an email address the connect button doesn't actually change the UI at all but it does log an exception that it got the wrong response from the api call for BitbucketServerApi.getUser(). The Cloud project has a function that encodes paths in more places but it uses url encoding which server doesn't like.  There are likely more places where the path needs to be encoded but this is what I needed.
I'm fine with using a locally built patch but I figured I would share.  Sorry for the low quality PR but work isn't paying me to write code for jenkins.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

