### PR TITLE
Deflake `PipelineApiTest.testPipelineQueue`

### DIFF
--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -544,13 +544,13 @@ public class PipelineApiTest extends BaseTest {
         Run r = QueueUtil.getRun(p1, Long.parseLong((String)((Map)queue.get(0)).get("id")));
         assertNull(r); //its not moved out of queue yet
 
+        for (Queue.Item i : j.jenkins.getQueue().getItems()) {
+            j.jenkins.getQueue().cancel(i);
+        }
         b1.doStop();
         b2.doStop();
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b1));
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b2));
-        for (Queue.Item i : j.jenkins.getQueue().getItems()) {
-            j.jenkins.getQueue().cancel(i);
-        }
         j.waitUntilNoActivity();
     }
 


### PR DESCRIPTION
Would I think fix https://github.com/jenkinsci/bom/issues/2916. You can see

```
WARNING: pipeline1 #3 still seems to be running, which could break deletion of log files or metadata in the log
```

which is a good clue that the test is broken. Indeed the test times out reproducibly after

```diff
diff --git blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
index 6151d3a30..78c900448 100644
--- blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
+++ blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/PipelineApiTest.java
@@ -548,6 +548,7 @@ public class PipelineApiTest extends BaseTest {
         b2.doStop();
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b1));
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b2));
+        Thread.sleep(1000);
         for (Queue.Item i : j.jenkins.getQueue().getItems()) {
             j.jenkins.getQueue().cancel(i);
         }
```

since builds 1 and 2 are aborted and then build 3 is scheduled on an executor before the test gets a chance to cancel its queue item. It looks like the mistake came from the succession of #2450 & #2468.
