### PR TITLE
Separate lines on blueocean output without paragraphs

### DIFF
--- a/blueocean-dashboard/package-lock.json
+++ b/blueocean-dashboard/package-lock.json
@@ -251,10 +251,10 @@
         "@jenkins-cd/storage": "^0.0.6"
       }
     },
-    "node_modules/@jenkins-cd/pipeline-graph-widget": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@jenkins-cd/pipeline-graph-widget/-/pipeline-graph-widget-0.1.2.tgz",
-      "integrity": "sha512-nMTenuo6J52l495NQ3vTqwy8J+Uhe1TTOWhmop26Z7/va7CjR5tD9UeebtHuGXhHknlTFHj2E0KfBgZXpOHWhw==",
+    "@werkt/pipeline-graph-widget": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@werkt/pipeline-graph-widget/-/pipeline-graph-widget-0.1.4.tgz",
+      "integrity": "sha512-Rcz5AO20E9IJf24YXJnkVrspX91B+976SL+HyWH9p4kvu24+CDt3ZMwehLMpPoItFJ8HVGQVr/o1K+LSioBpvg=="
       "peerDependencies": {
         "react": "^15",
         "react-dom": "^15"

--- a/blueocean-dashboard/package.json
+++ b/blueocean-dashboard/package.json
@@ -62,7 +62,7 @@
     "@jenkins-cd/design-language": "1.10.4",
     "@jenkins-cd/js-extensions": "0.0.44",
     "@jenkins-cd/js-modules": "0.0.10",
-    "@jenkins-cd/pipeline-graph-widget": "0.1.2",
+    "@werkt/pipeline-graph-widget": "0.1.4",
     "@jenkins-cd/preferences": "0.0.4",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "bluebird": "3.5.0",

--- a/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
+++ b/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { PipelineGraph } from '@jenkins-cd/pipeline-graph-widget';
+import { PipelineGraph } from '@werkt/pipeline-graph-widget';
 
 import { convertJenkinsNodeGraph } from './GraphNodeConverter';
 

--- a/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
+++ b/blueocean-dashboard/src/main/js/components/karaoke/components/LogConsole.jsx
@@ -28,7 +28,7 @@ class LogLine extends PureComponent {
         const lineChunks = makeReactChildren(tokenized);
 
         return (
-            <p id={`${prefix}log-${index + 1}`}>
+            <span id={`${prefix}log-${index + 1}`} className="log-row">
                 <div className="log-boxes">
                     <a
                         className="linenumber"
@@ -39,7 +39,7 @@ class LogLine extends PureComponent {
                     />
                     {React.createElement(Linkify, { className: 'line ansi-color' }, ...lineChunks)}
                 </div>
-            </p>
+            </span>
         );
     }
 }

--- a/blueocean-dashboard/src/main/less/core.less
+++ b/blueocean-dashboard/src/main/less/core.less
@@ -279,10 +279,11 @@ a.pipelineRedirectLink svg {
             justify-content: center;
         }
     }
-    p {
+    span.log-row {
         padding: 0 15px 0 55px;
         margin: 0;
         min-height: 16px;
+        display: block;
 
         .log-boxes {
             display: flex;

--- a/blueocean-dashboard/src/main/less/pipeline-run-graph.less
+++ b/blueocean-dashboard/src/main/less/pipeline-run-graph.less
@@ -1,3 +1,3 @@
-@import (less) "../../../node_modules/@jenkins-cd/pipeline-graph-widget/dist/styles/css/main.css";
+@import (less) "../../../node_modules/@werkt/pipeline-graph-widget/dist/styles/css/main.css";
 // TODO: There's probably a nicer way to do this, but js-builder is probably in the way of same.
 

--- a/blueocean-rest-impl/pom.xml
+++ b/blueocean-rest-impl/pom.xml
@@ -43,10 +43,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
         </dependency>
-        <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-        </dependency>
         <!-- Test plugins -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/LogResource.java
@@ -72,20 +72,23 @@ public class LogResource{
 
         long r = logText.writeLogTo(offset,spool);
 
-        try (Writer w = rsp.getWriter()) {
-        spool.writeTo(new LineEndNormalizingWriter(w));
-        if(!logText.isComplete()) {
+        // write the headers before we deliver 32k of data through the response
+        // ignore the appenderLogReader, because it does not seem to be reset, and makes no sense
+        if (!logText.isComplete()) {
             rsp.addHeader("X-More-Data", "true");
-        }else{
-            int text = appenderLogReader.read();
-            while(text != -1){
-                w.write(text);
-                r++;
-                text = appenderLogReader.read();
-            }
         }
         rsp.addHeader("X-Text-Size", String.valueOf(r));
         rsp.addHeader("X-Text-Delivered", String.valueOf(r - offset));
+
+        try (Writer w = rsp.getWriter()) {
+            spool.writeTo(new LineEndNormalizingWriter(w));
+            if(logText.isComplete()) {
+                int text = appenderLogReader.read();
+                while(text != -1){
+                    w.write(text);
+                    text = appenderLogReader.read();
+                }
+            }
         }
     }
 }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/GlobMatcher.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/util/GlobMatcher.java
@@ -1,23 +1,20 @@
 package io.jenkins.blueocean.service.embedded.util;
 
-import org.apache.oro.text.GlobCompiler;
-import org.apache.oro.text.regex.MalformedPatternException;
-import org.apache.oro.text.regex.Pattern;
-import org.apache.oro.text.regex.Perl5Matcher;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
 
 /**
- * Matches glob string patters
+ * Matches case-insensitive glob string patterns
  * See https://en.wikipedia.org/wiki/Glob_(programming)
  */
 public final class GlobMatcher {
 
-    private static final GlobCompiler GLOB_COMPILER = new GlobCompiler();
-    private static final Perl5Matcher MATCHER = new Perl5Matcher();
-    private final Pattern pattern;
+    private final PathMatcher matcher;
 
     public GlobMatcher(String patternStr) {
         try {
-            this.pattern = GLOB_COMPILER.compile(patternStr, GlobCompiler.CASE_INSENSITIVE_MASK);
+            String multiDirUpperGlobPattern = patternStr.replaceAll("\\*", "**").toUpperCase();
+            this.matcher = FileSystems.getDefault().getPathMatcher("glob:" + multiDirUpperGlobPattern);
         } catch (Throwable e) {
             throw new IllegalArgumentException(String.format("bad pattern '%s'", patternStr), e);
         }
@@ -28,6 +25,7 @@ public final class GlobMatcher {
      * @return matches pattern or not
      */
     public boolean matches(String input) {
-        return MATCHER.matches(input, pattern);
+        String upperInput = input.toUpperCase();
+        return matcher.matches(FileSystems.getDefault().getPath(upperInput));
     }
 }

--- a/jenkins-design-language/src/js/components/TruncatingLabel.jsx
+++ b/jenkins-design-language/src/js/components/TruncatingLabel.jsx
@@ -107,7 +107,7 @@ export class TruncatingLabel extends Component {
         }
 
         return (
-            <div style={mergedStyle} className={'TruncatingLabel ' + className} title={this.innerText}>
+            <div style={mergedStyle} className={'TruncatingLabel ' + className} title={this.completeText}>
                 {this.innerText}
             </div>
         );

--- a/pom.xml
+++ b/pom.xml
@@ -431,11 +431,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-            <version>2.0.8</version>
-        </dependency>
-        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
             <version>0.9.6</version>


### PR DESCRIPTION
Paragraph html content causes double-spacing to occur when pasting into raw text. Seek the line separation through alternate methods that don't disrupt outputs.

# Description

See [JENKINS-57305](https://issues.jenkins-ci.org/browse/JENKINS-57305).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

