### PR TITLE
Remove parboiled usage

### DIFF
--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubEnterpriseScm.java
@@ -10,7 +10,6 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.Scm;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmFactory;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmServerEndpointContainer;
-import org.parboiled.common.StringUtils;
 
 import javax.annotation.Nonnull;
 
@@ -36,7 +35,7 @@ public class GithubEnterpriseScm extends GithubScm {
         String apiUri = getCustomApiUri();
 
         // NOTE: GithubEnterpriseScm requires that the apiUri be specified
-        if (StringUtils.isEmpty(apiUri)) {
+        if (apiUri == null || apiUri.isEmpty()) {
             throw new ServiceException.BadRequestException(new ErrorMessage(400, "apiUrl is required parameter"));
         }
 


### PR DESCRIPTION
It was a transitive dependency from `token-macro` and it has been removed in last releases. Thus making BO to fail if the last version of token-macro is installed.

Plus, there is really no need to add a dependency just to check if a string is empty

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

