### PR TITLE
Bump jenkins 2.277 and remove blueocean-maven-plugin if possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <gitHubRepo>jenkinsci/blueocean-plugin</gitHubRepo>
     <java.level>8</java.level>
     <!-- when changing jenkins core version please remember to change it in Jenkinsfile as well jenkinsVersions -->
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.277</jenkins.version>
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <frontend-version>1.12.0</frontend-version>
     <node.version>10.13.0</node.version>
@@ -491,7 +491,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pubsub-light</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -837,30 +837,6 @@
             </activation>
             <build>
                 <plugins>
-
-                    <plugin>
-                        <groupId>io.jenkins.blueocean</groupId>
-                        <artifactId>blueocean-maven-plugin</artifactId>
-                        <version>0.0.2</version>
-                        <executions>
-                            <execution>
-                                <!-- unpack package.json + JS into node_modules for any deps with JS files -->
-                                <!-- NOTE: must use 'initialize' and be declared before frontend-plugin so this occurs before npm install -->
-                                <id>upstream-dependencies</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>process-node-dependencies</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>package</id>
-                                <goals>
-                                    <goal>package-blueocean-resources</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>


### PR DESCRIPTION
Tentatively removing dependency and execution of blueocean-maven-plugin.

Following a local debug:
blueocean-maven-plugin is only used by blueocean-core-js
 and it is scanning all jar of all dependency to only add jenkins-design-language package.json

and jenkins-design-language is already set as js dependency in blueocean-core-js/package.json so I even think that not needed anymore, trying to see if it's working.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

