### PR TITLE
Removing `instance-identity` dependency

### DIFF
--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -152,11 +152,6 @@
             <artifactId>jsoup</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>instance-identity</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -85,10 +85,6 @@
             <groupId>io.keen</groupId>
             <artifactId>keen-client-api-java</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>instance-identity</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>com.github.ua-parser</groupId>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
@@ -8,7 +8,6 @@ import io.jenkins.blueocean.analytics.Analytics;
 import io.jenkins.blueocean.commons.DigestUtils;
 import io.jenkins.blueocean.commons.ServiceException;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -50,11 +49,9 @@ public abstract class AbstractAnalytics extends Analytics {
                 allProps.putAll(additionalProperties);
             }
         }
-        String server = server();
-        allProps.put("jenkins", server);
         // Background requests do not have userId
         if (Stapler.getCurrentRequest() != null) {
-            String identity = identity(server);
+            String identity = identity();
             allProps.put("userId", identity);
         }
 
@@ -71,20 +68,9 @@ public abstract class AbstractAnalytics extends Analytics {
 
     protected abstract void doTrack(String name, Map<String, Object> allProps);
 
-    protected final String server() {
-        byte[] identityBytes;
-        try {
-            identityBytes = InstanceIdentity.get().getPublic().getEncoded();
-        } catch (AssertionError e) {
-            LOGGER.error("There was a problem identifying this server", e);
-            throw new IllegalStateException("There was a problem identifying this server", e);
-        }
-        return DigestUtils.sha256(identityBytes);
-    }
-
-    protected final String identity(String server) {
+    protected final String identity() {
         User user = User.current();
         String username = user == null ? "ANONYMOUS" : user.getId();
-        return DigestUtils.sha256(username + server, Charset.defaultCharset());
+        return DigestUtils.sha256(username, Charset.defaultCharset());
     }
 }

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/analytics/AnalyticsTest.java
@@ -56,7 +56,6 @@ public class AnalyticsTest {
         analytics.track(new TrackRequest("test", props));
 
         Map<String, Object> expectedProps = new HashMap<>(props);
-        expectedProps.put("jenkins", analytics.getServer());
 
         Assert.assertEquals("test", analytics.lastName);
         Assert.assertEquals( expectedProps, analytics.lastProps);
@@ -70,7 +69,6 @@ public class AnalyticsTest {
         analytics.track(new TrackRequest("test", null));
 
         Map<String, Object> expectedProps = new HashMap();
-        expectedProps.put("jenkins", analytics.getServer());
         expectedProps.put("jenkinsVersion", j.jenkins.getVersion().toString());
         expectedProps.put("blueoceanVersion", Jenkins.get().getPlugin("blueocean-commons").getWrapper().getVersion());
 
@@ -117,12 +115,8 @@ public class AnalyticsTest {
             lastProps = allProps;
         }
 
-        public String getServer() {
-            return server();
-        }
-
         public String getIdentity() {
-            return identity(server());
+            return identity();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -558,14 +558,6 @@
             </exclusions>
         </dependency>
 
-        <!-- Included in core -->
-        <dependency>
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>instance-identity</artifactId>
-            <version>2.2</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.github.ua-parser</groupId>
             <artifactId>uap-java</artifactId>


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/6585 using `instance-identity` requires a plugin dep, which would mean a newer core baseline. However it seems pretty superfluous here as it is apparently only used to identify the Jenkins instance—which actually is normally done via `Jenkins.get().getLegacyInstanceId()`—to some sort of analytics introduced in #1202 and expanded in #1502. Since this project is moribund I doubt anyone is actually looking at these analytics and the whole thing should likely be ripped out.
