### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/blueocean-core-js/pom.xml
+++ b/blueocean-core-js/pom.xml
@@ -13,7 +13,7 @@
 
     <name>Blue Ocean Core JS</name>
 
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Blue+Ocean+Core+JS</url>
+    <url>https://github.com/jenkinsci/blueocean-plugin/blob/master/blueocean/doc/BlueOcean.adoc</url>
 
     <build>
         <resources>


### PR DESCRIPTION
This plugin was skipped in https://github.com/jenkinsci/blueocean-plugin/pull/2044 -- this PR makes it consistent. @MarkEWaite 's suggestion https://github.com/jenkinsci/blueocean-plugin/pull/2044#issuecomment-579087326 is not implemented here.