### PR TITLE
Upgrade plugin parent POM from 4.53 to 4.57

### DIFF
--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -170,6 +170,13 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- RequireUpperBoundDeps with mockito-core -->
+                <exclusion>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-pipeline-editor/pom.xml
+++ b/blueocean-pipeline-editor/pom.xml
@@ -66,6 +66,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>sonar</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- RequireUpperBoundDeps with github-branch-source -->
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.53</version>
+    <version>4.57</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This is needed for the forthcoming PCT multi-module mode to pull in the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658) via https://github.com/jenkinsci/maven-hpi-plugin/pull/453. I tested this successfully with the latest update to the multimodule project branch of PCT, which is now doing `mvn process test-classes` rather than `mvn install`, therefore requiring the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658). With these changes you can now successfully run `mvn process-test-classes` in the root directory of the repository, which was not possible with the old version of Maven HPI plugin.

To test this PR I ran:

```
$ git checkout blueocean-parent-1.27.3
$ git clean -fxd
$ mvn clean process-test-classes  # failed before, passes now
$ mvn -Dtest=InjectedTest -Djth.jenkins-war.path=/home/basil/src/jenkinsci/bom/target/local-test/megawar.war -DoverrideWarAdditions=true -DoverrideWar=/home/basil/src/jenkinsci/bom/target/local-test/megawar.war -Djenkins.version=2.396 -DuseUpperBounds=true -Dtest=InjectedTest hpi:resolve-test-dependencies hpi:test-hpl surefire:test # passes
```

CC @olamy