### PR TITLE
Add user hyperlink in RunDetailsHeader when job is started by a user

### DIFF
--- a/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
+++ b/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
@@ -196,6 +196,17 @@ class RunDetailsHeader extends Component {
                     </div>
                 );
             }
+
+            if (lastCause && lastCause.userId) {
+                const userProfileUrl = `${UrlConfig.getJenkinsRootURL()}/user/${lastCause.userId}`;
+
+                return (
+                    <div className="causes" title={lastCause.shortDescription}>
+                        Started by user <a href={userProfileUrl}>{lastCause.userName || lastCause.userId}</a>
+                    </div>
+                );
+            }
+
             const causeMessage = (lastCause && lastCause.shortDescription) || null;
             return (
                 <div className="causes" title={causeMessage}>


### PR DESCRIPTION
# Description

This PR fixes [Jira issue 71028](https://issues.jenkins.io/browse/JENKINS-71028) by adding a user hyperlink in the run details header when the job is started by a user.

![Screenshot 2025-03-19 233959](https://github.com/user-attachments/assets/589c1ad7-8c72-44bb-9c38-e2c06c74c5e1)


For testing, I reviewed the current tests and did not find relevant unit tests specifically targeting the RunDetailsHeader component; therefore, testing was done manually in local development. I am also providing a screenshot showing an example of how the user link now appears in the UI.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
