### PR TITLE
Remove unused `hudson.udp` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -754,12 +754,6 @@
       <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-              <systemProperties>
-                  <property>
-                      <name>hudson.udp</name>
-                      <value>33849</value>
-                  </property>
-              </systemProperties>
               <reuseForks>true</reuseForks>
               <forkCount>${concurrency}</forkCount>
               <!--


### PR DESCRIPTION
Forgotten in jenkinsci/jenkins#4460 & jenkinsci/jenkins#5720.