### PR TITLE
Change to https url for maven download

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -38,7 +38,7 @@ ENV LC_ALL en_US.UTF-8
 #==========
 # Maven
 #==========
-RUN curl -fsSL http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
+RUN curl -fsSL https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
   && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 ENV MAVEN_HOME /usr/share/maven


### PR DESCRIPTION
# Description

[Dockerfile.build still uses an http URL to access repo.maven.apache.org](https://github.com/jenkinsci/blueocean-plugin/blob/e3e4ddc5cb2f642efd774a7cc75dca52ef56a81b/Dockerfile.build#L41). This is no longer supported. So let's fix that. 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate: N/A
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests: I verified that this curl command does indeed work.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

