### PR TITLE
Use a pattern match in Bitbucket Wiremock test definition

### DIFF
--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-pipeline-demo-test-branches-all.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-pipeline-demo-test-branches-all.json
@@ -1,7 +1,7 @@
 {
   "id" : "21f37681-abff-31fc-800a-38c1eb44d6a0",
   "request" : {
-    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/branches?start=0&limit=200",
+    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/pull-requests?start=0&limit=200",
     "method" : "GET"
   },
   "response" : {

--- a/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-pipeline-demo-test-branches-all.json
+++ b/blueocean-bitbucket-pipeline/src/test/resources/api/server/mappings/mapping-pipeline-demo-test-branches-all.json
@@ -1,7 +1,7 @@
 {
   "id" : "21f37681-abff-31fc-800a-38c1eb44d6a0",
   "request" : {
-    "url" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/pull-requests?start=0&limit=200",
+    "urlPattern" : "/rest/api/1.0/projects/TESTP/repos/pipeline-demo-test/(branches|pull-requests)[?]start=0[&]limit=200",
     "method" : "GET"
   },
   "response" : {

--- a/blueocean-git-pipeline/pom.xml
+++ b/blueocean-git-pipeline/pom.xml
@@ -29,6 +29,14 @@
       <artifactId>blueocean-pipeline-api-impl</artifactId>
     </dependency>
     <dependency>
+      <!-- Workaround to avoid test failures for CLI git 2.51.0 -->
+      <!-- If plugin is ever updated to require 2.492.3 or later, this can be removed -->
+      <!-- BOM for 2.479.x does not include a new enough git client plugin -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+      <version>6.1.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
     </dependency>
@@ -38,7 +46,7 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
       <!-- TODO this is hard to manage; if needed, should be in BOM -->
-      <version>6.9.0.202403050737-r</version>
+      <version>7.0.0.202409031743-r</version>
       <exclusions>
         <!-- Exclude the jgit library because it is provided by git client plugin -->
         <exclusion>

--- a/blueocean-git-pipeline/pom.xml
+++ b/blueocean-git-pipeline/pom.xml
@@ -29,14 +29,6 @@
       <artifactId>blueocean-pipeline-api-impl</artifactId>
     </dependency>
     <dependency>
-      <!-- Workaround to avoid test failures for CLI git 2.51.0 -->
-      <!-- If plugin is ever updated to require 2.492.3 or later, this can be removed -->
-      <!-- BOM for 2.479.x does not include a new enough git client plugin -->
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git-client</artifactId>
-      <version>6.1.5</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
     </dependency>

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -64,14 +64,6 @@
             <artifactId>workflow-multibranch</artifactId>
         </dependency>
         <dependency>
-            <!-- Workaround to avoid test failures for CLI git 2.51.0 -->
-            <!-- If plugin is ever updated to require 2.492.3 or later, this can be removed -->
-            <!-- BOM for 2.479.x does not include a new enough git client plugin -->
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git-client</artifactId>
-            <version>6.1.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
         </dependency>

--- a/blueocean-pipeline-api-impl/pom.xml
+++ b/blueocean-pipeline-api-impl/pom.xml
@@ -64,6 +64,14 @@
             <artifactId>workflow-multibranch</artifactId>
         </dependency>
         <dependency>
+            <!-- Workaround to avoid test failures for CLI git 2.51.0 -->
+            <!-- If plugin is ever updated to require 2.492.3 or later, this can be removed -->
+            <!-- BOM for 2.479.x does not include a new enough git client plugin -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>6.1.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         and  acceptance-tests/runner/scripts/args.sh
     -->
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <byte-buddy.version>1.17.2</byte-buddy.version>
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4770.v9a_2b_7a_9d8b_7f</version>
+            <version>4969.v6ffa_18d90c9f</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-            <version>936.4.0</version>
+            <version>937.0.3</version>
         </dependency>
 
         <!-- Module versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         and  acceptance-tests/runner/scripts/args.sh
     -->
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <javadoc.exec.goal>javadoc-no-fork</javadoc.exec.goal> <!-- stop initialize phase plugins executing twice -->
     <byte-buddy.version>1.17.2</byte-buddy.version>
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>4969.v6ffa_18d90c9f</version>
+            <version>4770.v9a_2b_7a_9d8b_7f</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-            <version>937.0.3</version>
+            <version>936.4.0</version>
         </dependency>
 
         <!-- Module versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,16 @@
             <type>pom</type>
         </dependency>
 
+        <!-- remove when update BOM to version that includes git client 6.1.5 or newer  -->
+        <dependency>
+            <!-- Workaround to avoid test failures for CLI git 2.51.0 -->
+            <!-- If plugin is ever updated to require 2.492.3 or later, this can be removed -->
+            <!-- BOM for 2.479.x does not include a new enough git client plugin -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>6.1.5</version>
+        </dependency>
+
         <!-- remove when update BOM to version that include bitbucket 936.4.0  -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
# Description

Use a pattern match in Bitbucket Wiremock test definition so that automated tests pass with previous and latest versions of Bitbucket Branch Source plugin.  Special thanks to @nfalco79 for investigation and the original submission in pull request:

* #2653

Bitbucket branch source 936.x and 937.x use different initial URLs.  Check for either and pass the test if one or the other is used.

Change included in Bitbucket branch source 937.0.0 pull request:

* https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/1060

Originally detected in:

* https://github.com/jenkinsci/bom/pull/5669

Plugin BOM blocked 937.0.3 upgrades in:

* https://github.com/jenkinsci/bom/pull/5693

While waiting for the release of this merge request, the test failure will be blocked in the plugin BOM.

### Testing done

Confirmed that the regular expression matches both URLs, using https://www.regexplanet.com/advanced/java/index.html

Confirmed that the test passes with older version of Bitbucket branch source with:

```
mvn clean package "-Dskip.npm" "-Denforcer.skip" -Dtest=BitbucketPipelineCreateRequestTest
```

Confirmed that the test passes with newer version of Bitbucket branch source with:

```
mvn clean package "-Dskip.npm" "-Denforcer.skip" -Dtest=BitbucketPipelineCreateRequestTest
```

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
