### PR TITLE
[JENKINS-70559] Fix class cast exception in ssh Pipeline editor

### DIFF
--- a/blueocean-git-pipeline/pom.xml
+++ b/blueocean-git-pipeline/pom.xml
@@ -31,6 +31,13 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
     </dependency>
+    <!-- JGit JSch dependency that was previously in git client plugin -->
+    <!-- https://issues.jenkins.io/browse/JENKINS-70559 class not found exception -->
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+      <version>6.4.0.202211300538-r</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,7 @@
         <!-- TODO: java8 signature doesn't exist yet -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.22</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-2.361.x</artifactId>
-            <version>1766.v0b_f2a_f7d0b_1d</version>
+            <version>1798.vc671fe94856f</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
## [JENKINS-70559] Fix class cast exception in ssh Pipeline editor

See [JENKINS-70559](https://issues.jenkins-ci.org/browse/JENKINS-70559) where it reports a class not found exception when using the Blue Ocean Pipeline editor to create a new Pipeline.

The JGit project delivers org.eclipse.jgit.ssh.apache in addition to the org.eclipse.jgit.ssh.jsch library. The org.eclipse.jgit.ssh.apache library appears to be a complete replacement for git client plugin use cases. The JGIt project has declared their jsch library is deprecated and may be removed at any time.

[JENKINS-69159](https://issues.jenkins.io/browse/JENKINS-69159) describes the transition the git client plugin has made from the unmaintained Jsch library to the Apache Mina SSHD library.

[Future of Jsch](https://www.matez.de/index.php/2020/06/22/the-future-of-jsch-without-ssh-rsa/) notes that Jsch is no longer receiving updates.

This pull request adds the JGit 6.4.0 Jsch API library to the blue ocean git pipeline plugin so that the JSch symbols from JGit are resolved.  This may not be a long term solution, but it is much simpler than replacing the Jsch implementation with the Apache Mina SSHD implementation.

### Justification for no automated tests

No unit tests or acceptance tests because the failure to resolve the library happens at compile time once the plugin references git client plugin 4.1.0.

### Interactive test plan

Follow the steps in [JENKINS-70559](https://issues.jenkins-ci.org/browse/JENKINS-70559) include:

* Define a new blue ocean Pipeline using an ssh repository URL to a repository that does not contain a Jenkinsfile
* Confirm that the class cast exception is reported to the Jenkins console log without this fix and that it is not reported with this fix

# Description


# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
