### PR TITLE
Add Java 21 build for https://ci.jenkins.io/

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 if (JENKINS_URL == 'https://ci.jenkins.io/') {
   buildPlugin(
     configurations: [
+      [ platform: "linux", jdk: "21" ],
       [ platform: "linux", jdk: "17" ]
     ],
     // Tests were locking up and timing out on non-aci


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change adds a Java 21 test on ci.jenkins.io.  It does not change the other CI configurations.
