### PR TITLE
Explicitly use Atlassian repository

### DIFF
--- a/blueocean-jira/pom.xml
+++ b/blueocean-jira/pom.xml
@@ -48,4 +48,16 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>atlassian-maven-public</id>
+            <url>https://packages.atlassian.com/maven-public/</url>
+        </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.5.0</version>
+            <version>3.9.2</version>
         </dependency>
 
         <!-- Other -->
@@ -375,7 +375,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
-            <version>3.0.14</version>
+            <version>3.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/issues/3842. This plugin currently depends on JCenter for Atlassian libraries, but JFrog has asked us to stop caching JCenter dependencies. Based on [this page](https://developer.atlassian.com/server/framework/atlassian-sdk/working-with-maven/), the dependencies we need are officially published at https://packages.atlassian.com/maven-public/ so fetch them from there directly. We choose `maven-public` rather than `maven-external` because Atlassian may one day go through a similar bandwidth reduction exercise as we are currently going through right now, and in such an event they would want us to rely on public repositories for third-party libraries, so proactively anticipate such an event by using the repository that contains just Atlassian libraries. We bump the managed dependency on `jira` to the latest version because the old version that we currently depend on isn't present in Atlassian's repository anymore. We bump `maven-artifact` to a more recent version to resolve a require upper bounds error after upgrading the Jira plugin to the latest version.

To test this, I verified that I could run `mvn clean verify -DskipTests '-P!consume-incrementals,!might-produce-incrementals' -Dskip.npm -Dskip.installnodenpm` in a clean Docker container (without `~/.m2`) and without the JCenter cache:

```xml
diff --git a/jenkins-design-language/pom.xml b/jenkins-design-language/pom.xml
index 6d04b824b..0a7d7f776 100644
--- a/jenkins-design-language/pom.xml
+++ b/jenkins-design-language/pom.xml
@@ -44,13 +44,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </pluginRepository>
     </pluginRepositories>
 
diff --git a/pom.xml b/pom.xml
index 638c01c6b..014316b2f 100644
--- a/pom.xml
+++ b/pom.xml
@@ -145,17 +145,30 @@
 
   <repositories>
     <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
+    </repository>
+    <repository>
+      <releases>
         <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
       </snapshots>
+      <id>orphans</id>
+      <url>https://repo.jenkins-ci.org/artifactory/orphans/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </pluginRepository>
   </pluginRepositories>
```