### PR TITLE
Jenkins 56392

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/BlueOceanWebURLBuilderTest.java
@@ -72,7 +72,7 @@ public class BlueOceanWebURLBuilderTest {
         String blueOceanURL;
 
         blueOceanURL = urlMapper.getUrl(mp);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches/", blueOceanURL);
 
         mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
         for (SCMSource source : mp.getSCMSources()) {
@@ -86,19 +86,19 @@ public class BlueOceanWebURLBuilderTest {
         // page for the multibranch job in Blue Ocean.
         WorkflowJob masterJob = findBranchProject(mp, "master");
         blueOceanURL = urlMapper.getUrl(masterJob);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches/", blueOceanURL);
         WorkflowJob featureUx1Job = findBranchProject(mp, "feature/ux-1");
         blueOceanURL = urlMapper.getUrl(featureUx1Job);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches/", blueOceanURL);
         WorkflowJob feature2Job = findBranchProject(mp, "feature2");
         blueOceanURL = urlMapper.getUrl(feature2Job);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/branches/", blueOceanURL);
 
         // Runs on the jobs
         blueOceanURL = urlMapper.getUrl(masterJob.getFirstBuild());
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/master/1", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/master/1/", blueOceanURL);
         blueOceanURL = urlMapper.getUrl(featureUx1Job.getFirstBuild());
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/feature%2Fux-1/1", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Fp/detail/feature%2Fux-1/1/", blueOceanURL);
     }
 
     private WorkflowJob findBranchProject(WorkflowMultiBranchProject mp, String name) throws Exception {

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlMapperImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlMapperImpl.java
@@ -52,7 +52,7 @@ public class BlueOceanUrlMapperImpl extends BlueOceanUrlMapper {
                 // specifically %. Encoding it again breaks things ala JENKINS-40137. The creation name can also
                 // have spaces, even from the UI (it should prevent that). So, decode to revert anything that's already
                 // encoded and re-encode to do the full monty. Nasty :)
-                return baseUrl +"/" + encodeURIComponent(blueResource.getFullName())+"/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId()) +"/";
+                return baseUrl + "/" + encodeURIComponent(blueResource.getFullName()) + "/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId()) + "/";
             }
         } else if(modelObject instanceof Item){
             Resource bluePipeline = BluePipelineFactory.resolve((Item)modelObject);
@@ -65,9 +65,9 @@ public class BlueOceanUrlMapperImpl extends BlueOceanUrlMapper {
 
     private String getPipelineUrl(String baseUrl, BluePipeline pipeline){
         if(pipeline instanceof BlueMultiBranchPipeline){
-            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName())+"/branches/";
+            return baseUrl + "/" + encodeURIComponent(pipeline.getFullName()) + "/branches/";
         }else{
-            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName()) + "/";
+            return baseUrl + "/" + encodeURIComponent(pipeline.getFullName()) + "/";
         }
     }
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlMapperImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlMapperImpl.java
@@ -52,7 +52,7 @@ public class BlueOceanUrlMapperImpl extends BlueOceanUrlMapper {
                 // specifically %. Encoding it again breaks things ala JENKINS-40137. The creation name can also
                 // have spaces, even from the UI (it should prevent that). So, decode to revert anything that's already
                 // encoded and re-encode to do the full monty. Nasty :)
-                return baseUrl +"/" + encodeURIComponent(blueResource.getFullName())+"/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId());
+                return baseUrl +"/" + encodeURIComponent(blueResource.getFullName())+"/detail/" + encodeURIComponent(decodeURIComponent(job.getName())) + "/" + encodeURIComponent(run.getId()) +"/";
             }
         } else if(modelObject instanceof Item){
             Resource bluePipeline = BluePipelineFactory.resolve((Item)modelObject);
@@ -65,9 +65,9 @@ public class BlueOceanUrlMapperImpl extends BlueOceanUrlMapper {
 
     private String getPipelineUrl(String baseUrl, BluePipeline pipeline){
         if(pipeline instanceof BlueMultiBranchPipeline){
-            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName())+"/branches";
+            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName())+"/branches/";
         }else{
-            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName());
+            return baseUrl + "/" +encodeURIComponent(pipeline.getFullName()) + "/";
         }
     }
 

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BlueOceanWebURLBuilderTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/BlueOceanWebURLBuilderTest.java
@@ -79,11 +79,11 @@ public class BlueOceanWebURLBuilderTest {
         String blueOceanURL;
 
         blueOceanURL = urlMapper.getUrl(freestyleProject);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Ffreestyle%20with%20spaces", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Ffreestyle%20with%20spaces/", blueOceanURL);
 
         FreeStyleBuild run = freestyleProject.scheduleBuild2(0).get();
         blueOceanURL = urlMapper.getUrl(run);
-        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Ffreestyle%20with%20spaces/detail/freestyle%20with%20spaces/1", blueOceanURL);
+        assertURL("blue/organizations/jenkins/folder1%2Ffolder%20two%20with%20spaces%2Ffreestyle%20with%20spaces/detail/freestyle%20with%20spaces/1/", blueOceanURL);
     }
 
 


### PR DESCRIPTION
Avoid unecessary location roudtrips by adding a slash to all generated URLs

See [JENKINS-56392](https://issues.jenkins-ci.org/browse/JENKINS-56392).

