### PR TITLE
[JENKINS-60983] Fix broken incremental deploys

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -19,6 +19,7 @@
         <connection>scm:git:https://github.com/jenkinsci/blueocean-plugin.git</connection>
         <developerConnection>scm:git:https://github.com/jenkinsci/blueocean-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/blueocean-plugin</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
# Description

See [JENKINS-60983](https://issues.jenkins-ci.org/browse/JENKINS-60983).
Add missing <tag> section in <scm> of blueocean/pom.xml.
No new unit/acceptance tests are required.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

