### PR TITLE
Remove unused jquery-detached js dependency

### DIFF
--- a/blueocean-web/package-lock.json
+++ b/blueocean-web/package-lock.json
@@ -6736,15 +6736,6 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "optional": true
     },
-    "jquery-detached": {
-      "version": "2.1.4-v4",
-      "resolved": "https://registry.npmjs.org/jquery-detached/-/jquery-detached-2.1.4-v4.tgz",
-      "integrity": "sha1-8muyKXGxB0F4ut+vLxQ9mW0Y35w=",
-      "dev": true,
-      "requires": {
-        "window-handle": "^1.0.0"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11671,12 +11662,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
-    "window-handle": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/window-handle/-/window-handle-1.0.1.tgz",
-      "integrity": "sha1-GhsrPg2/OEP1udzhkFSNKpliGO0=",
       "dev": true
     },
     "window-size": {

--- a/blueocean-web/package.json
+++ b/blueocean-web/package.json
@@ -33,7 +33,6 @@
     "gulp": "3.9.1",
     "gulp-typescript": "4.0.1",
     "jest": "19.0.2",
-    "jquery-detached": "2.1.4-v4",
     "ncp": "2.0.0",
     "reactify": "1.1.1",
     "ts-jest": "19.0.2",


### PR DESCRIPTION
# Description

- jquery-detached provides an outdated and insecure version of jQuery. It's removed from the project because it is insecure.
- There are other legacy uses of old versions of jquery but they are limited to the jenkins-design-language website. They were not touched.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

