### PR TITLE
Replace wiki URL with github URL in pom files

### DIFF
--- a/blueocean-bitbucket-pipeline/pom.xml
+++ b/blueocean-bitbucket-pipeline/pom.xml
@@ -11,7 +11,7 @@
   <name>Bitbucket Pipeline for Blue Ocean</name>
   <artifactId>blueocean-bitbucket-pipeline</artifactId>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
   <properties>
     <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-commons/pom.xml
+++ b/blueocean-commons/pom.xml
@@ -13,7 +13,7 @@
 
   <name>Common API for Blue Ocean</name>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-config/pom.xml
+++ b/blueocean-config/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
 
   <name>Config API for Blue Ocean</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
   <dependencies>
     <dependency>

--- a/blueocean-dashboard/pom.xml
+++ b/blueocean-dashboard/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-dashboard</artifactId>
     <packaging>hpi</packaging>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-events</artifactId>
     <packaging>hpi</packaging>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <properties>
         <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-executor-info/pom.xml
+++ b/blueocean-executor-info/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>blueocean-executor-info</artifactId>
     <packaging>hpi</packaging>
     <description>Show what executors are doing what.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <developers>
         <developer>

--- a/blueocean-git-pipeline/pom.xml
+++ b/blueocean-git-pipeline/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>blueocean-git-pipeline</artifactId>
   <packaging>hpi</packaging>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
   <properties>
     <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>blueocean-github-pipeline</artifactId>
   <packaging>hpi</packaging>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
   <properties>
     <jacoco.haltOnFailure>true</jacoco.haltOnFailure>
   </properties>

--- a/blueocean-i18n/pom.xml
+++ b/blueocean-i18n/pom.xml
@@ -13,7 +13,7 @@
 
   <name>i18n for Blue Ocean</name>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>

--- a/blueocean-jira/pom.xml
+++ b/blueocean-jira/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>JIRA Integration for Blue Ocean</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <properties>
         <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-jwt/pom.xml
+++ b/blueocean-jwt/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
 
   <name>JWT for Blue Ocean</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
   <dependencies>
       <dependency>

--- a/blueocean-personalization/pom.xml
+++ b/blueocean-personalization/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>blueocean-personalization</artifactId>
     <packaging>hpi</packaging>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>Pipeline implementation for Blue Ocean</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <properties>
         <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-pipeline-editor/pom.xml
+++ b/blueocean-pipeline-editor/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>blueocean-pipeline-editor</artifactId>
     <packaging>hpi</packaging>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <licenses>
         <license>

--- a/blueocean-pipeline-scm-api/pom.xml
+++ b/blueocean-pipeline-scm-api/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>Pipeline SCM API for Blue Ocean</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>REST Implementation for Blue Ocean</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <properties>
         <jacoco.haltOnFailure>true</jacoco.haltOnFailure>

--- a/blueocean-rest/pom.xml
+++ b/blueocean-rest/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
 
   <name>REST API for Blue Ocean</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+  <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
   <dependencies>
       <dependency>

--- a/blueocean-web/pom.xml
+++ b/blueocean-web/pom.xml
@@ -13,7 +13,7 @@
 
     <name>Web for Blue Ocean</name>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
 
     <name>Blue Ocean</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
     <description>Blue Ocean is a new project that rethinks the user experience of Jenkins. Designed from the ground up for Jenkins Pipeline and compatible with Freestyle jobs, Blue Ocean reduces clutter and increases clarity for every member of your team.</description>
 
     <properties>

--- a/docker/official/pom.xml
+++ b/docker/official/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>BlueOcean plugin fetcher</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
# Update project.url in pom files for documentation migration project

Changes the `document.url` field in each submodules' pom.xml to point to instead of `https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Plugin`. This is the same URL as put into the aggregator by @MarkEWaite in [PR2040](https://github.com/jenkinsci/blueocean-plugin/pull/2040). 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate: N/A
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: N/A. Strictly a doc link change in pom files.
- [x] Reviewer's manual test instructions provided in PR description: there are none. Strictly a doc link change in pom files.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

