### PR TITLE
Update hamcrest

### DIFF
--- a/acceptance-tests/runner/runtime/pom.xml
+++ b/acceptance-tests/runner/runtime/pom.xml
@@ -44,8 +44,8 @@
       <dependencies>
           <dependency>
               <groupId>org.hamcrest</groupId>
-              <artifactId>hamcrest-core</artifactId>
-              <version>1.3</version>
+              <artifactId>hamcrest</artifactId>
+              <version>2.2</version>
           </dependency>
           <dependency>
               <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,13 +217,7 @@
       <!-- This is needed in order to force junit4 and JTH tests to use newer hamcrest version -->
       <dependency>
           <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-          <version>${hamcrest.version}</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
+          <artifactId>hamcrest</artifactId>
           <version>${hamcrest.version}</version>
           <scope>test</scope>
       </dependency>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_

Edit: The build is green on ci.jenkins.io.