### PR TITLE
fix tests failed because of git-client ssh key verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,11 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>3.11.1</version>
+        </dependency>
 
         <!-- Other -->
         <dependency>


### PR DESCRIPTION
After security hardening for git client plugin 3.11.1 starts to verify ssh host key. Before the fix `GitReadSaveTest#bareRepoReadWriteOverSSH` and `GitReadSaveTest#bareRepoReadWriteNoEmail` used `cli git` and 
default `AcceptFirstConnection` strategy to verify the key, but it will fail if test running system using OpenSSH < 7.6. The fix set `JGit` as Git installation, it should work in all environments.

# Description


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

