### PR TITLE
chore: Add support for 'GitParameterDefinition' (Git plugin) in Blue Ocean

### DIFF
--- a/blueocean-core-js/src/js/parameter/index.js
+++ b/blueocean-core-js/src/js/parameter/index.js
@@ -15,7 +15,7 @@ import { ParameterApi } from './rest/ParameterApi';
 export { ParametersRunButton } from './ParametersRunButton';
 /**
  * all input types that we know of mapping against the component
- * @type {{BooleanParameterDefinition: Boolean, ChoiceParameterDefinition: Choice, TextParameterDefinition: String, StringParameterDefinition: Text, PasswordParameterDefinition: Password}}
+ * @type {{BooleanParameterDefinition: Boolean, ChoiceParameterDefinition: Choice, TextParameterDefinition: String, StringParameterDefinition: Text, PasswordParameterDefinition: Password, GitParameterDefinition: Text}}
  */
 export const supportedInputTypesMapping = {
     BooleanParameterDefinition: Boolean,
@@ -23,6 +23,7 @@ export const supportedInputTypesMapping = {
     TextParameterDefinition: Text,
     StringParameterDefinition: String,
     PasswordParameterDefinition: Password,
+    GitParameterDefinition: String
 };
 /**
  * all input types that we know of


### PR DESCRIPTION
# Description

Add support for 'GitParameterDefinition' (Git plugin) in Blue Ocean. This allows one to start pipelines that take parameters like a git branch that's exposed from the Jenkins Git plugin. 

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

