### PR TITLE
Remove dependencies to joda-time

### DIFF
--- a/blueocean-jwt/pom.xml
+++ b/blueocean-jwt/pom.xml
@@ -28,10 +28,5 @@
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>mailer</artifactId>
       </dependency>
-
-      <dependency>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-      </dependency>
   </dependencies>
 </project>

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SigningKeyProviderImpl.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/SigningKeyProviderImpl.java
@@ -1,23 +1,21 @@
 package io.jenkins.blueocean.auth.jwt.impl;
 
+import static java.util.logging.Level.WARNING;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
 import hudson.Extension;
 import io.jenkins.blueocean.auth.jwt.JwtSigningKeyProvider;
 import io.jenkins.blueocean.auth.jwt.JwtToken;
 import io.jenkins.blueocean.auth.jwt.SigningKey;
 import io.jenkins.blueocean.auth.jwt.SigningPublicKey;
 import io.jenkins.blueocean.commons.ServiceException;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
-import java.io.IOException;
-import java.security.interfaces.RSAPublicKey;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-
-import static java.util.logging.Level.*;
 
 /**
  * Default {@link JwtSigningKeyProvider} that rotates a key over time.
@@ -29,13 +27,15 @@ import static java.util.logging.Level.*;
 public class SigningKeyProviderImpl extends JwtSigningKeyProvider {
     private static final Logger LOGGER = Logger.getLogger(SigningKeyProviderImpl.class.getName());
     private static final Pattern YYYYMM = Pattern.compile("[0-9]{6}");
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormat.forPattern("yyyyMM");
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMM")
+        .withZone(ZoneId.systemDefault());
 
     private final AtomicReference<JwtRsaDigitalSignatureKey> key = new AtomicReference<>();
 
     @Override
     public SigningKey select(JwtToken token) {
-        String id = DATE_FORMAT.print(new Date().getTime());
+        String id = DATE_FORMAT.format(Instant.now());
         JwtRsaDigitalSignatureKey k = key.get();
         if (k==null || !k.getId().equals(id))
             key.set(k=new JwtRsaDigitalSignatureKey(id));

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeImpl.java
@@ -113,7 +113,7 @@ public class PipelineNodeImpl extends BluePipelineNode {
         if (getStartTime() == null) {
             return null;
         }
-        return AbstractRunImpl.DATE_FORMAT.print(getStartTime().getTime());
+        return AbstractRunImpl.DATE_FORMAT.format(getStartTime().toInstant());
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepImpl.java
@@ -124,7 +124,7 @@ public class PipelineStepImpl extends BluePipelineStep {
 
     @Override
     public String getStartTimeString(){
-        return AbstractRunImpl.DATE_FORMAT.print(getStartTime().getTime());
+        return AbstractRunImpl.DATE_FORMAT.format(getStartTime().toInstant());
     }
 
     @Override

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -97,11 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness-tools</artifactId>
         </dependency>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -1,15 +1,28 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.BooleanUtils;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.export.Exported;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Collections2;
+
 import hudson.model.Action;
 import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.blueocean.commons.ServiceException;
-import io.jenkins.blueocean.rest.Navigable;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
 import io.jenkins.blueocean.rest.hal.Link;
@@ -25,23 +38,7 @@ import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.BlueTestResultContainer;
 import io.jenkins.blueocean.rest.model.BlueTestSummary;
 import io.jenkins.blueocean.rest.model.Container;
-import io.jenkins.blueocean.rest.model.Containers;
 import io.jenkins.blueocean.rest.model.GenericResource;
-import jenkins.util.SystemProperties;
-import org.apache.commons.lang.BooleanUtils;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.export.Exported;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.Date;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Basic {@link BlueRun} implementation.
@@ -52,7 +49,9 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
 
     public static final String BLUEOCEAN_FEATURE_RUN_DESCRIPTION_ENABLED = "blueocean.feature.run.description.enabled";
 
-    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        .withZone(ZoneId.systemDefault());
+
     private static final Logger LOGGER = LoggerFactory.getLogger( AbstractRunImpl.class.getName());
 
     private static final long TEST_SUMMARY_CACHE_MAX_SIZE = Long.getLong("TEST_SUMMARY_CACHE_MAX_SIZE", 10000);
@@ -117,12 +116,12 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
 
     @Override
     public String getEnQueueTimeString() {
-        return DATE_FORMAT.print(getEnQueueTime().getTime());
+        return DATE_FORMAT.format(getEnQueueTime().toInstant());
     }
 
     @Override
     public String getStartTimeString(){
-        return DATE_FORMAT.print(getStartTime().getTime());
+        return DATE_FORMAT.format(getStartTime().toInstant());
     }
 
     @Override
@@ -131,7 +130,7 @@ public abstract class AbstractRunImpl<T extends Run> extends BlueRun {
         if(endTime == null) {
             return null;
         } else {
-            return DATE_FORMAT.print(endTime.getTime());
+            return DATE_FORMAT.format(endTime.toInstant());
         }
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ChangeSetResource.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Collection;
 
 /**
@@ -52,7 +53,7 @@ public class ChangeSetResource extends BlueChangeSetEntry {
     @Override
     public String getTimestamp(){
         if(changeSet.getTimestamp() > 0) {
-            return AbstractRunImpl.DATE_FORMAT.print(changeSet.getTimestamp());
+            return AbstractRunImpl.DATE_FORMAT.format(Instant.ofEpochMilli(changeSet.getTimestamp()));
         }else{
             return null;
         }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueItemImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/QueueItemImpl.java
@@ -69,7 +69,7 @@ public class QueueItemImpl extends BlueQueueItem {
 
     @Exported(name=QUEUED_TIME)
     public String getQueuedTimeString(){
-        return AbstractRunImpl.DATE_FORMAT.print(getQueuedTime().getTime());
+        return AbstractRunImpl.DATE_FORMAT.format(getQueuedTime().toInstant());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -734,12 +734,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-
         <!-- Needed for blueocean-display-url plugin -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
With Java 8 or higher Joda Time can be replaced with java.time.

# Description

See [JENKINS-60218](https://issues.jenkins-ci.org/browse/JENKINS-60218).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

Unclear how to test this. The fix replaces existing Joda Time code with the equivalent `java.time.*` code. Hereby the system's default time zone is used for formatting, as it was the case with Joda Time.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

