### PR TITLE
Fix misleading in logging statement in parallelPipeline Method

### DIFF
--- a/acceptance-tests/src/main/java/io/blueocean/ath/GitRepositoryRule.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/GitRepositoryRule.java
@@ -51,7 +51,7 @@ public class GitRepositoryRule extends ExternalResource {
             Ref ref = client.branchCreate().setName(prefix + i).call();
             refs.add(ref);
         }
-        logger.info("Created " + number + " branches " + prefix + "[1-" + (number + 1) + "]");
+        logger.info("Created " + number + " branches " + prefix + "[1-" + number + "]");
 
         return refs;
     }

--- a/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
+++ b/acceptance-tests/src/main/java/io/blueocean/ath/pages/blue/EditorPage.java
@@ -166,7 +166,7 @@ public class EditorPage {
      * @param numberOfParallels number of parallel branches we want to create.
      */
     public void parallelPipeline(int numberOfParallels) {
-        logger.info("Editing a parallel pipeline");
+        logger.info("Creating a parallel pipeline from scratch");
         for (int i = 1; i < numberOfParallels; i++) {
             logger.info("Create stage Parallel-" + i);
             // The "add" Button will always have the id pipeline-node-hittarget-2-add


### PR DESCRIPTION
# Description

This PR updates the logging statement in the parallelPipeline method to accurately reflect the action being performed. The previous log message indicated that a parallel pipeline was being “edited,” while the surrounding code clearly shows that a new parallel pipeline is being created from scratch.

## Reason for the Change

The original log statement was misleading, suggesting that an existing pipeline was being modified rather than a new one being created. This could cause confusion for developers and maintainers when reviewing logs. The new log statement more accurately describes the process of creating a new parallel pipeline, thus improving the clarity and accuracy of the code’s documentation through logs.

## Testing
Verified that the method performs as expected and that the new logging message appears correctly in the logs during execution.

