### PR TITLE
[JENKINS-75768] Blue Ocean Fails to Load with GitHub Auth: 403 Forbidden on PUT Request

### DIFF
--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/BlueOceanRootAction.java
@@ -14,7 +14,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.factory.organization.OrganizationFactory;
 import io.jenkins.blueocean.rest.model.BlueOrganization;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
+import org.springframework.security.core.Authentication;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -67,8 +67,8 @@ public class BlueOceanRootAction implements UnprotectedRootAction, StaplerProxy 
              *
              * @see Jenkins#getTarget()
              */
-            Authentication a = Jenkins.getAuthentication();
-            if(!Jenkins.get().getACL().hasPermission(a,Jenkins.READ)){
+            Authentication a = Jenkins.getAuthentication2();
+            if(!Jenkins.get().getACL().hasPermission2(a,Jenkins.READ)){
                 throw new ServiceException.ForbiddenException("Forbidden");
             }
         }else{

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -22,7 +22,7 @@ import io.jenkins.blueocean.rest.model.BlueUser;
 import io.jenkins.blueocean.rest.model.BlueUserPermission;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
-import org.acegisecurity.Authentication;
+import org.springframework.security.core.Authentication;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Collections;
@@ -71,7 +71,7 @@ public class UserImpl extends BlueUser {
 
     @Override
     public String getEmail() {
-        String name = Jenkins.getAuthentication().getName();
+        String name = Jenkins.getAuthentication2().getName();
         if(isAnonymous(name)){
             return null;
         }else{
@@ -113,7 +113,7 @@ public class UserImpl extends BlueUser {
 
     @Override
     public BlueUserPermission getPermission() {
-        Authentication authentication = Jenkins.getAuthentication();
+        Authentication authentication = Jenkins.getAuthentication2();
         String name = authentication.getName();
         if(isAnonymous(name)){
             return null;


### PR DESCRIPTION
### Description

See [JENKINS-75768](https://issues.jenkins.io/browse/JENKINS-75768). https://github.com/jenkinsci/github-oauth-plugin/blob/f5ddfba7349dac0eec130482ca98b6ab236f0c49/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java#L84 means that `github-oauth` is limited to working in two configurations:

- Caller (Blue Ocean) is using Acegi, and callee (`github-oauth`) is also using Acegi
- Caller (Blue Ocean) is using Spring Security, and callee (`github-oauth`) is also using Spring Security

Prior to https://github.com/jenkinsci/github-oauth-plugin/pull/285, the former was the case. After https://github.com/jenkinsci/github-oauth-plugin/pull/285, the caller (Blue Ocean) is using Acegi, but the callee (`github-oauth`) is using Spring Security; hence, the `instanceof` check fails and the symptoms reported in the ticket are visible. This PR solves the issue by making the caller (Blue Ocean) also using Spring Security, thus restoring the working status quo.

While I was here, cleaned up after #1571 and #2106.

### Testing done

Reproduced the problem as described in the ticket; could no longer reproduce after this PR.

### Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

### Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

