### PR TITLE
Jenkins Design Language: Use GitHub as a source of plugin docs + Remove the confusing link to the JDL2 website

### DIFF
--- a/jenkins-design-language/README.md
+++ b/jenkins-design-language/README.md
@@ -10,6 +10,6 @@ npm run build-storybook
 npm run site-server
 ```
 
-> License is MIT. Other licenses in /licenses
+## License
 
-__[Docs Site](http://jenkinsci.github.io/jenkins-design-language/docs)__
+License is MIT. Other licenses in /licenses

--- a/jenkins-design-language/pom.xml
+++ b/jenkins-design-language/pom.xml
@@ -13,7 +13,7 @@
 
     <name>Jenkins Design Language</name>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Design+Language</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/jenkins-design-language/README.md</url>
 
     <build>
         <resources>


### PR DESCRIPTION
# Description

Ass @NicuPascu explained to me, http://jenkinsci.github.io/jenkins-design-language/docs/ links the Jenkins Design Language 2 website. This site has nothing to do with the JDL implementation included in this repo, so it is better to just remove the link.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

