### PR TITLE
Remove usages of Prototype.js

### DIFF
--- a/blueocean-rest-impl/src/main/webapp/scripts/analytics.js
+++ b/blueocean-rest-impl/src/main/webapp/scripts/analytics.js
@@ -1,11 +1,15 @@
 window.addEventListener('load', function() {
     var eventData = { name: 'pageview', properties: { mode: 'classic' } };
-    new Ajax.Request(rootURL + '/blue/rest/analytics/track', {
+    fetch(rootURL + '/blue/rest/analytics/track', {
         method: 'POST',
-        contentType: 'application/json',
-        postBody: JSON.stringify(eventData),
-        onFailure: function() {
+        headers: crumb.wrap({
+            'Content-Type': 'application/json'
+        }),
+        // TODO simplify when Prototype.js is removed
+        body: Object.toJSON ? Object.toJSON(eventData) : JSON.stringify(eventData)
+    }).then(function(rsp) {
+        if (!rsp.ok) {
             console.error('Could not send pageview event');
-        },
+        }
     });
 });


### PR DESCRIPTION
Followed [the migration guide](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/).

### Testing done

- "Enable analytics" by commenting out the `<if>` statement in `action.jelly`
- Step through Prototype code in the debugger, verify it is successfully making a POST request
- Enable the user experimental flag to remove Prototype
- Step through Prototype code in the debugger, verify it is now failing due to Prototype being removed
- Make the change from this PR, verify the code is working again and the POST request is made successfully without any errors in the console log