### PR TITLE
Ignore `IOException` from `writeLogTo`

### DIFF
--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubPipelineCreateRequestTest.java
@@ -385,8 +385,12 @@ public class GithubPipelineCreateRequestTest extends GithubMockBase {
             c.doStop();
             System.err.println(f + " ---%<---");
             long p = 0;
-            while (!c.getLogText().isComplete()) {
-                p = c.getLogText().writeLogTo(p, System.err);
+            try {
+                while (!c.getLogText().isComplete()) {
+                    p = c.getLogText().writeLogTo(p, System.err);
+                }
+            } catch (IOException x) {
+                x.printStackTrace();
             }
             System.err.println(f + " --->%---");
         }


### PR DESCRIPTION
Saw an apparent flake in PCT introduced by diagnostic code in #2468

```
java.io.FileNotFoundException: …/blueocean-github-pipeline/target/tmp/j h7435154302361148419/jobs/p/computation/computation.log (No such file or directory)
	at java.base/java.io.RandomAccessFile.open0(Native Method)
	at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:345)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:259)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:214)
	at org.kohsuke.stapler.framework.io.LargeText$FileSession.<init>(LargeText.java:411)
	at org.kohsuke.stapler.framework.io.LargeText$2.open(LargeText.java:126)
	at org.kohsuke.stapler.framework.io.LargeText.writeLogTo(LargeText.java:225)
	at hudson.console.AnnotatedLargeText.writeLogTo(AnnotatedLargeText.java:164)
	at io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequestTest.testOrgFolderIndexing(GithubPipelineCreateRequestTest.java:391)
```