### PR TITLE
Prevent multiBranchPipelineIndex failure due to DirectoryNotEmptyException

### DIFF
--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -318,6 +318,8 @@ public class MultiBranchTest extends PipelineBaseTest {
 
     @Test
     public void multiBranchPipelineIndex() throws Exception {
+        // Skip test to avoid intermittent test failures with DirectoryNotEmptyException
+        // Assume.assumeTrue(runAllTests());
         User user = login();
         WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
         mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false),

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -318,8 +318,6 @@ public class MultiBranchTest extends PipelineBaseTest {
 
     @Test
     public void multiBranchPipelineIndex() throws Exception {
-        // Skip test to avoid intermittent test failures with DirectoryNotEmptyException
-        // Assume.assumeTrue(runAllTests());
         User user = login();
         WorkflowMultiBranchProject mp = j.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
         mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false),
@@ -337,8 +335,12 @@ public class MultiBranchTest extends PipelineBaseTest {
                 .build(Map.class);
 
         assertNotNull(map);
-        // Wait for activity to finish before exiting the test
-        // Avoid intermittent failures from DirectoryNotEmptyException
+        // Cancel jobs in the queue so that waitUntilNoActivity waits less.
+        // Wait for activity to finish before exiting the test.
+        // Avoid intermittent failures from DirectoryNotEmptyException.
+        for (Queue.Item i : j.jenkins.getQueue().getItems()) {
+            j.jenkins.getQueue().cancel(i);
+        }
         j.waitUntilNoActivity();
     }
 

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -337,6 +337,9 @@ public class MultiBranchTest extends PipelineBaseTest {
                 .build(Map.class);
 
         assertNotNull(map);
+        // Wait for activity to finish before exiting the test
+        // Avoid intermittent failures from DirectoryNotEmptyException
+        j.waitUntilNoActivity();
     }
 
 


### PR DESCRIPTION
# Fix multiBranchPipelineIndex test failure

- Skip flaky multiBranchPipelineIndex test
- Do not exit test until no activity

https://github.com/jenkinsci/bom/runs/16996428210 shows the failure happened in 2 of the 4 configurations that are tested by the plugin bill of materials.

This pull request offers two different alternatives to resolve the issue.

1. Stop running the test (most likely to resolve the issue, but will hide failures that the test might have detected)
2. Wait for Jenkins to be quiet before exiting the test (may not prevent all test failures)

I'm open to either change and am happy to modify this pull request to include which ever is preferred by @olamy and the other maintainers of the plugin.

We like having the blueocean plugin in the Jenkins plugin bill of materials so that we can detect issues more quickly.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

