### PR TITLE
[JENKINS-74883] Remove unsafe `eval` call from third-party library

### DIFF
--- a/blueocean-core-js/package-lock.json
+++ b/blueocean-core-js/package-lock.json
@@ -8071,11 +8071,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9261,6 +9256,13 @@
         "isemail": "1.x.x",
         "moment": "2.x.x",
         "topo": "1.x.x"
+      },
+      "dependencies": {
+        "isemail": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.1.2.tgz",
+          "integrity": "sha512-z/MMeAOXgWtttqjSPZrcuk/X44SXTm+4Ia2YOfHYY7VInBw/KR/VwsX3xWs8JPTApuInchkQ/QYPyoaxOQooew=="
+        }
       }
     },
     "jquery": {

--- a/blueocean-core-js/package.json
+++ b/blueocean-core-js/package.json
@@ -18,7 +18,8 @@
     "test:fast": "gulp test:fast",
     "mvnbuild": "gulp lint build bundle",
     "mvnbuild:fast": "gulp bundle",
-    "mvntest": "gulp test"
+    "mvntest": "gulp test",
+    "preinstall": "npx npm-force-resolutions"
   },
   "author": "Cliff Meyers <cmeyers@cloudbees.com> (https://www.cloudbees.com/)",
   "contributors": [
@@ -99,6 +100,9 @@
     "tsify": "4.0.0",
     "typescript": "2.7.2",
     "watchify": "3.7.0"
+  },
+  "resolutions": {
+    "isemail": "2.1.2"
   },
   "jenkinscd": {
     "export": [


### PR DESCRIPTION
### Context

See [JENKINS-74883](https://issues.jenkins.io/browse/JENKINS-74883).

### Problem

```
EvalError: call to Function() blocked by CSP
    optimizeLookup https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:48503
    [223]</< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:48507
    [223]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:49728
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [222]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:48330
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [238]</< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:53245
    [238]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:53710
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [230]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:51456
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [233]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:51983
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [248]</< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:54046
    [248]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:54193
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [243]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:53979
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [379]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:71583
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [375]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:70717
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [377]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:71215
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    [376]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:71127
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    execute https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:68818
    ___exec https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:67756
    make https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:2834
    ___$$$___exec https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:67753
    ___$$$___doBundleInit https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:67830
    [348]</< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:67842
    doFulfill https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:2860
    onFulfilled https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:2872
    [348]< https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:67841
    o https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    r https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
    <anonymous> https://127.0.0.1/adjuncts/f72d66ff/io/jenkins/blueocean/blueocean-core-js.js:1
blueocean-core-js.js:67758:17
```

### Solution

Pull in https://github.com/skeggse/isemail/pull/12, first released in https://github.com/skeggse/isemail/releases/tag/v2.1.2.

### Implementation

Override the transitive dependency. The `overrides` feature could be used for this, but it was introduced in NPM version 8, while we are still on NPM 6.14.4. NPM 6.14.4 doesn't natively support `overrides`, but we can use the [npm-force-resolutions](https://github.com/rogeriochaves/npm-force-resolutions) package to enforce specific versions for dependencies as recommended [here](https://docs.veracode.com/r/Fix_Example_Transitive_Vulnerability_for_NPM). This PR sets up that package as described in its README, then uses it to override the version of `isemail` to 2.1.2.

### Testing done

Tested together with #2587, #2588, and

```xml
diff --git a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
index dc61f3c0d..fa7e41d48 100644
--- a/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
+++ b/blueocean-web/src/main/resources/io/jenkins/blueocean/BlueOceanUI/index.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
     <st:contentType value="text/html;charset=UTF-8"/>
+    <st:header name="Content-Security-Policy" value="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io" />
 
     <!-- Add HTTP headers from extensions. See BluePageDecorator.java -->
     <j:forEach var="pd" items="${it.pageDecorators}">
```

Note that the above does _not_ contain `unsafe-eval`, exposing [JENKINS-74883](https://issues.jenkins.io/browse/JENKINS-74883).

Confirmed that after the header was added but before this PR, Blue Ocean blew up with the CSP violation described in the **Problem** section.

Confirmed that after the header was added and after this PR, Blue Ocean loaded successfully and I could browse both Pipeline jobs and Pipeline runs without any errors in the console log. Confirmed that the CSP header was being sent _without_ `unsafe-eval`.

### Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

### Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

