### PR TITLE
Upgrade UA Parser Library

### DIFF
--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -92,8 +92,8 @@
         </dependency>
 
         <dependency>
-            <groupId>ua_parser</groupId>
-            <artifactId>ua-parser</artifactId>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
         </dependency>
 
         <dependency>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/BrowserAndOperatingSystemAnalyticsProperties.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/BrowserAndOperatingSystemAnalyticsProperties.java
@@ -19,20 +19,7 @@ import static org.apache.commons.lang.StringUtils.isNotEmpty;
 @Extension
 public class BrowserAndOperatingSystemAnalyticsProperties extends AdditionalAnalyticsProperties {
 
-    private static final Logger LOGGER = Logger.getLogger(BrowserAndOperatingSystemAnalyticsProperties.class.getName());
-
-    private static final Parser PARSER;
-
-    static {
-        Parser parser;
-        try {
-            parser = new Parser();
-        } catch (IOException e) {
-            parser = null;
-            LOGGER.log(Level.SEVERE, "There was a problem loading the UAParser. Browser detection is unavailable.", e);
-        }
-        PARSER = parser;
-    }
+    private static final Parser PARSER = new Parser();
 
     @Override
     public Map<String, Object> properties(TrackRequest req) {

--- a/pom.xml
+++ b/pom.xml
@@ -705,9 +705,9 @@
         </dependency>
 
         <dependency>
-            <groupId>ua_parser</groupId>
-            <artifactId>ua-parser</artifactId>
-            <version>1.3.0</version>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
+            <version>1.5.0</version>
             <exclusions>
               <!-- commons-collections comes from jenkins core -->
               <exclusion>


### PR DESCRIPTION
`ua_parser:ua-parser` has been replaced by `com.github.ua-parser:uap-java`

More info here - https://github.com/tobie/ua-parser/

The library at older coordinates was never published to Maven Central.
The new one exists on Maven Central.

# Description

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

