### PR TITLE
Fix PCT failures when running against Jenkins 2.249+

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/parallelStepsFromPost.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/parallelStepsFromPost.jenkinsfile
@@ -36,7 +36,6 @@ pipeline {
       input(message: 'User input required', ok: 'Engage!', parameters: [
                                                           string(name: 'STRING', description: 'String Param', defaultValue: 'Hello'),
                                                           text(name: 'TEXT', description: 'Text Param', defaultValue: 'This is a\nmulti line string'),
-                                                          password(name: 'PASSWORD', description: 'Password Param', defaultValue: 'foo'),
                                                           booleanParam(name: 'BOOLEAN', description: 'Boolean Param', defaultValue: false),
                                                           choice(
                                                                         name: 'CHOICE',

--- a/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/stepsFromPost.jenkinsfile
+++ b/blueocean-pipeline-api-impl/src/test/resources/io/jenkins/blueocean/rest/impl/pipeline/stepsFromPost.jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
             input(message: 'User input required', ok: 'Engage!', parameters: [
                     string(name: 'STRING', description: 'String Param', defaultValue: 'Hello'),
                     text(name: 'TEXT', description: 'Text Param', defaultValue: 'This is a\nmulti line string'),
-                    password(name: 'PASSWORD', description: 'Password Param', defaultValue: 'foo'),
                     booleanParam(name: 'BOOLEAN', description: 'Boolean Param', defaultValue: false),
                     choice(
                             name: 'CHOICE',

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenuTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/TryBlueOceanMenuTest.java
@@ -9,6 +9,9 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * @author Vivek Pandey
  */
@@ -19,6 +22,6 @@ public class TryBlueOceanMenuTest extends BaseTest{
         HtmlPage page = webClient.getPage(j.getInstance());
         HtmlAnchor anchor = page.getAnchorByText(Messages.BlueOceanUrlAction_DisplayName());
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/pipelines/", anchor.getHrefAttribute());
-        Assert.assertEquals("task-link", anchor.getAttribute("class"));
+        assertThat(anchor.getAttribute("class"), containsString("task-link"));
     }
 }


### PR DESCRIPTION
# Description

This PR fixes three tests that are failing in the PCT when running against Jenkins 2.249:
* `TryBlueOceanMenuTest.testOpenBlueOcean`: Issue is that https://github.com/jenkinsci/jenkins/pull/4700 changed the styling of the sidebar links, and as a result the `class` attribute has a space at the end now (to make it easier to add a class under certain conditions).
* `PipelineNodeTest.submitInputPostBlock`: Underlying issue is [JENKINS-63516](https://issues.jenkins-ci.org/browse/JENKINS-63516). This test doesn't really have anything to do with password parameters specifically, so we just remove the password parameter from the test to fix the PCT failures.
* `PipelineNodeTest.submitInputPostBlockWithParallelStages`: Same as `PipelineNodeTest.submitInputPostBlock`.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

