### PR TITLE
Simplify JSON parsing

### DIFF
--- a/blueocean-rest-impl/src/main/webapp/scripts/analytics.js
+++ b/blueocean-rest-impl/src/main/webapp/scripts/analytics.js
@@ -5,8 +5,7 @@ window.addEventListener('load', function() {
         headers: crumb.wrap({
             'Content-Type': 'application/json'
         }),
-        // TODO simplify when Prototype.js is removed
-        body: Object.toJSON ? Object.toJSON(eventData) : JSON.stringify(eventData)
+        body: JSON.stringify(eventData)
     }).then(function(rsp) {
         if (!rsp.ok) {
             console.error('Could not send pageview event');


### PR DESCRIPTION
Now that Prototype.js has been removed in 2.426.x, we can remove the no-longer needed `Object.toJSON` workaround. This plugin's baseline is 2.426.3, so this change is safe.

### Testing done

`mvn clean verify -DskipTests`