### PR TITLE
[JENKINS-50885] Make blueocean-jira plugin optional

### DIFF
--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -106,6 +106,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>blueocean-jira</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- TODO remove with next release -->


### PR DESCRIPTION
# Description

See [JENKINS-50885](https://issues.jenkins-ci.org/browse/JENKINS-50885).

Resurrecting https://github.com/jenkinsci/blueocean-plugin/pull/1719 now that [JENKINS-33843](https://issues.jenkins.io/browse/JENKINS-33843) has been fixed. Blue Ocean users may not be using Jira, so we should not force them to install the `blueocean-jira` and `jira` plugins just to be able to use Blue Ocean.

Opening a draft PR for now to check if any ATH tests fail with this change.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

