### PR TITLE
README: remove reference to the Blue Ocean roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Blue Ocean 
-Blue Ocean is the next generation user experience for Jenkins. You can learn more about its features and roadmap on the [Blue Ocean project website](https://jenkins.io/projects/blueocean/).
+Blue Ocean is the next generation user experience for Jenkins. You can learn more about its features on the [Blue Ocean project website](https://jenkins.io/projects/blueocean/).
 
 Join the community and [![Gitter](https://badges.gitter.im/jenkinsci/blueocean-plugin.svg)](https://gitter.im/jenkinsci/blueocean-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Follow-up to https://github.com/jenkins-infra/jenkins.io/issues/3046 . There is no Blue Ocean roadmap anymore on the site