### PR TITLE
Adding Blue Ocean statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ Blue Ocean is an alternative user experience for Jenkins. You can learn more abo
 
 Join the community and [![Gitter](https://badges.gitter.im/jenkinsci/blueocean-plugin.svg)](https://gitter.im/jenkinsci/blueocean-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+# Blue Ocean status
+
+Blue Ocean will not receive further functionality updates.
+Blue Ocean will continue to provide easy-to-use Pipeline visualization, but it will not be enhanced further.
+It will only receive selective updates for significant security issues or functional defects.
+
+Alternative options for Pipeline visualization, such as the [Pipeline: Stage View](https://plugins.jenkins.io/pipeline-stage-view/) and [Pipeline Graph View](https://plugins.jenkins.io/pipeline-graph-view/) plugins, are available and offer some of the same functionality.
+While not complete replacements for Blue Ocean, contributions are encouraged from the community for continued development of these plugins.
+
+The [Pipeline syntax snippet generator](https://www.jenkins.io/doc/book/pipeline/getting-started/#snippet-generator) assists users as they define Pipeline steps with their arguments.
+It is the preferred tool for Jenkins Pipeline creation, as it provides online help for the Pipeline steps available in your Jenkins controller.
+It uses the plugins installed on your Jenkins controller to generate the Pipeline syntax.
+Refer to the [Pipeline steps reference](https://www.jenkins.io/doc/pipeline/steps/) page for information on all available Pipeline steps.
 
 # Get Blue Ocean
 

--- a/blueocean/doc/BlueOcean.adoc
+++ b/blueocean/doc/BlueOcean.adoc
@@ -14,6 +14,22 @@ Note that the **__Blue Ocean__** plugin is the only one that you need to install
 
 https://jenkins.io/projects/blueocean/[Learn more]
 
+[NOTE]
+.Blue Ocean status
+====
+Blue Ocean will not receive further functionality updates.
+Blue Ocean will continue to provide easy-to-use Pipeline visualization, but it will not be enhanced further.
+It will only receive selective updates for significant security issues or functional defects.
+
+Alternative options for Pipeline visualization, such as the link:https://plugins.jenkins.io/pipeline-stage-view/[Pipeline: Stage View] and link:https://plugins.jenkins.io/pipeline-graph-view/[Pipeline Graph View] plugins, are available and offer some of the same functionality.
+While not complete replacements for Blue Ocean, contributions are encouraged from the community for continued development of these plugins.
+
+The link:https://www.jenkins.io/doc/book/pipeline/getting-started/#snippet-generator[Pipeline syntax snippet generator] assists users as they define Pipeline steps with their arguments.
+It is the preferred tool for Jenkins Pipeline creation, as it provides online help for the Pipeline steps available in your Jenkins controller.
+It uses the plugins installed on your Jenkins controller to generate the Pipeline syntax.
+Refer to the link:https://www.jenkins.io/doc/pipeline/steps/[Pipeline steps reference] page for information on all available Pipeline steps.
+====
+
 == Running behind a proxy? Read this
 
 In some cases proxies can rewrite URIs that have encoding in them and break web apps.


### PR DESCRIPTION
jenkins-infra/jenkins.io#5288 added a useful statement to the documentation site, but it neglected to add the new statement to the plugin site and the GitHub landing page, both of which are significant places for such a statement to be displayed.

As @oleg-nenashev would say, "bonus points" for adding this important statement to other significant places:

- https://www.jenkins.io/projects/blueocean/
- https://hub.docker.com/r/jenkinsci/blueocean/

Note that I am explicitly not volunteering to add the statement to either of those two places.

@halkeye
@kmartens27
@markewaite