### PR TITLE
[JENKINS-50328] [JENKINS-51066] Fix bug where pipeline editor ignores custom Jenkinsfile script path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelogs
 
-# new test
-
 ## 1.13.2 (March 6st, 2019)
 
 * HOTFIX - [JENKINS-56383](https://issues.jenkins-ci.org/browse/JENKINS-56383) Reverted the fix for [JENKINS-38339](https://issues.jenkins-ci.org/browse/JENKINS-38339) which was causing double parallel steps to fail to render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelogs
 
+# test change
+
 ## 1.13.2 (March 6st, 2019)
 
 * HOTFIX - [JENKINS-56383](https://issues.jenkins-ci.org/browse/JENKINS-56383) Reverted the fix for [JENKINS-38339](https://issues.jenkins-ci.org/browse/JENKINS-38339) which was causing double parallel steps to fail to render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelogs
 
+# new test
+
 ## 1.13.2 (March 6st, 2019)
 
 * HOTFIX - [JENKINS-56383](https://issues.jenkins-ci.org/browse/JENKINS-56383) Reverted the fix for [JENKINS-38339](https://issues.jenkins-ci.org/browse/JENKINS-38339) which was causing double parallel steps to fail to render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelogs
 
-# test change
-
 ## 1.13.2 (March 6st, 2019)
 
 * HOTFIX - [JENKINS-56383](https://issues.jenkins-ci.org/browse/JENKINS-56383) Reverted the fix for [JENKINS-38339](https://issues.jenkins-ci.org/browse/JENKINS-38339) which was causing double parallel steps to fail to render

--- a/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
+++ b/blueocean-pipeline-editor/src/main/js/EditorPage.jsx
@@ -177,6 +177,7 @@ class PipelineLoader extends React.Component {
         this.contentApi = new ScmContentApi();
 
         this.state = {
+            scriptPath: null,
             scmSource: null,
             credential: null,
             sha: null,
@@ -329,6 +330,7 @@ class PipelineLoader extends React.Component {
 
     _savePipelineMetadata(pipeline) {
         this.setState({
+            scriptPath: pipeline.scriptPath,
             scmSource: pipeline.scmSource,
         });
     }
@@ -346,9 +348,9 @@ class PipelineLoader extends React.Component {
     }
 
     loadContent(onComplete) {
-        const { organization, pipeline, branch } = this.props.params;
+        const { organization, pipeline, branch, path = this.state.scriptPath } = this.props.params;
         this.contentApi
-            .loadContent({ organization, pipeline, branch })
+            .loadContent({ organization, pipeline, branch, path})
             .then(({ content }) => {
                 if (!content.base64Data) {
                     throw { type: LoadError.JENKINSFILE_NOT_FOUND };
@@ -611,6 +613,7 @@ class PipelineLoader extends React.Component {
                     targetBranch: saveToBranch || this.defaultBranch,
                     sha: this.state.sha,
                     message: saveMessage,
+                    path: this.state.scriptPath,
                     content: pipelineScript,
                 };
 


### PR DESCRIPTION
# Description
This change fixes a bug where the pipeline editor ignores and therefore fails to load or save custom Jenkinsfile script paths. This is a fix to existing functionality so no new tests have been added.

See [JENKINS-50328](https://issues.jenkins-ci.org/browse/JENKINS-50328).
See [JENKINS-51066](https://issues.jenkins-ci.org/browse/JENKINS-51066).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

