### PR TITLE
Require Jenkins 2.361.4 and Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </licenses>
 
   <properties>
-    <revision>1.26.2</revision>
+    <revision>1.27.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/blueocean-plugin</gitHubRepo>
     <!--


### PR DESCRIPTION
## Require Jenkins 2.361.4 and Java 11

Justifies an increment of the minor version number

Earlier changes are bug fixes, but users will perceive it as more than a bug fix

See [JENKINS-70379](https://issues.jenkins-ci.org/browse/JENKINS-70379) for the original motivation to require Java 11 and Jenkins 2.361.4.  The git client plugin 4.0.0 change from Java 8 to Java 11 brought a change from JGit 5.13.1 to JGit 6.4.0.  The JGit change included a breaking change in the location of one or more JGit classes.

No tests because this is proposing a larger version number for clarity to users rather than due to the size or impact of a change.

Related to:

* #2379 

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

