### PR TITLE
Move away from deprecated Release Drafter App

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,17 @@
+# Note: additional setup is required, see https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
 name: Release Drafter
+
 on:
   push:
     branches:
       - master
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.18.1
+      # Drafts your next Release notes as Pull Requests are merged into the default branch
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🤖 Beep boop!

This is an automatic pull request that sets up release drafter as GitHub action for your repository.
Currently, you're using the app version of release drafter, which is deprecated since 2019. Features were only added to the action.

Switching to the action is a drop in replacement and requires no further work from your side.
Once you merge this PR, the action is setup. If you want to configure it further, read [here](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc).

In case of questions, please ping `@NotMyFault`.

Additional information:

- [Click here to read more about the deprecated app](https://github.com/release-drafter/release-drafter/issues/335)
- [Click here to read more about release drafter as GitHub action in Jenkins](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc)
