### PR TITLE
Prepare for Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ if (JENKINS_URL == 'https://ci.jenkins.io/') {
   buildPlugin(
     configurations: [
       [ platform: "linux", jdk: "21" ],
-      [ platform: "linux", jdk: "17" ]
+      [ platform: "linux", jdk: "25" ],
     ],
     // Tests were locking up and timing out on non-aci
     useContainerAgent: true,

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
@@ -327,8 +327,6 @@ class GitUtils {
         }
     }
 
-    // TODO - remove once https://github.com/spotbugs/spotbugs/issues/756 is resolved
-    @SuppressFBWarnings(value={"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}, justification="JDK11 produces different bytecode - https://github.com/spotbugs/spotbugs/issues/756")
     public static void commit(final Repository repo, final String refName, final String path, final byte[] contents,
             final String name, final String email, final String message, final TimeZone timeZone, final Date when) {
 
@@ -460,8 +458,6 @@ class GitUtils {
         return inCoreIndex;
     }
 
-    // TODO - remove once https://github.com/spotbugs/spotbugs/issues/756 is resolved
-    @SuppressFBWarnings(value={"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}, justification="JDK11 produces different bytecode - https://github.com/spotbugs/spotbugs/issues/756")
     static byte[] readFile(Repository repository, String ref, String filePath) {
         try (ObjectReader reader = repository.newObjectReader()) {
             ObjectId branchRef = repository.resolve(ref); // repository.exactRef(ref);

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractPipelineImpl.java
@@ -2,7 +2,6 @@ package io.jenkins.blueocean.service.embedded.rest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.Util;
@@ -159,7 +158,6 @@ public class AbstractPipelineImpl extends BluePipeline {
     }
 
     @Override
-    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "isDisabled will return null if the job type doesn't support it")
     public Boolean getDisabled() {
         return Disabler.isDisabled(job);
     }

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/PipelineFolderImpl.java
@@ -203,7 +203,6 @@ public class PipelineFolderImpl extends BluePipelineFolder {
     }
 
     @Override
-    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "isDisabled will return null if the job type doesn't support it")
     public Boolean getDisabled() {
         return Disabler.isDisabled(folder);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
# Description

Prepare for Java 25

Java 25 will release Sep 16, 2025 and the Jenkins project plans to support it soon after its release.  This upodate to the most recent parent pom successfully compiles and tests with Java 25 early access 26, when combined with the removal of a few spotbugs suppressions that are no longer necessary.

Switches the Jenkinsfile to test Java 25 and Java 21 instead of testing Java 17 and Java 21.  Generated byte code is still Java 17, but I'm not aware of any case where Java 17 exposed an issue that was not also seen with Java 21.

## Testing to do

* [ ] Confirm the plugins runs as expected with Jenkins in Java 25.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

