### PR TITLE
[JENKINS-62767] Don't bundle git test deps in events plugin

### DIFF
--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -31,6 +31,24 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit.http.apache</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit.http.server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>async-http-client</artifactId>
             <scope>test</scope>
         </dependency>
@@ -114,6 +132,7 @@
                     <artifactId>org.eclipse.jgit</artifactId>
                 </exclusion>
             </exclusions>
+
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -32,6 +32,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jgit</groupId>

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -56,6 +56,63 @@
                     <groupId>org.jenkins-ci</groupId>
                     <artifactId>annotation-indexer</artifactId>
                 </exclusion>
+                <!-- Git transitive dependencies should not be included in blueocean-events packaging -->
+                <exclusion>
+                    <groupId>com.googlecode.javaewah</groupId>
+                    <artifactId>JavaEWAH</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.infradna.tool</groupId>
+                    <artifactId>bridge-method-annotation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>fluent-hc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpasyncclient-cache</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpasyncclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient-cache</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore-nio</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpmime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit.http.apache</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit.http.server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -34,6 +34,7 @@
             <artifactId>git-client</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <version>2.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jgit</groupId>

--- a/blueocean-events/pom.xml
+++ b/blueocean-events/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
-            <classifier>tests</classifier>
             <scope>test</scope>
             <version>2.7.0</version>
             <exclusions>


### PR DESCRIPTION
## [JENKINS-62767](https://issues.jenkins-ci.org/browse/JENKINS-62767) Don't bundle git test deps in events plugin

The blueocean-events plugin has a test dependency on the git plugin.  The maven hpi plugin incorrectly includes the transitive dependencies of test dependencies in the hpi file.

That caused the blueocean-events plugin to deliver a copy of JGit 4.5.4 and its dependencies when the git client plugin (owner of the JGit library) is now delivering JGit 5.8.0.

Might also be able to resolve the issue by updating the maven hpi plugin to a newer version or by updating the parent pom to a newer version.  Since I can't compile the blueocean-plugin on my computer, this seemed like the smallest possible change that would remove the undesirable inclusions from the hpi file.  This technique can also be tested by viewing the pull request build log to confirm that blueocean-events no longer includes JGit.

This pull request includes no tests because I am unable to compile the blueocean plugin on my computer.  I failed my attempts to compile with the various techniques mentioned in the docs.  An automated acceptance test is implemented on my Jenkins instance that will warn if any plugin includes JGit other than the git client plugin.  See my [check job](https://github.com/MarkEWaite/docker-lfs/blob/lts-with-plugins/ref/jobs/Maintenance/jobs/check-jgit-not-bundled-by-wrong-plugins/config.xml) for more details.  That test currently reports an issue with blueocean-events, gitlab-plugin, and workflow-remote-loader.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

Reviewer can check the build log for the pull request to confirm that the following content is *NOT* in the log:

```
[WARNING] Bundling transitive dependency JavaEWAH-0.7.9.jar (via git)
[WARNING] Bundling transitive dependency bridge-method-annotation-1.17.jar (via git)
[WARNING] Bundling transitive dependency joda-time-2.9.9.jar (via git)
[WARNING] Bundling transitive dependency fluent-hc-4.5.10.jar (via git)
[WARNING] Bundling transitive dependency httpasyncclient-cache-4.1.4.jar (via git)
[WARNING] Bundling transitive dependency httpasyncclient-4.1.4.jar (via git)
[WARNING] Bundling transitive dependency httpclient-cache-4.5.10.jar (via git)
[WARNING] Bundling transitive dependency httpclient-4.5.10.jar (via git)
[WARNING] Bundling transitive dependency httpcore-nio-4.4.10.jar (via git)
[WARNING] Bundling transitive dependency httpcore-4.4.12.jar (via git)
[WARNING] Bundling transitive dependency httpmime-4.5.10.jar (via git)
[WARNING] Bundling transitive dependency org.eclipse.jgit.http.apache-4.5.4.201711221230-r.jar (via git)
[WARNING] Bundling transitive dependency org.eclipse.jgit.http.server-4.5.4.201711221230-r.jar (via git)
[WARNING] Bundling transitive dependency org.eclipse.jgit-4.5.4.201711221230-r.jar (via git)
```

Reviewer can also check interactively that [JENKINS-62767](https://issues.jenkins-ci.org/browse/JENKINS-62767) is resolved.