### PR TITLE
Don't check read permission for sidebar link

### DIFF
--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction/action.jelly
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/BlueOceanUrlAction/action.jelly
@@ -5,6 +5,5 @@
     </j:if>
     <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
             href="${rootURL}/${action.urlName}"
-            permission="${app.READ}"
     />
 </j:jelly>


### PR DESCRIPTION
Theres no need, because the user wouldn't be viewing
the build page if they didn't have the required read permission.

# Description

See [JENKINS-46540](https://issues.jenkins-ci.org/browse/JENKINS-46540).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

