### PR TITLE
[JENKINS-72467] Fix localization

### DIFF
--- a/blueocean-i18n/src/main/java/io/jenkins/blueocean/i18n/BlueI18n.java
+++ b/blueocean-i18n/src/main/java/io/jenkins/blueocean/i18n/BlueI18n.java
@@ -140,7 +140,9 @@ public class BlueI18n implements ApiRoutable {
         }
 
         try {
-            ResourceBundle resourceBundle = ResourceBundle.getBundle(bundleParams.bundleName, locale, plugin.classLoader);
+            // We don't want to fall back to the default locale.
+            var control = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT);
+            ResourceBundle resourceBundle = ResourceBundle.getBundle(bundleParams.bundleName, locale, plugin.classLoader, control);
             JSONObject bundleJSON = new JSONObject();
             for (String key : resourceBundle.keySet()) {
                 bundleJSON.put(key, resourceBundle.getString(key));


### PR DESCRIPTION
# Description

Similar fix to https://github.com/jenkinsci/jenkins/pull/8776

See [JENKINS-72467](https://issues.jenkins-ci.org/browse/JENKINS-72467).

This ensures that the blueocean pages are displayed in the language requested by the browser, and not falling back to the default JVM locale when requesting english.

Verified manually that with this change, a JVM with `-Duser.language=fr`, and a browser configured for english only, the BlueOcean page is displayed in english only. When adding the french language to the browser, the page is then translated to french as expected (at least for the translated strings part of Blue Ocean).

Could not add a unit test to verify the behaviour as I'm not familiar with how BlueOcean deals with resource bundles and there was no existing bundle part of `blueocean-i18n` that I could reuse to implement a test.

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

