### PR TITLE
Prepare tests for newer core/BOM

### DIFF
--- a/blueocean-events/src/test/java/io/jenkins/blueocean/events/SseEventTest.java
+++ b/blueocean-events/src/test/java/io/jenkins/blueocean/events/SseEventTest.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.branch.BranchProperty;
@@ -135,7 +134,7 @@ public class SseEventTest {
     }
 
     @Test
-    public void pipelineWithInput() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    public void pipelineWithInput() throws Exception {
         final OneShotEvent success = new OneShotEvent();
 
         String script = "node {\n" +

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CredentialApiTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/CredentialApiTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNotNull;
 public class CredentialApiTest extends PipelineBaseTest {
 
     @Test
-    public void listCredentials() throws IOException {
+    public void listCredentials() throws Exception {
         SystemCredentialsProvider.ProviderImpl system = ExtensionList.lookup(CredentialsProvider.class).get(SystemCredentialsProvider.ProviderImpl.class);
         CredentialsStore systemStore = system.getStore(j.getInstance());
         systemStore.addDomain(new Domain("domain1", null, null));
@@ -59,7 +59,7 @@ public class CredentialApiTest extends PipelineBaseTest {
     }
 
     @Test
-    public void listAllCredentials() throws IOException {
+    public void listAllCredentials() throws Exception {
         SystemCredentialsProvider.ProviderImpl system = ExtensionList.lookup(CredentialsProvider.class).get(SystemCredentialsProvider.ProviderImpl.class);
         CredentialsStore systemStore = system.getStore(j.getInstance());
         systemStore.addDomain(new Domain("domain1", null, null));

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/GraphBuilderTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/GraphBuilderTest.java
@@ -542,7 +542,7 @@ public class GraphBuilderTest extends PipelineBaseTest {
         return job.getLastBuild();
     }
 
-    private WorkflowJob createJob(String jobName, String jenkinsFileName) throws java.io.IOException {
+    private WorkflowJob createJob(String jobName, String jenkinsFileName) throws Exception {
         WorkflowJob job = j.createProject(WorkflowJob.class, jobName);
 
         URL resource = getClass().getResource(jenkinsFileName);

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/LinkResolverTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/LinkResolverTest.java
@@ -14,7 +14,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockFolder;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class LinkResolverTest extends PipelineBaseTest {
     }
 
     @Test
-    public void nestedFolderJobLinkResolveTest() throws IOException {
+    public void nestedFolderJobLinkResolveTest() throws Exception {
         Project f = j.createFreeStyleProject("fstyle1");
         MockFolder folder1 = j.createFolder("folder1");
         Project p1 = folder1.createProject(FreeStyleProject.class, "test1");

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -647,7 +647,7 @@ public abstract class PipelineBaseTest{
         return login("bob", "Bob Smith", "bob@jenkins-ci.org");
     }
 
-    protected WorkflowJob createWorkflowJobWithJenkinsfile(Class<?> contextClass, String jenkinsFileName) throws java.io.IOException {
+    protected WorkflowJob createWorkflowJobWithJenkinsfile(Class<?> contextClass, String jenkinsFileName) throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "project-" + UUID.randomUUID());
         URL resource = contextClass.getResource(jenkinsFileName);
         String jenkinsFile = IOUtils.toString(resource, StandardCharsets.UTF_8);

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/analytics/PipelinePluginAnalyticsTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/analytics/PipelinePluginAnalyticsTest.java
@@ -71,7 +71,7 @@ public class PipelinePluginAnalyticsTest extends PipelineBaseTest {
         Assert.assertEquals("runResult", "SUCCESS", properties.get("runResult"));
     }
 
-    private void createAndRunPipeline(String jenkinsFileName) throws java.io.IOException, InterruptedException, java.util.concurrent.ExecutionException {
+    private void createAndRunPipeline(String jenkinsFileName) throws Exception {
         // Create the pipeline and run it
         WorkflowJob scriptedSingle = createWorkflowJobWithJenkinsfile(getClass(), jenkinsFileName);
         WorkflowRun scriptedSingleRun = scriptedSingle.scheduleBuild2(0, new CauseAction()).waitForStart();


### PR DESCRIPTION
Newer versions of core/BOM break source compatibility in tests by throwing new exception types. This PR prepares this repository's tests by broadening the exception types.