### PR TITLE
[JENKINS-58732] Remove docker-workflow dep from blueocean-pipeline-editor

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -1082,6 +1082,7 @@ public class MultiBranchTest extends PipelineBaseTest {
 
     @Test
     public void testMultiBranchPipelineQueueContainer() throws Exception {
+        j.jenkins.setQuietPeriod(0);
         WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
         sampleRepo1.init();
         sampleRepo1.write("Jenkinsfile", "stage 'build'\n " + "node {echo 'Building'}\n" +

--- a/blueocean-pipeline-editor/pom.xml
+++ b/blueocean-pipeline-editor/pom.xml
@@ -64,10 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>docker-workflow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sonar</artifactId>
             <scope>test</scope>
         </dependency>

--- a/blueocean-pipeline-editor/src/test/java/io/blueocean/rest/pipeline/editor/PipelineMetadataServiceTest.java
+++ b/blueocean-pipeline-editor/src/test/java/io/blueocean/rest/pipeline/editor/PipelineMetadataServiceTest.java
@@ -4,7 +4,7 @@ import hudson.model.JDK;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.hamcrest.Matcher;
-import org.jenkinsci.plugins.docker.workflow.declarative.DockerPipeline;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.Label;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -57,7 +57,7 @@ public class PipelineMetadataServiceTest {
         ExportedDescribableModel m = null;
 
         for (ExportedDescribableModel a : agents) {
-            if (a.getType().equals(DockerPipeline.class.getName())) {
+            if (a.getType().endsWith(Label.class.getName())) {
                 m = a;
             }
         }

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -94,6 +94,12 @@
         <dependency>
             <groupId>com.github.ua-parser</groupId>
             <artifactId>uap-java</artifactId>
+            <exclusions>
+              <exclusion> <!-- from io.jenkins.plugins:snakeyaml-api -->
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/blueocean/pom.xml
+++ b/blueocean/pom.xml
@@ -149,6 +149,12 @@
             <groupId>com.mashape.unirest</groupId>
             <artifactId>unirest-java</artifactId>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/blueocean-plugin</gitHubRepo>
     <java.level>8</java.level>
-    <jenkins.version>2.176.4</jenkins.version> <!-- Should be kept in sync with the version resulting from Dockerfile FROM statement-->
+    <jenkins.version>2.222.4</jenkins.version>
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <frontend-version>1.7.5</frontend-version>
     <node.version>10.13.0</node.version>
@@ -45,9 +45,6 @@
     <jacoco.missedclass.coverage>0.00</jacoco.missedclass.coverage>
     <hpi.dependencyResolution>runtime</hpi.dependencyResolution>
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
-    <workflow-support.version>3.3</workflow-support.version>
-    <pipeline-model-definition.version>1.6.0</pipeline-model-definition.version>
-    <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
   </properties>
 
   <scm>
@@ -197,6 +194,12 @@
           <groupId>com.mashape.unirest</groupId>
           <artifactId>unirest-java</artifactId>
           <scope>test</scope>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.json</groupId>
+                  <artifactId>json</artifactId>
+              </exclusion>
+          </exclusions>
       </dependency>
 
       <!-- Needed for unirest -->
@@ -229,8 +232,8 @@
 
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.176.x</artifactId>
-            <version>11</version>
+            <artifactId>bom-2.222.x</artifactId>
+            <version>22</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>
@@ -362,115 +365,8 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>ssh-credentials</artifactId>
-            <version>1.17.3</version>
-        </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.jenkins-ci.plugins</groupId>-->
-<!--            <artifactId>trilead-api</artifactId>-->
-<!--            <version>1.0.5</version>-->
-<!--        </dependency>-->
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>4.2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>4.2.2</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Pipeline plugins -->
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-definition</artifactId>
-            <version>${pipeline-model-definition.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>git-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-stage-tags-metadata</artifactId>
-            <version>${pipeline-model-definition.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-api</artifactId>
-            <version>${pipeline-model-definition.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkinsci.plugins</groupId>
-            <artifactId>pipeline-model-extensions</artifactId>
-            <version>${pipeline-model-definition.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.33</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-graph-analysis</artifactId>
             <version>1.10</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.20</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.22</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.31</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>${workflow-support.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>${workflow-support.version}</version>
-            <classifier>tests</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <version>2.18</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>2.11</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-stage-step</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-input-step</artifactId>
-            <version>2.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-build-step</artifactId>
-            <version>2.7</version>
         </dependency>
 
         <dependency>
@@ -479,31 +375,7 @@
             <version>1.3.1</version>
         </dependency>
 
-        <!-- scm plugins -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>${scm-api-plugin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.0.20</version>
-            <exclusions>
-                <!-- Upper dependency fix: annotation-indexer comes from core, exclude from git -->
-                <exclusion>
-                    <groupId>org.jenkins-ci</groupId>
-                    <artifactId>annotation-indexer</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Other -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>docker-workflow</artifactId>
-            <version>1.23</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-branch-source</artifactId>
@@ -569,11 +441,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>cloudbees-folder</artifactId>
-            <version>6.9</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness-tools</artifactId>
             <version>2.2</version>
@@ -587,11 +454,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.20</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pubsub-light</artifactId>
             <version>1.13</version>
         </dependency>
@@ -600,17 +462,6 @@
             <artifactId>sse-gateway</artifactId>
             <version>1.24</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>variant</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>htmlpublisher</artifactId>
-            <version>1.14</version>
-        </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
@@ -626,11 +477,7 @@
             <artifactId>okhttp</artifactId>
             <version>3.12.12</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jackson2-api</artifactId>
-            <version>2.10.2</version>
-        </dependency>
+        <!-- TODO many of the following are suspect, should be using core bom -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -669,17 +516,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.11</version>
         </dependency>
         <dependency>
             <groupId>oro</groupId>
             <artifactId>oro</artifactId>
             <version>2.0.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>display-url-api</artifactId>
-            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
@@ -735,23 +577,10 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
               </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- used in blueocean-rest-impl test -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-auth</artifactId>
-            <version>1.7</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- upper bound fix: icon-set comes from core, lets ignore the one coming from matrix-auth
-                     PR https://github.com/jenkinsci/plugin-pom/pull/72
-                -->
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-                    <artifactId>icon-set</artifactId>
-                </exclusion>
+              <exclusion> <!-- from io.jenkins.plugins:snakeyaml-api -->
+                <groupId>org.yaml</groupId>
+                <artifactId>snake-yaml</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
 
@@ -865,13 +694,6 @@
             <groupId>org.eclipse.sisu</groupId>
             <artifactId>org.eclipse.sisu.plexus</artifactId>
             <version>0.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <classifier>tests</classifier>
-            <version>${scm-api-plugin.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.damnhandy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -577,10 +577,6 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
               </exclusion>
-              <exclusion> <!-- from io.jenkins.plugins:snakeyaml-api -->
-                <groupId>org.yaml</groupId>
-                <artifactId>snake-yaml</artifactId>
-              </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
# Description

See [JENKINS-58732](https://issues.jenkins-ci.org/browse/JENKINS-58732). Amends #2056 by @Vlatombe to pick up https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/393 via https://github.com/jenkinsci/bom/pull/415, which in turn requires switching to a somewhat more recent LTS baseline (2.176.x → 2.222.x). While I am here, using the BOM more consistently.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

