### PR TITLE
Remove usage of `--ajp13Port` in ATH tests

### DIFF
--- a/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
+++ b/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
@@ -102,7 +102,6 @@ public class BlueOceanWinstoneController extends LocalController {
         cb.add(
                 "-Duser.language=en",
                 "-jar", war,
-                "--ajp13Port=-1",
                 "--httpPort=" + httpPort);
         cb.env.putAll(commonLaunchEnv());
         System.out.println("Starting Jenkins: " + cb.toString());


### PR DESCRIPTION
AJP support was removed in Jetty 9 and Winstone 3.0 in https://github.com/jenkinsci/winstone/pull/22, never to return. As a result it is pointless to keep setting this option.