### PR TITLE
Upgrade plugin parent POM from 4.57 to 4.65

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.6</version>
   </extension>
 </extensions>

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubMockBase.java
@@ -83,7 +83,7 @@ public abstract class GithubMockBase extends PipelineBaseTest {
                         }
 
                     })
-    );
+    , false);
 
     protected final List<StubMapping> perTestStubMappings = new ArrayList<>();
 

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubOrgFolderPermissionsTest.java
@@ -8,6 +8,7 @@ import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.service.embedded.OrganizationFactoryImpl;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
+import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 import net.sf.json.JSONArray;
@@ -110,7 +111,7 @@ public class GithubOrgFolderPermissionsTest extends GithubMockBase {
         assertEquals(6, res.size());
     }
 
-    private void createGithubPipeline(String jwt, boolean shouldSucceed) {
+    private void createGithubPipeline(String jwt, boolean shouldSucceed) throws Exception {
         String pipelineName = "cloudbeers";
         Map resp = new RequestBuilder(baseUrl)
                 .status(shouldSucceed ? 201 : 403)
@@ -128,6 +129,9 @@ public class GithubOrgFolderPermissionsTest extends GithubMockBase {
             Assert.assertTrue(item instanceof WorkflowMultiBranchProject);
             Map r = get("/organizations/"+ getOrgName() + "/pipelines/"+pipelineName+"/");
             assertEquals(pipelineName, r.get("name"));
+            MultiBranchProject<?, ?> p = (MultiBranchProject<?, ?>) item;
+            p.scheduleBuild2(0).getFuture().get();
+            j.waitUntilNoActivity();
         }
         else {
             assertEquals(403, resp.get("code"));

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.57</version>
+    <version>4.65</version>
     <relativePath />
   </parent>
 
@@ -253,7 +253,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-2.361.x</artifactId>
-            <version>2059.v69eec68eb_b_b_e</version>
+            <version>2102.v854b_fec19c92</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
I observed some of these tests flaking in `TemporaryDirectoryAllocator`, presumably due to a race with indexing. To avoid this flakiness I have adopted the idiom from `branch-api` of waiting for indexing to finish before starting test teardown.