### PR TITLE
Fixing build configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 if (JENKINS_URL == 'https://ci.jenkins.io/') {
   buildPlugin(
     configurations: [
-      [ platform: "linux", jdk: "8", jenkins: "2.164.3" ],
-      [ platform: "linux", jdk: "11", jenkins: "2.164.3", javaLevel: "8" ]
+      [ platform: "linux", jdk: "8" ],
+      [ platform: "linux", jdk: "11" ]
     ],
     // Tests were locking up and timing out on non-aci
     useAci: true,


### PR DESCRIPTION
Incrementals were not being deployed because #2075 improperly defined the `jenkins` variable in _every_ configuration; Incrementals are only deployed (and artifacts archived) when this is null. Also

* `javaLevel` does not need to be overridden, the POM specifies it
* after #2079, the declared `jenkins` level was _older_ than what the plugin actually requires