### PR TITLE
[JENKINS-47929] Extensible run details tabs

### DIFF
--- a/blueocean-core-js/src/js/index.ts
+++ b/blueocean-core-js/src/js/index.ts
@@ -119,7 +119,6 @@ export const DEBUG = {
     disableMocksForI18n,
 };
 
-export { ComponentLink } from './utils/ComponentLink';
 export { TimeManager } from './utils/TimeManager';
 
 export { TimeHarmonizer, TimeHarmonizerUtil } from './components/TimeHarmonizer';

--- a/blueocean-core-js/src/js/index.ts
+++ b/blueocean-core-js/src/js/index.ts
@@ -71,7 +71,7 @@ window.JenkinsBlueOceanCoreJSSSEConnected = false;
 
 // Create and export the SSE connection that will be shared by other
 // Blue Ocean components via this package.
-export const sseConnection = sse.connect('jenkins-blueocean-core-js', function () {
+export const sseConnection = sse.connect('jenkins-blueocean-core-js', function() {
     // Declare SSE is fully loaded and ready for events.
     // Mostly used by our ATH to prevent actions from happening
     // too quickly
@@ -119,6 +119,7 @@ export const DEBUG = {
     disableMocksForI18n,
 };
 
+export { ComponentLink } from './utils/ComponentLink';
 export { TimeManager } from './utils/TimeManager';
 
 export { TimeHarmonizer, TimeHarmonizerUtil } from './components/TimeHarmonizer';

--- a/blueocean-core-js/src/js/utils/ComponentLink.js
+++ b/blueocean-core-js/src/js/utils/ComponentLink.js
@@ -1,0 +1,27 @@
+import { PropTypes, Component } from 'react';
+import { SandboxedComponent } from '@jenkins-cd/js-extensions';
+
+export class ComponentLink {
+    constructor(props) {
+        if (props) {
+            for (const key of Object.keys(props)) {
+                this[key] = props[key];
+            }
+        }
+    }
+    get view() {
+        const children = this.component;
+        return class ViewRenderer extends SandboxedComponent {
+            constructor(props) {
+                super();
+                this.children = children;
+            }
+        };
+    }
+    static propTypes = {
+        name: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        notification: PropTypes.string,
+        component: PropTypes.element.isRequired,
+    };
+}

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -5,7 +5,7 @@ import Extensions, { dataType } from '@jenkins-cd/js-extensions';
 
 import { Icon } from '@jenkins-cd/design-language';
 
-import { UrlBuilder, buildClassicConfigUrl } from '@jenkins-cd/blueocean-core-js';
+import { UrlBuilder } from '@jenkins-cd/blueocean-core-js';
 import { MULTIBRANCH_PIPELINE } from '../Capabilities';
 import { RunDetailsHeader } from './RunDetailsHeader';
 import { RunRecord } from './records';

--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -19,7 +19,7 @@ const logger = logging.logger('io.jenkins.blueocean.dashboard.RunDetails');
 const translate = i18nTranslator('blueocean-dashboard');
 const webTranslate = i18nTranslator('blueocean-web');
 
-const classicConfigLink = (pipeline) => {
+const classicConfigLink = pipeline => {
     let link = null;
     if (Security.permit(pipeline).configure()) {
         let url = UrlBuilder.buildClassicConfigUrl(pipeline);
@@ -57,11 +57,14 @@ function getTestSummaryUrl(runDetails) {
 class RunDetails extends Component {
     constructor(props) {
         super(props);
-        this.state = { isVisible: true };
+        this.state = { isVisible: true, actions: [] };
     }
 
     componentWillMount() {
         this._fetchRun(this.props);
+        Extensions.store.getExtensions(['jenkins.run.actions'], Extensions.Utils.sortByOrdinal, (actions = []) => {
+            this.setState({ actions });
+        });
     }
 
     componentWillReceiveProps(nextProps) {
@@ -88,7 +91,7 @@ class RunDetails extends Component {
                 runId: props.params.runId,
             });
 
-            this.context.activityService.fetchActivity(this.href, { useCache: true }).then((run) => {
+            this.context.activityService.fetchActivity(this.href, { useCache: true }).then(run => {
                 const testSummaryUrl = getTestSummaryUrl(run);
                 return testSummaryUrl && this.context.activityService.fetchTestSummary(testSummaryUrl);
             });
@@ -144,7 +147,7 @@ class RunDetails extends Component {
 
         const { router, location, params } = this.context;
         const { pipeline, setTitle, t, locale } = this.props;
-        const { isVisible } = this.state;
+        const { isVisible, actions } = this.state;
 
         if (!run || !pipeline) {
             this.props.setTitle(translate('common.pager.loading', { defaultValue: 'Loading...' }));
@@ -159,15 +162,12 @@ class RunDetails extends Component {
         }`;
         setTitle(computedTitle);
 
-        const switchRunDetails = (newUrl) => {
+        const switchRunDetails = newUrl => {
             location.pathname = newUrl;
             router.push(location);
         };
 
         const base = { base: baseUrl };
-
-        const failureCount = Math.min(99, (testSummary && parseInt(testSummary.failed)) || 0);
-        const testsBadge = failureCount > 0 && <div className="TabBadgeIcon">{failureCount}</div>;
 
         const tabs = [
             <TabLink to="/pipeline" {...base}>
@@ -175,21 +175,15 @@ class RunDetails extends Component {
                     defaultValue: 'Pipeline',
                 })}
             </TabLink>,
-            <TabLink to="/changes" {...base}>
-                {t('rundetail.header.tab.changes', {
-                    defaultValue: 'Changes',
-                })}
-            </TabLink>,
-            <TabLink to="/tests" {...base}>
-                {t('rundetail.header.tab.tests', { defaultValue: 'Tests' })}
-                {testsBadge}
-            </TabLink>,
-            <TabLink to="/artifacts" {...base}>
-                {t('rundetail.header.tab.artifacts', {
-                    defaultValue: 'Artifacts',
-                })}
-            </TabLink>,
         ];
+
+        actions.map(descriptor => {
+            const action = new descriptor({pipeline, run: currentRun});
+            const badge = action.notification && <div className="TabBadgeIcon">{ action.notification }</div>;
+            tabs.push(
+                <TabLink to={'/' + action.name} { ...base }>{action.title}{badge}</TabLink>
+            );
+        });
 
         const iconButtons = [
             <ReplayButton className="icon-button dark" runnable={this.props.pipeline} latestRun={currentRun} onNavigation={switchRunDetails} autoNavigate />,

--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -2,12 +2,13 @@ import React, { Component, PropTypes } from 'react';
 import { FileSize, JTable, TableRow, TableCell, TableHeaderRow } from '@jenkins-cd/design-language';
 import { Icon } from '@jenkins-cd/design-language';
 import { observer } from 'mobx-react';
-import { logging, UrlConfig, ShowMoreButton } from '@jenkins-cd/blueocean-core-js';
+import { logging, UrlConfig, ShowMoreButton, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
 
 const logger = logging.logger('io.jenkins.blueocean.dashboard.artifacts');
+const t = i18nTranslator('blueocean-dashboard');
 
-const ZipFileDownload = (props) => {
-    const { zipFile, t } = props;
+const ZipFileDownload = props => {
+    const { zipFile } = props;
     if (!zipFile) {
         return null;
     }
@@ -26,14 +27,13 @@ const ZipFileDownload = (props) => {
 
 ZipFileDownload.propTypes = {
     zipFile: PropTypes.string,
-    t: PropTypes.func,
 };
 
 /**
  * Displays a list of artifacts from the supplied build run property.
  */
 @observer
-export default class RunDetailsArtifacts extends Component {
+export class RunDetailsArtifacts extends Component {
     componentWillMount() {
         this._fetchArtifacts(this.props);
     }
@@ -55,7 +55,7 @@ export default class RunDetailsArtifacts extends Component {
     }
 
     render() {
-        const { result, t } = this.props;
+        const { result } = this.props;
 
         if (!result || !this.pager || this.pager.pendingD) {
             return null;
@@ -66,7 +66,7 @@ export default class RunDetailsArtifacts extends Component {
 
         const nameLabel = t('rundetail.artifacts.header.name', { defaultValue: 'Name' });
         const sizeLabel = t('rundetail.artifacts.header.size', { defaultValue: 'Size' });
-        const displayLabel = t('rundetail.artifacts.button.display', { defaultValue: 'Display the artifact in new window' });
+        const displayLabel =  t('rundetail.artifacts.button.display', { defaultValue: 'Display the artifact in new window' });
         const downloadLabel = t('rundetail.artifacts.button.download', { defaultValue: 'Download the artifact' });
         const openLabel = t('rundetail.artifacts.button.open', { defaultValue: 'Open the artifact' });
 
@@ -74,7 +74,7 @@ export default class RunDetailsArtifacts extends Component {
 
         const rootURL = UrlConfig.getJenkinsRootURL();
 
-        const artifactsRendered = artifacts.map((artifact) => {
+        const artifactsRendered = artifacts.map(artifact => {
             const urlArray = artifact.url.split('/');
             const fileName = urlArray[urlArray.length - 1];
             logger.debug('artifact - url:', artifact.url, 'artifact - fileName:', fileName);
@@ -104,10 +104,7 @@ export default class RunDetailsArtifacts extends Component {
                         </a>
                     </TableCell>
                     <TableCell>{artifactSize}</TableCell>
-                    <TableCell className="TableCell--actions">
-                        {displayLink}
-                        {downloadLink}
-                    </TableCell>
+                    <TableCell className="TableCell--actions">{displayLink}{downloadLink}</TableCell>
                 </TableRow>
             );
         });
@@ -150,5 +147,10 @@ RunDetailsArtifacts.contextTypes = {
 
 RunDetailsArtifacts.propTypes = {
     result: PropTypes.object,
-    t: PropTypes.func,
 };
+
+export default class RunDetailsArtifactsLink extends ComponentLink {
+    name = "artifacts";
+    title = t('rundetail.header.tab.artifacts');
+    component = RunDetailsArtifacts;
+}

--- a/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
@@ -2,7 +2,12 @@ import React, { Component, PropTypes } from 'react';
 import { FileSize, JTable, TableRow, TableCell, TableHeaderRow } from '@jenkins-cd/design-language';
 import { Icon } from '@jenkins-cd/design-language';
 import { observer } from 'mobx-react';
-import { logging, UrlConfig, ShowMoreButton, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
+import { logging, UrlConfig, ShowMoreButton, i18nTranslator } from '@jenkins-cd/blueocean-core-js';
+import { ComponentLink } from '../util/ComponentLink';
+
+if (ComponentLink === undefined) {
+    throw "ComponentLink is undefined";
+}
 
 const logger = logging.logger('io.jenkins.blueocean.dashboard.artifacts');
 const t = i18nTranslator('blueocean-dashboard');

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -13,8 +13,7 @@ if (ComponentLink === undefined) {
 
 const t = i18nTranslator('blueocean-dashboard');
 
-function NoChangesPlaceholder(props) {
-
+function NoChangesPlaceholder() {
     const columns = [
         { width: 750, isFlexible: true, head: { text: 40 }, cell: { text: 150 } },
         { width: 90, head: { text: 50 }, cell: { text: 60 } },

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -4,10 +4,11 @@ import { CommitId, PlaceholderTable, ReadableDate, JTable, TableHeaderRow, Table
 import Icon from './placeholder/Icon';
 import { PlaceholderDialog } from './placeholder/PlaceholderDialog';
 import LinkifiedText from './LinkifiedText';
-import { ShowMoreButton } from '@jenkins-cd/blueocean-core-js';
+import { ShowMoreButton, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
+
+const t = i18nTranslator('blueocean-dashboard');
 
 function NoChangesPlaceholder(props) {
-    const { t } = props;
 
     const columns = [
         { width: 750, isFlexible: true, head: { text: 40 }, cell: { text: 150 } },
@@ -28,12 +29,8 @@ function NoChangesPlaceholder(props) {
     );
 }
 
-NoChangesPlaceholder.propTypes = {
-    t: PropTypes.func,
-};
-
 @observer
-export default class RunDetailsChanges extends Component {
+export class RunDetailsChanges extends Component {
     componentWillMount() {
         this._fetchChangeSet(this.props);
     }
@@ -49,7 +46,7 @@ export default class RunDetailsChanges extends Component {
     }
 
     render() {
-        const { t, locale } = this.props;
+        const { locale } = this.props;
 
         if (!this.pager) {
             return null;
@@ -78,7 +75,7 @@ export default class RunDetailsChanges extends Component {
         ];
 
         const changeSetSplitBySource = [];
-        changeSet.map((commit) => {
+        changeSet.map(commit => {
             if (changeSetSplitBySource[commit.checkoutCount] === undefined) {
                 changeSetSplitBySource[commit.checkoutCount] = [];
             }
@@ -90,7 +87,7 @@ export default class RunDetailsChanges extends Component {
                 {changeSetSplitBySource.map((changeSet, changeSetIdx) => (
                     <JTable columns={columns} className="changeset-table" key={changeSetIdx}>
                         <TableHeaderRow />
-                        {changeSet.map((commit) => (
+                        {changeSet.map(commit => (
                             <TableRow key={commit.commitId}>
                                 <TableCell>
                                     <CommitId commitId={commit.commitId} url={commit.url} />
@@ -121,7 +118,6 @@ export default class RunDetailsChanges extends Component {
 RunDetailsChanges.propTypes = {
     result: PropTypes.object,
     locale: PropTypes.string,
-    t: PropTypes.func,
     params: PropTypes.any,
     pipeline: PropTypes.object,
     results: PropTypes.object,
@@ -131,3 +127,9 @@ RunDetailsChanges.contextTypes = {
     params: PropTypes.object.isRequired,
     activityService: PropTypes.object.isRequired,
 };
+
+export default class RunDetailsChangesLink extends ComponentLink {
+    name = 'changes';
+    title = t('rundetail.header.tab.changes');
+    component = RunDetailsChanges;
+}

--- a/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsChanges.jsx
@@ -4,7 +4,12 @@ import { CommitId, PlaceholderTable, ReadableDate, JTable, TableHeaderRow, Table
 import Icon from './placeholder/Icon';
 import { PlaceholderDialog } from './placeholder/PlaceholderDialog';
 import LinkifiedText from './LinkifiedText';
-import { ShowMoreButton, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
+import { ShowMoreButton, i18nTranslator } from '@jenkins-cd/blueocean-core-js';
+import { ComponentLink } from '../util/ComponentLink';
+
+if (ComponentLink === undefined) {
+    throw "ComponentLink is undefined";
+}
 
 const t = i18nTranslator('blueocean-dashboard');
 

--- a/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
@@ -1,9 +1,10 @@
 import React, { Component, PropTypes } from 'react';
-import { pagerService, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
+import { pagerService, i18nTranslator } from '@jenkins-cd/blueocean-core-js';
 
 import TestResults from './testing/TestResults';
 import TestService from './testing/TestService';
 import NoTestsPlaceholder from './testing/NoTestsPlaceholder';
+import { ComponentLink } from '../util/ComponentLink';
 
 const t = i18nTranslator('blueocean-dashboard');
 

--- a/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsTests.jsx
@@ -1,21 +1,22 @@
 import React, { Component, PropTypes } from 'react';
-import { pagerService } from '@jenkins-cd/blueocean-core-js';
+import { pagerService, i18nTranslator, ComponentLink } from '@jenkins-cd/blueocean-core-js';
 
 import TestResults from './testing/TestResults';
 import TestService from './testing/TestService';
 import NoTestsPlaceholder from './testing/NoTestsPlaceholder';
 
+const t = i18nTranslator('blueocean-dashboard');
+
 /**
  * Displays a list of tests from the supplied build run property.
  */
-export default class RunDetailsTests extends Component {
+export class RunDetailsTests extends Component {
     propTypes = {
         params: PropTypes.object,
         pipeline: PropTypes.object,
         isMultiBranch: PropTypes.bool,
         result: PropTypes.object,
         fetchTypeInfo: PropTypes.func,
-        t: PropTypes.func,
         locale: PropTypes.string,
         testSummary: PropTypes.object,
     };
@@ -29,7 +30,7 @@ export default class RunDetailsTests extends Component {
     }
 
     render() {
-        const { t, locale, testSummary } = this.props;
+        const { locale, testSummary } = this.props;
 
         let result;
         if (testSummary && (testSummary.total || testSummary.total > 0)) {
@@ -46,8 +47,15 @@ export default class RunDetailsTests extends Component {
                 </div>
             );
         } else {
-            result = <NoTestsPlaceholder t={this.props.t} />;
+            result = <NoTestsPlaceholder t={t} />;
         }
         return result;
     }
+}
+
+export default class RunDetailsTestsLink extends ComponentLink {
+    name = 'tests';
+    title = t('rundetail.header.tab.tests');
+    component = RunDetailsTests;
+    get notification() { return Math.min(99, (this.run.testSummary && parseInt(this.run.testSummary.failed)) || 0) || null; }
 }

--- a/blueocean-dashboard/src/main/js/components/index.jsx
+++ b/blueocean-dashboard/src/main/js/components/index.jsx
@@ -6,9 +6,6 @@ import PipelineTrends from './PipelineTrends';
 import PipelinePage from './PipelinePage';
 import RunDetails from './RunDetails';
 import RunDetailsPipeline from './RunDetailsPipeline';
-import RunDetailsChanges from './RunDetailsChanges';
-import RunDetailsArtifacts from './RunDetailsArtifacts';
-import RunDetailsTests from './RunDetailsTests';
 
 export {
     Pipelines,
@@ -19,7 +16,4 @@ export {
     PipelinePage,
     RunDetails,
     RunDetailsPipeline,
-    RunDetailsChanges,
-    RunDetailsTests,
-    RunDetailsArtifacts,
 };

--- a/blueocean-dashboard/src/main/js/jenkins-js-extension.yaml
+++ b/blueocean-dashboard/src/main/js/jenkins-js-extension.yaml
@@ -41,3 +41,13 @@ extensions:
 # Trends
   - component: components/trends/StageDurationChart
     extensionPoint: jenkins.pipeline.trends
+# Actions
+  - component: components/RunDetailsChanges
+    extensionPoint: jenkins.run.actions
+    ordinal: 100
+  - component: components/RunDetailsTests
+    extensionPoint: jenkins.run.actions
+    ordinal: 200
+  - component: components/RunDetailsArtifacts
+    extensionPoint: jenkins.run.actions
+    ordinal: 300

--- a/blueocean-dashboard/src/main/js/util/ComponentLink.js
+++ b/blueocean-dashboard/src/main/js/util/ComponentLink.js
@@ -1,5 +1,9 @@
-import { PropTypes, Component } from 'react';
+import { PropTypes } from 'react';
 import { SandboxedComponent } from '@jenkins-cd/js-extensions';
+
+if (SandboxedComponent === undefined) {
+    throw "SandboxedComponent is undefined";
+}
 
 export class ComponentLink {
     constructor(props) {
@@ -13,7 +17,7 @@ export class ComponentLink {
         const children = this.component;
         return class ViewRenderer extends SandboxedComponent {
             constructor(props) {
-                super();
+                super(props);
                 this.children = children;
             }
         };

--- a/blueocean-dashboard/src/test/js/run-details-artifacts-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-artifacts-spec.js
@@ -1,0 +1,56 @@
+import { assert } from 'chai';
+import React from 'react';
+import { mount } from 'enzyme';
+import { i18nTranslator } from '@jenkins-cd/blueocean-core-js';
+
+import { latestRuns } from './data/runs/latestRuns';
+import { RunDetailsArtifacts } from '../../main/js/components/RunDetailsArtifacts';
+
+const t = i18nTranslator('blueocean-dashboard');
+
+import { mockExtensionsForI18n } from './mock-extensions-i18n';
+mockExtensionsForI18n();
+
+function buildContext(artifactPagerData) {
+    return {
+        /*params: {
+            organization: 'jenkins',
+            pipeline: 'job1',
+            branch: 'master',
+            runId: '2',
+        },*/
+        activityService: {
+            artifactsPager() {
+                return {
+                    data: artifactPagerData,
+                };
+            },
+        },
+    };
+}
+
+describe('RunDetailsArtifacts', () => {
+    beforeAll(() => mockExtensionsForI18n());
+
+    it('renders nothing with no data', () => {
+        const wrapper = mount(<RunDetailsArtifacts t={t}/>, { context: buildContext() });
+
+        assert.equal(wrapper.html(), null, 'output should be empty');
+    });
+
+    it('renders a valid list of artifacts', () => {
+        const runs = latestRuns.map(run => run.latestRun);
+        const wrapper = mount(<RunDetailsArtifacts t={t} result={runs[0]} />, { context: buildContext(runs[0].artifacts) });
+        const output = wrapper.html();
+
+        // Class names we expect to see
+        assert(output.match('JTable'), 'output should contain "JTable"');
+        assert(output.match('JTable-row'), 'output should contain "JTable-row"');
+        assert(output.match('JTable-cell'), 'output should contain "JTable-cell"');
+
+        // Data values we expect to see
+        assert(output.match('hey'), 'output should contain "hey"');
+        assert(output.match('href'), 'output should contain "href"');
+        assert(output.match('/jenkins/job/jenkinsfile-experiments/branch/master/1/artifact/hey'), 'output should contain "/jenkins/job/jenkinsfile-experiments/branch/master/1/artifact/hey"');
+    });
+});

--- a/blueocean-dashboard/src/test/js/run-details-changes-spec.js
+++ b/blueocean-dashboard/src/test/js/run-details-changes-spec.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import { i18nTranslator } from '@jenkins-cd/blueocean-core-js';
 
 import { latestRuns } from './data/runs/latestRuns';
-import RunDetailsChanges from '../../main/js/components/RunDetailsChanges';
+import { RunDetailsChanges } from '../../main/js/components/RunDetailsChanges';
 
 const t = i18nTranslator('blueocean-dashboard');
 


### PR DESCRIPTION
# Description

See [JENKINS-47929](https://issues.jenkins-ci.org/browse/JENKINS-47929).
Fixing issues reported after https://github.com/jenkinsci/blueocean-plugin/pull/2268 was merged.

**Unit/Acceptance Tests**
Added additional test for `RunDetailsArtifacts` component in `run-details-artifacts-spec.js`.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given