### PR TITLE
Improve Jenkinsfile error handling by removing unnecessary catch block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,22 +99,17 @@ node() {
             }
           }
         }
-      } catch(err) {
-        echo(err)
-        currentBuild.result = "FAILURE"
-
-        if (err.toString().contains('exit code 143')) {
-          currentBuild.result = "ABORTED"
-        }
       } finally {
         stage('Cleanup') {
-          if (params.USE_SAUCELABS) {
-            sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-sc.sh"
-          } else {
-            sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-selenium.sh"
+          catchError(message: 'Suppressing error in Stage: Cleanup') {
+            if (params.USE_SAUCELABS) {
+              sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-sc.sh"
+            } else {
+              sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-selenium.sh"
+            }
+            sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-bitbucket-server.sh"
+            deleteDir()
           }
-          sh "${env.WORKSPACE}/acceptance-tests/runner/scripts/stop-bitbucket-server.sh"
-          deleteDir()
         }
       }
     }


### PR DESCRIPTION
# Description

The previous usage of the echo step was incorrect because the argument was not a string. It is generally better to throw errors instead of logging them and using `currentBuild.result` to set the result so that the stack trace of the error is displayed in the build log. The relevant code failed in [this PR build](https://ci.blueocean.io/job/blueocean/job/PR-2064/20/), here is an excerpt from the log:

```
java.lang.ClassCastException: org.jenkinsci.plugins.workflow.steps.EchoStep.message expects class java.lang.String but received class org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
```

We use `catchError` in the `finally` block so that exceptions thrown by that stage do not mask errors throw from the `try` block, which  are more likely to be the root cause of any problems.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

