### PR TITLE
Exclude useless `gradle` test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,12 @@
             <artifactId>jenkins-test-harness-tools</artifactId>
             <version>2.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>gradle</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
# Description

`jenkins-test-harness-tools` depends on `gradle:2.15`. This causes an issue when running PCT on megawar containing `blueocean-plugin` and `gradle:2.16.1149.v711b_998b_0532` (see [JENKINS-76087](https://issues.jenkins.io/browse/JENKINS-76087)).

Let's exclude `gradle` which is not used from here.

### Testing done

I verified locally that "mvn clean test" succeed.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

