### PR TITLE
remove obsolete config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -682,12 +682,10 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
               <reuseForks>true</reuseForks>
-              <forkCount>${concurrency}</forkCount>
               <!--
               The following line is the one that's a must. Without it, will get jacoco complexity failures.
               -->
               <argLine>-Djava.awt.headless=true ${argLine}</argLine>
-              <rerunFailingTestsCount>0</rerunFailingTestsCount>
               <systemPropertyVariables>
                   <jacoco-agent.destfile>${project.build.directory}/code-coverage/jacoco.exec</jacoco-agent.destfile>
               </systemPropertyVariables>


### PR DESCRIPTION
since a while ago the default to surefire rerun tests was set to zero so it is not needed.

Additionally things pass `-DforkCount` not `-Dconcurrency` for a while too.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

