### PR TITLE
JENKINS-70421 Add missing test result badges to menu item

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetails.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetails.jsx
@@ -156,7 +156,7 @@ class RunDetails extends Component {
 
         const baseUrl = UrlBuilder.buildRunUrl(params.organization, params.pipeline, params.branch, params.runId, null);
         logger.debug('params', params.organization, params.pipeline, params.branch, params.runId);
-        const currentRun = new RunRecord(run);
+        const currentRun = new RunRecord({...run, testSummary});
         const computedTitle = `${currentRun.organization} / ${pipeline.fullName} / ${params.pipeline === params.branch ? '' : `${params.branch} / `} #${
             currentRun.id
         }`;


### PR DESCRIPTION
# Description

This is a simple one-line fix for the reported issue. This is a reopen of https://github.com/jenkinsci/blueocean-plugin/pull/2535 due to a technical error in the pipeline.

See [JENKINS-70421](https://issues.jenkins-ci.org/browse/JENKINS-70421).

# Submitter checklist
- [ X ] Link to JIRA ticket in description, if appropriate.
- [ X ] Change is code complete and matches issue description
- [ X ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ X ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

