### PR TITLE
the method is called twice for the same object so at least we can store the result in a field which reduce call by 2 :) (#2408)

### DIFF
--- a/blueocean-github-pipeline/pom.xml
+++ b/blueocean-github-pipeline/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
 
     <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>pubsub-light</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pubsub-light</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -74,5 +74,21 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <!-- because test GithubOrgFolderPermissionsTest is using some bad static library
+                     it would be better to fix that but maybe next time -->
+              <reuseForks>false</reuseForks>
+            </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/FlowNodeWrapper.java
@@ -65,7 +65,7 @@ public class FlowNodeWrapper {
     public final NodeType type;
     private final String displayName;
     private final InputStep inputStep;
-    private final WorkflowRun run;
+    private final String runExternalizableId;
     private String causeOfFailure;
 
     private List<FlowNodeWrapper> parents = new ArrayList<>();
@@ -86,12 +86,11 @@ public class FlowNodeWrapper {
         this.type = getNodeType(node);
         this.displayName = PipelineNodeUtil.getDisplayName(node);
         this.inputStep = inputStep;
-        this.run = run;
+        this.runExternalizableId = run.getExternalizableId();
     }
 
-
     public WorkflowRun getRun() {
-        return run;
+        return PipelineRunImpl.findRun(runExternalizableId);
     }
 
     public @NonNull

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeContainerImpl.java
@@ -17,14 +17,15 @@ import java.util.Map;
  * @author Vivek Pandey
  */
 public class PipelineNodeContainerImpl extends BluePipelineNodeContainer {
-    private final WorkflowRun run;
     private final Map<String, BluePipelineNode> nodeMap = new HashMap<>();
 
     private final List<BluePipelineNode> nodes;
     private final Link self;
 
+    private final String jobFullName;
+
     public PipelineNodeContainerImpl(WorkflowRun run, Link parentLink) {
-        this.run = run;
+        this.jobFullName = run.getParent().getFullName();
         this.self = parentLink.rel("nodes");
 
         WorkflowJob job = run.getParent();
@@ -47,11 +48,12 @@ public class PipelineNodeContainerImpl extends BluePipelineNodeContainer {
 
     @Override
     public BluePipelineNode get(String name) {
+
         if(nodeMap.get(name) != null){
             return nodeMap.get(name);
         }
         throw new ServiceException.NotFoundException(String.format("Stage %s not found in pipeline %s.",
-            name, run.getParent().getName()));
+            name, jobFullName));
     }
 
     @Override

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepContainerImpl.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineStepContainerImpl.java
@@ -3,7 +3,6 @@ package io.jenkins.blueocean.rest.impl.pipeline;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BluePipelineStep;
 import io.jenkins.blueocean.rest.model.BluePipelineStepContainer;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import java.util.Iterator;
 
@@ -13,31 +12,31 @@ import java.util.Iterator;
 public class PipelineStepContainerImpl extends BluePipelineStepContainer {
     private final FlowNodeWrapper node;
     private final Link self;
-    private final WorkflowRun run;
+    private final String runExternalizableId;
 
 
-    public PipelineStepContainerImpl(FlowNodeWrapper node, Link parentLink, WorkflowRun run) {
+    public PipelineStepContainerImpl(FlowNodeWrapper node, Link parentLink, String runExternalizableId) {
         this.self = parentLink.rel("steps");
         this.node = node;
-        this.run = run;
+        this.runExternalizableId = runExternalizableId;
 
     }
 
-    public PipelineStepContainerImpl(WorkflowRun run, Link parentLink) {
+    public PipelineStepContainerImpl(String runExternalizableId, Link parentLink) {
         this.self = parentLink.rel("steps");
         this.node = null;
-        this.run = run;
+        this.runExternalizableId = runExternalizableId;
     }
 
     @Override
     public BluePipelineStep get(String name) {
-        NodeGraphBuilder builder = NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(run);
+        NodeGraphBuilder builder = NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(PipelineRunImpl.findRun(runExternalizableId));
         return  builder.getPipelineNodeStep(name, getLink());
     }
 
     @Override
     public Iterator<BluePipelineStep> iterator() {
-        NodeGraphBuilder builder = NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(run);
+        NodeGraphBuilder builder = NodeGraphBuilder.NodeGraphBuilderFactory.getInstance(PipelineRunImpl.findRun(runExternalizableId));
         return (node == null)
             ? builder.getPipelineNodeSteps(getLink()).iterator()
             : builder.getPipelineNodeSteps(node.getId(), getLink()).iterator();

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -94,6 +94,8 @@ public abstract class PipelineBaseTest{
         this.jwtToken = getJwtToken(j.jenkins);
         this.crumb = getCrumb(j.jenkins );
 
+        PipelineRunImpl.clearCache();
+
         Unirest.setObjectMapper(new ObjectMapper() {
             public <T> T readValue(String value, Class<T> valueType) {
                 try {


### PR DESCRIPTION
add some caching to avoid expensive call for completed run

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

