### PR TITLE
Add description for plugin manager

### DIFF
--- a/blueocean-core-js/pom.xml
+++ b/blueocean-core-js/pom.xml
@@ -24,6 +24,12 @@
                     <include>dist/**/*</include>
                 </includes>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>index.jelly</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/blueocean-jira/src/main/resources/index.jelly
+++ b/blueocean-jira/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+  Provides JIRA intgration for the Blue Ocean user interface.
+</div>

--- a/jenkins-design-language/pom.xml
+++ b/jenkins-design-language/pom.xml
@@ -25,10 +25,9 @@
                 </includes>
             </resource>
             <resource>
-                <directory>src/main/resources/io/jenkins/blueocean</directory>
-                <targetPath>io/jenkins/blueocean</targetPath>
+                <directory>src/main/resources</directory>
                 <includes>
-                    <include>.adjunct</include>
+                    <include>**/*</include>
                 </includes>
             </resource>
             <resource>


### PR DESCRIPTION
# Description

See [JENKINS-68300](https://issues.jenkins-ci.org/browse/JENKINS-68300). This adds missing description for Jira plugin and makes sure description is exported for JDL and core-js plugins.

To verify you can compile all plugins, `index.jelly` should appear in the root of the .jar file.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [n/a] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

