### PR TITLE
Remove executor plugin from required deps

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -108,12 +108,6 @@
             <artifactId>blueocean-jira</artifactId>
         </dependency>
 
-        <!-- TODO remove with next release -->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>blueocean-executor-info</artifactId>
-        </dependency>
-
         <!-- Bundled plugins for improved out of the box experience -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
# Description

People are complaining because they can't uninstall this plugin but it's marked as deprecated, not a good user experience. Can we get a release ASAP for this?

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

