### PR TITLE
Tolerate testing in PCT context

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/BlueTrendTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/BlueTrendTest.java
@@ -1,5 +1,9 @@
 package io.jenkins.blueocean.service.embedded.rest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.FreeStyleProject;
@@ -83,7 +87,7 @@ public class BlueTrendTest extends BaseTest {
     public void testTrendsIdCollision() throws Exception {
         // verify the extension did register correctly
         ExtensionList<BlueTrendFactory> extensionList = ExtensionList.lookup(BlueTrendFactory.class);
-        Assert.assertEquals(2, extensionList.size());
+        assertThat(extensionList, hasSize(greaterThanOrEqualTo(2)));
 
         Project project = j.createProject(FreeStyleProject.class, "freestyle1");
         BlueOrganization org = new OrganizationImpl("jenkins", j.jenkins);


### PR DESCRIPTION
When attempting to add Blue Ocean to `jenkinsci/bom` I discovered this test started failing with the list being of size 3 rather than the expected size 2. Peeking at the contents I see

```
io.jenkins.blueocean.rest.impl.pipeline.StageDurationTrend$FactoryImpl@7e9c962a
io.jenkins.blueocean.service.embedded.rest.junit.BlueJUnitTrend$FactoryImpl@36b5b88a
io.jenkins.blueocean.service.embedded.rest.BlueTrendTest$1@5584dbb
```

whereas when the test is executed outside of PCT only the last two entries are present. This is to be expected, since PCT places all the plugins in the managed set in the class path. To deal with this issue I have made the test tolerate this situation by checking for a size greater than or equal to 2.