### PR TITLE
[JENKINS-73775] Replace deprecated call to JGit setLastModified(long)

### DIFF
--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -405,7 +406,7 @@ class GitUtils {
         final DirCache inCoreIndex = DirCache.newInCore();
         final DirCacheBuilder dcBuilder = inCoreIndex.builder();
         try (final ObjectInserter inserter = repo.newObjectInserter()) {
-            long lastModified = System.currentTimeMillis();
+            Instant lastModified = Instant.now();
 
             try {
                 if (contents != null) {


### PR DESCRIPTION
# [JENKINS-73775] Replace deprecated call to JGit setLastModified(long)

See [JENKINS-73775](https://issues.jenkins.io/browse/JENKINS-73775)

JGit 5 deprecated the `DirCacheEntry.setLastModified(long)` method and recommends `DirCacheEntry.setLastModified(Instant)`.  JGit 7.0.0 removes DirCacheEntry.setLastModified(long).  This change will work with older versions of JGit (like 6.9.0 and 6.10.0) and JGit 7.0.0 because the replacement method is available with older versions and the most recent release.

[Javadoc for JGit 6.9.0](https://javadoc.io/doc/org.eclipse.jgit/org.eclipse.jgit/6.9.0.202403050737-r/org.eclipse.jgit/org/eclipse/jgit/dircache/DirCacheEntry.html) shows the deprecation.

Without this change, users that try to run a commit from the Git portion of Blue Ocean may see a method not found exception that will fail the operation.

No additional tests because the automated tests running in plugin BOM are what showed the issue.

This needs to be merged and released soon so that users of Jenkins weekly 2.463 and later do not see the method not found exception when they install git client plugin 6.0.0.

I've confirmed that I can see the issue with interactive testing of Jenkins 2.476 using git client plugin 6.0.0.  When I replace git client plugin 6.0.0 with git client plugin 5.0.0 the issue does not appear.  In order to duplicate it with Jenkins 2.476, I had to use a FreeBSD git server (git.markwaite.net) where I could add the RSA SHA-1 public key that Blue Ocean generates to ~/.ssh/authorized_keys.  I can't do that with github.com because they no longer accept RSA SHA-1 public keys.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
