### PR TITLE
[JENKINS-62063] Fix failure when using pipeline-multibranch-defaults

### DIFF
--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchPipelineImpl.java
@@ -38,7 +38,11 @@ import io.jenkins.blueocean.service.embedded.rest.ActionProxiesImpl;
 import io.jenkins.blueocean.service.embedded.rest.FavoriteImpl;
 import io.jenkins.blueocean.service.embedded.util.Disabler;
 import io.jenkins.blueocean.service.embedded.util.FavoriteUtil;
+import jenkins.branch.BranchProjectFactory;
 import jenkins.branch.MultiBranchProject;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.kohsuke.stapler.export.Exported;
@@ -274,9 +278,11 @@ public class MultiBranchPipelineImpl extends BlueMultiBranchPipeline {
                 MultiBranchPipelineImpl mbpi = new MultiBranchPipelineImpl(organization, (MultiBranchProject) item);
                 if (item instanceof WorkflowMultiBranchProject) {
                     WorkflowMultiBranchProject wfmbp = (WorkflowMultiBranchProject)item;
-                    WorkflowBranchProjectFactory wbpf = (WorkflowBranchProjectFactory)wfmbp.getProjectFactory();
-                    String sp = wbpf.getScriptPath();
-                    mbpi.setScriptPath(sp);
+                    BranchProjectFactory<WorkflowJob, WorkflowRun> bpf = wfmbp.getProjectFactory();
+                    if (bpf instanceof WorkflowBranchProjectFactory) {
+                        String sp = ((WorkflowBranchProjectFactory) bpf).getScriptPath();
+                        mbpi.setScriptPath(sp);
+                    }
                 }
                 return mbpi;
             }


### PR DESCRIPTION
This change will stop the failure but also rolls back #2049 when using pipeline-multibranch-defaults

# Description

See [JENKINS-62063](https://issues.jenkins-ci.org/browse/JENKINS-62063).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

