### PR TITLE
Allow the user to know if their click will be useful

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanUrlObjectImpl.java
@@ -23,7 +23,11 @@ public class BlueOceanUrlObjectImpl extends BlueOceanUrlObject {
 
     @Override
     public @NonNull String getDisplayName() {
-        return Messages.BlueOceanUrlAction_DisplayName();
+        if (this.mappedUrl.equals(BlueOceanUrlMapperImpl.getLandingPagePath())) {
+            return Messages.BlueOceanUrlAction_DisplayName();
+        } else {
+            return Messages.BlueOceanUrlAction_GenericDisplayName();
+        }
     }
 
     @Override

--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages.properties
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages.properties
@@ -1,1 +1,2 @@
 BlueOceanUrlAction.DisplayName=Open Blue Ocean
+BlueOceanUrlAction.GenericDisplayName=Open Blue Ocean Homepage

--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_ko.properties
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_ko.properties
@@ -1,1 +1,3 @@
 BlueOceanUrlAction.DisplayName=\ube14\ub8e8 \uc624\uc158 \uc5f4\uae30
+# I can't translate this but don't want to cause a language regression so leave as it was in other languages
+BlueOceanUrlAction.GenericDisplayName=\ube14\ub8e8 \uc624\uc158 \uc5f4\uae30

--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_ru.properties
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_ru.properties
@@ -1,2 +1,4 @@
 #X-Generator: crowdin.com
 BlueOceanUrlActionImpl.DisplayName=\u041e\u0442\u043a\u0440\u044b\u0442\u044c Blue Ocean
+# I can't translate this but don't want to cause a language regression so leave as it was in other languages
+BlueOceanUrlAction.GenericDisplayName=\u041e\u0442\u043a\u0440\u044b\u0442\u044c Blue Ocean

--- a/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_zh_CN.properties
+++ b/blueocean-rest-impl/src/main/resources/io/jenkins/blueocean/service/embedded/Messages_zh_CN.properties
@@ -21,3 +21,5 @@
 # THE SOFTWARE.
 
 BlueOceanUrlAction.DisplayName=\u6253\u5F00 Blue Ocean
+# I can't translate this but don't want to cause a language regression so leave as it was in other languages
+BlueOceanUrlAction.GenericDisplayName=\u6253\u5F00 Blue Ocean


### PR DESCRIPTION
# Description

When clicking on "Open Blue Ocean" sometimes the click is useful, for example taking me to a page where I can see the progress of my current build. Other times it is useless, for example when I click on "Open Blue Ocean" on a job page. This change allows the user to know before they click whether they'll be taken to a helpful related page or to a generic Blue Ocean home page.
See [JENKINS-71418](https://issues.jenkins-ci.org/browse/JENKINS-71418).

No new tests because I'm not sure how to set up or mock the required build in order to test this.
Manual testing:
* Vew the link on a generic Jenkins page such as http://jenkinsserver/ and check it says "Open Blue Ocean Homepage"
* View the link on a specific numbered Jenkins build page such as http://jenkinsserver/job/foldername/job/jobname/1/ and check it says "Open Blue Ocean"

I did also consider "Open In Blue Ocean" for the helpful link and leaving "Open Blue Ocean" for the generic one.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

