### PR TITLE
[JENKINS-73775] Replace call to removed CommitBuilder.setEncoding(String)

### DIFF
--- a/blueocean-git-pipeline/pom.xml
+++ b/blueocean-git-pipeline/pom.xml
@@ -39,6 +39,13 @@
       <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
       <!-- TODO this is hard to manage; if needed, should be in BOM -->
       <version>6.9.0.202403050737-r</version>
+      <exclusions>
+        <!-- Exclude the jgit library because it is provided by git client plugin -->
+        <exclusion>
+          <groupId>org.eclipse.jgit</groupId>
+          <artifactId>org.eclipse.jgit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test dependencies -->

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
@@ -344,7 +344,7 @@ class GitUtils {
             final CommitBuilder commit = new CommitBuilder();
             commit.setAuthor(author);
             commit.setCommitter(author);
-            commit.setEncoding(Constants.CHARACTER_ENCODING);
+            commit.setEncoding(StandardCharsets.UTF_8);
             commit.setMessage(message);
             //headId can be null if the repository has no commit yet
             if (headId != null) {


### PR DESCRIPTION
# [JENKINS-73775] Replace call to removed CommitBuilder.setEncoding(String)

See [JENKINS-73775](https://issues.jenkins.io/browse/JENKINS-73775)

JGit 7.0.0 removed the setEncoding(String) method that had been deprecated previously.  The replacement is setEncoding(Charset).  The JGit documentation recommends commit.setEncoding(StandardCharsets.UTF_8)

Failure was hidden by the previous setLastModified() exception because this call happens later in the same calling sequence.

Exclude org.eclipse.jgit from transitive inclusion in the git-pipeline plugin

The org.eclipse.jgit jar file is already provided by the git client plugin.  Let's not risk that a 6.9.0 copy of the library is loaded into the same Java process that is running either JGit 6.10.0 (with git client plugin 5.0.0) or JGit 7.0.0 with git client plugin 6.0.0)

## Testing done

Confirmed that the steps that show the error in [JENKINS-73775](https://issues.jenkins.io/browse/JENKINS-73775) are passing with a snapshot build of the plugin.  Steps are:

1. Create an ECDSA private key on the client machine and add its public key to ~/.ssh/authorized_keys in the mwaite account on git.markwaite.net
2. Create a private key credential in the Jenkins controller using the ECDSA private key with git client plugin 5.0.0 installed
3. Create a multibranch Pipeline job using the Git source code provider, the repository URL mwaite@git.markwaite.net:git/bare/bin.git, and the private key credential defined in the previous step
4. After the multibranch Pipeline job runs, open Blue Ocean from the multibranch Pipeline job page
5. Confirm that all the branches are shown on the Blue Ocean page and that the pencil icon is displayed for each of the branches
6. Click the pencil icon to open the Blue Ocean editor, edit the job definition, and save it as a new branch
7. Confirm that the new branch is saved and the job runs
8. Upgrade git client plugin from 5.0.0 to 6.0.0 and restart the controller
9. Run the job from the new branch to confirm it works
10. Click the pencil icon to edit the Jenkinsfile, make a change, and save it

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
