### PR TITLE
Bump parent plugin from 4.25 to 4.47 to fix flaky JwtAuthenticationServiceImplTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.25</version>
+    <version>4.47</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
4.47 got the fixed jenkins-test-harness to remove flakiness in JwtAuthenticationServiceImplTest