### PR TITLE
Upgrade Jira plugin 3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.5.0</version>
+            <version>3.9.2</version>
         </dependency>
 
         <!-- Other -->
@@ -375,7 +375,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
-            <version>3.0.14</version>
+            <version>3.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This isn't managed in BOM, and we're currently depending on an out-of-date version. The update to `maven-artifact` is to satisfy a require upper bounds error.