### PR TITLE
Fix missing parentheses causing logic bug for tests tab failure count

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
@@ -57,5 +57,5 @@ export default class RunDetailsTestsLink extends ComponentLink {
     name = 'tests';
     title = t('rundetail.header.tab.tests');
     component = RunDetailsTests;
-    get notification() { return Math.min(99, this.run.testSummary && parseInt(this.run.testSummary.failed) || 0) || null; }
+    get notification() { return Math.min(99, (this.run.testSummary && parseInt(this.run.testSummary.failed)) || 0) || null; }
 }


### PR DESCRIPTION
# Description

This bug was introduced in [JENKINS-47929](https://issues.jenkins-ci.org/browse/JENKINS-47929).
https://github.com/jenkinsci/blueocean-plugin/pull/2050/files#diff-783146f6c8f9ef19650a1bed48fa2e790ffac355579651682c728c1e572141aaR60
The "Tests" tab is not showing the number of test that failed. This PR fixes that bug caused by missing parentheses breaking the logic to calculate the number.

# Submitter checklist
- [X ] Link to JIRA ticket in description, if appropriate.
- [ X] Change is code complete and matches issue description
- [X ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

