### PR TITLE
Prevent debounceFetchNodes from jumping node view

### DIFF
--- a/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/Pipeline.jsx
@@ -50,9 +50,10 @@ export default class Pipeline extends Component {
         this.debounceFetchNodes = debounce((karaokeOut) => {
             logger.debug('sse fetch it', this.karaoke);
             if (karaokeOut) {
-                this.pager.fetchNodesOnly({});
+                this.pager.fetchNodesOnly();
             } else {
-                this.pager.fetchNodes({});
+                const { node } = this.props.params;
+                this.pager.fetchNodes({ node });
             }
         }, 200);
     }


### PR DESCRIPTION
Any of the events which trigger debounceFetchNodes should call fetchNodes[Only] with the current props node specified. This prevents a pipeline view from jumping to the first still-running parallel stage when any non-first stage is focused and a handled non-pipeline_step event is received.

Removed unnecessary fetchNodesOnly parameter.

# Description

Test:
For a running job with parallel stages with multiple steps that emits non-pipeline_step events currently running:
Click to focus on a running step *below* the first still-running step at the top of the pipeline.
Wait for a pipeline_{end,start,block_end,stage} or job_run_ended event to be received.
Without this change, the log/steps view will switch to a view which includes all of the steps of the topmost still-running step (different from focusing on only that step, there is no click-focus that will produce this view).
With this change, the view will remain on the previously focused node after the event has been handled and the debounced fetchNodes triggered.

Reviewer: _If there is test coverage for the React behaviors, I can add them._

See [JENKINS-53296](https://issues.jenkins-ci.org/browse/JENKINS-53296).

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

