### PR TITLE
[JENKINS-62767] - Allow job creation in git repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 
 if (JENKINS_URL == 'https://ci.jenkins.io/') {
   buildPlugin(
-    configurations: buildPlugin.recommendedConfigurations().findAll { it.platform == 'linux' },
+    configurations: [
+      [ platform: "linux", jdk: "8", jenkins: "2.164.3" ],
+      [ platform: "linux", jdk: "11", jenkins: "2.164.3", javaLevel: "8" ]
+    ],
     // Tests were locking up and timing out on non-aci
     useAci: true,
     timeout: 90

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.3</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## [JENKINS-62767](https://issues.jenkins-ci.org/browse/JENKINS-62767) - Job creation fails due to outdated JGit in events.hpi

Uses the most recent parent pom which provides the most recent fixes for the maven hpi plugin.

Now requires Jenkins 2.164.3 instead of Jenkins 2.150.3 as minimum Jenkins version.  Jenkins version increment is required in order to use the most recent parent pom.

* 86% of all Blue Ocean installations use Jenkins 2.164.3 or later
* 91% of all Blue Ocean installations use Jenkins 2.150.3 or later

That 5% difference between 2.164.3 and 2.150.3 should not block our fixing JENKINS-62767, especially since none of the users in that 5% group are running Blue Ocean 1.23.0, 1.23.1, or 1.23.2.  Users that are still running Jenkins 2.150.3 are not likely to adopt the most recent Blue Ocean release.  They've already decided to remain on an older Jenkins version.  It is unlikely that they are aggressively upgrading plugins when they are being conservative about their Jenkins core version.

### Submitter checklist

- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

### Reviewer checklist

- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

### Reviewer manual test instructions

* Confirm that the build log segment describing blueocean-events contains no mention of including dependencies from the git plugin
* Confirm that the interactive behavior is consistent with previous releases (tester selected subset)