### PR TITLE
Stops using undeclared commons-lang2

### DIFF
--- a/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
+++ b/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
@@ -26,7 +26,7 @@ package io.jenkins.blueocean;
 import com.cloudbees.sdk.extensibility.Extension;
 import com.google.common.base.Splitter;
 import com.google.inject.Injector;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3StringUtils;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.controller.LocalController;
 import org.jenkinsci.utils.process.CommandBuilder;

--- a/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
+++ b/acceptance-tests/runner/runtime/src/main/java/io/jenkins/blueocean/BlueOceanWinstoneController.java
@@ -26,7 +26,7 @@ package io.jenkins.blueocean;
 import com.cloudbees.sdk.extensibility.Extension;
 import com.google.common.base.Splitter;
 import com.google.inject.Injector;
-import org.apache.commons.lang3StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.test.acceptance.controller.JenkinsController;
 import org.jenkinsci.test.acceptance.controller.LocalController;
 import org.jenkinsci.utils.process.CommandBuilder;

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/pipeline/DownstreamLinkTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/pipeline/DownstreamLinkTest.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3StringUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/acceptance-tests/src/test/java/io/blueocean/ath/offline/pipeline/DownstreamLinkTest.java
+++ b/acceptance-tests/src/test/java/io/blueocean/ath/offline/pipeline/DownstreamLinkTest.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/acceptance-tests/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
+++ b/acceptance-tests/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
@@ -2,7 +2,7 @@ package io.jenkins.blueocean.util;
 
 import com.damnhandy.uri.template.UriTemplate;
 import io.jenkins.blueocean.commons.JsonConverter;
-import org.apache.commons.lang3StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Content;

--- a/acceptance-tests/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
+++ b/acceptance-tests/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
@@ -2,7 +2,7 @@ package io.jenkins.blueocean.util;
 
 import com.damnhandy.uri.template.UriTemplate;
 import io.jenkins.blueocean.commons.JsonConverter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Content;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScm.java
@@ -17,7 +17,7 @@ import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmOrganization;
 import io.jenkins.blueocean.rest.model.Container;
 import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScmContentProvider.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/AbstractBitbucketScmContentProvider.java
@@ -23,7 +23,7 @@ import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketCredentialUtils.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketCredentialUtils.java
@@ -3,7 +3,7 @@ package io.jenkins.blueocean.blueocean_bitbucket_pipeline;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.BitbucketCloudScm;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.server.BitbucketServerScm;
 import io.jenkins.blueocean.commons.DigestUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author cliffmeyers

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketPipelineCreateRequest.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketPipelineCreateRequest.java
@@ -28,7 +28,7 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketRepositoryContainer.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/BitbucketRepositoryContainer.java
@@ -9,7 +9,7 @@ import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmRepositories;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmRepository;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmRepositoryContainer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.export.Exported;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpRequest.java
@@ -7,7 +7,7 @@ import hudson.ProxyConfiguration;
 import hudson.util.Secret;
 import io.jenkins.blueocean.commons.ServiceException;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/HttpResponse.java
@@ -5,7 +5,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
 import org.kohsuke.accmod.Restricted;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/BitbucketCloudApi.java
@@ -21,7 +21,7 @@ import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbUser;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.pageable.PagedResponse;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static io.jenkins.blueocean.commons.JsonConverter.om;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * @author Vivek Pandey

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/model/BbCloudTeam.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/cloud/model/BbCloudTeam.java
@@ -3,7 +3,7 @@ package io.jenkins.blueocean.blueocean_bitbucket_pipeline.cloud.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.blueocean.blueocean_bitbucket_pipeline.model.BbOrg;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerApi.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
@@ -205,7 +205,7 @@ public class BitbucketServerApi extends BitbucketApi {
             if(StringUtils.isNotBlank(sourceBranch)){
                 builder.addTextBody("sourceBranch", sourceBranch);
             }
-            if(org.apache.commons.lang.StringUtils.isNotBlank(commitId)){
+            if(org.apache.commons.lang3.StringUtils.isNotBlank(commitId)){
                    builder.addTextBody("sourceCommitId", commitId);
             }
             HttpEntity entity = builder.build();

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpoint.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpoint.java
@@ -8,7 +8,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmServerEndpoint;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;

--- a/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpointContainer.java
+++ b/blueocean-bitbucket-pipeline/src/main/java/io/jenkins/blueocean/blueocean_bitbucket_pipeline/server/BitbucketServerEndpointContainer.java
@@ -16,7 +16,7 @@ import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmServerEndpoint;
 import io.jenkins.blueocean.rest.impl.pipeline.scm.ScmServerEndpointContainer;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/blueocean-commons/pom.xml
+++ b/blueocean-commons/pom.xml
@@ -23,6 +23,10 @@
           <groupId>io.jenkins.plugins</groupId>
           <artifactId>commons-lang3-api</artifactId>
       </dependency>
+      <dependency>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>commons-text-api</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
@@ -25,7 +25,7 @@ package io.jenkins.blueocean.commons.stapler.export;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
+++ b/blueocean-commons/src/main/java/io/jenkins/blueocean/commons/stapler/export/JSONDataWriter.java
@@ -25,7 +25,7 @@ package io.jenkins.blueocean.commons.stapler.export;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -112,7 +112,7 @@ class JSONDataWriter implements DataWriter {
         buf.append('\"');
         // TODO: remove when JENKINS-45099 has been fixed correctly in upstream stapler
         if (config.isHtmlEncode()) {
-            jsonEncoder.quoteAsString(StringEscapeUtils.escapeHtml(v), buf);
+            jsonEncoder.quoteAsString(StringEscapeUtils.escapeHtml4(v), buf);
         } else {
             jsonEncoder.quoteAsString(v, buf);
         }

--- a/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
+++ b/blueocean-events/src/main/java/io/jenkins/blueocean/events/BlueMessageEnricher.java
@@ -35,7 +35,7 @@ import io.jenkins.blueocean.rest.model.BlueQueueItem;
 import io.jenkins.blueocean.service.embedded.rest.AbstractPipelineImpl;
 import io.jenkins.blueocean.service.embedded.rest.QueueUtil;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.pubsub.EventProps;
 import org.jenkinsci.plugins.pubsub.Events;
 import org.jenkinsci.plugins.pubsub.JobChannelMessage;

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequest.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitPipelineCreateRequest.java
@@ -14,7 +14,7 @@ import jenkins.plugins.git.traits.CleanBeforeCheckoutTrait;
 import jenkins.plugins.git.traits.LocalBranchTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceTrait;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitReadSaveService.java
@@ -56,7 +56,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.slf4j.Logger;

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/blueocean_git_pipeline/GitUtils.java
@@ -18,7 +18,7 @@ import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.credential.CredentialsUtils;
 import io.jenkins.blueocean.rest.impl.pipeline.credential.BlueOceanDomainRequirement;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.CheckoutCommand;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.MergeCommand;

--- a/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/ssh/UserPublicKeyRoute.java
+++ b/blueocean-git-pipeline/src/main/java/io/jenkins/blueocean/ssh/UserPublicKeyRoute.java
@@ -6,7 +6,7 @@ import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.commons.stapler.TreeResponse;
 import io.jenkins.blueocean.rest.UserRoute;
 import io.jenkins.blueocean.rest.model.BlueUser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.verb.DELETE;
 import org.kohsuke.stapler.verb.GET;

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubCredentialUtils.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubCredentialUtils.java
@@ -1,7 +1,7 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import io.jenkins.blueocean.commons.DigestUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author cliffmeyers

--- a/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
+++ b/blueocean-github-pipeline/src/main/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubScmContentProvider.java
@@ -18,7 +18,7 @@ import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.kohsuke.stapler.Stapler;

--- a/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubTestUtils.java
+++ b/blueocean-github-pipeline/src/test/java/io/jenkins/blueocean/blueocean_github_pipeline/GithubTestUtils.java
@@ -1,7 +1,7 @@
 package io.jenkins.blueocean.blueocean_github_pipeline;
 
 import io.jenkins.blueocean.commons.MapsHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 

--- a/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtAuthenticationFilter.java
+++ b/blueocean-jwt/src/main/java/io/jenkins/blueocean/auth/jwt/impl/JwtAuthenticationFilter.java
@@ -6,7 +6,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.PluginServletFilter;
 import io.jenkins.blueocean.auth.jwt.JwtTokenVerifier;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.springframework.security.core.Authentication;
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultibranchPipelineRunContainer.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/MultibranchPipelineRunContainer.java
@@ -11,7 +11,7 @@ import io.jenkins.blueocean.rest.model.BluePipeline;
 import io.jenkins.blueocean.rest.model.BlueRun;
 import io.jenkins.blueocean.rest.model.BlueRunContainer;
 import io.jenkins.blueocean.service.embedded.rest.QueueItemImpl;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 

--- a/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/scm/AbstractScmContentProvider.java
+++ b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/scm/AbstractScmContentProvider.java
@@ -6,7 +6,7 @@ import io.jenkins.blueocean.commons.ErrorMessage;
 import io.jenkins.blueocean.commons.ServiceException;
 import io.jenkins.blueocean.rest.impl.pipeline.ScmContentProvider;
 import jenkins.branch.MultiBranchProject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/MultiBranchTest.java
@@ -21,7 +21,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMSource;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.collection.IsArrayContainingInAnyOrder;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;

--- a/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
+++ b/blueocean-pipeline-api-impl/src/test/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineBaseTest.java
@@ -19,7 +19,7 @@ import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/credential/CredentialsUtils.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/credential/CredentialsUtils.java
@@ -15,7 +15,7 @@ import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
 import hudson.model.User;
 import io.jenkins.blueocean.commons.ServiceException;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
+++ b/blueocean-pipeline-scm-api/src/main/java/io/jenkins/blueocean/scm/api/AbstractMultiBranchCreateRequest.java
@@ -33,7 +33,7 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.SCMSourceEvent;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.pubsub.MessageException;
 import org.jenkinsci.plugins.pubsub.PubsubBus;
 import org.jenkinsci.plugins.pubsub.SimpleMessage;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/OrganizationFactoryImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/OrganizationFactoryImpl.java
@@ -7,11 +7,10 @@ import io.jenkins.blueocean.rest.model.BlueOrganization;
 import io.jenkins.blueocean.service.embedded.rest.OrganizationImpl;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
-import org.apache.commons.lang.StringUtils;
+import jenkins.util.SystemProperties;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -22,8 +21,7 @@ import java.util.logging.Logger;
  */
 @Extension(ordinal=-100)    // low ordinal to ensure this comes in the very last
 public class OrganizationFactoryImpl extends OrganizationFactory {
-    private static final String ORGANIZATION_NAME = StringUtils.defaultIfBlank(
-            System.getProperty("BLUE_ORGANIZATION_NAME"),"jenkins");
+    private static final String ORGANIZATION_NAME = SystemProperties.getString("BLUE_ORGANIZATION_NAME","jenkins");
 
     private static final String ROOT_FOLDER_NAME = System.getProperty("BLUE_ORGANIZATION_ROOT_FOLDER");
 

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/analytics/AbstractAnalytics.java
@@ -7,7 +7,7 @@ import io.jenkins.blueocean.analytics.AdditionalAnalyticsProperties;
 import io.jenkins.blueocean.analytics.Analytics;
 import io.jenkins.blueocean.commons.DigestUtils;
 import io.jenkins.blueocean.commons.ServiceException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/AbstractRunImpl.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 import org.slf4j.Logger;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/ActionProxiesImpl.java
@@ -4,7 +4,7 @@ import hudson.model.Action;
 import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueActionProxy;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.slf4j.Logger;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueTestResultContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/BlueTestResultContainerImpl.java
@@ -13,7 +13,7 @@ import io.jenkins.blueocean.rest.model.BlueTestResult;
 import io.jenkins.blueocean.rest.model.BlueTestResult.State;
 import io.jenkins.blueocean.rest.model.BlueTestResult.Status;
 import io.jenkins.blueocean.rest.model.BlueTestResultContainer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class BlueTestResultContainerImpl extends BlueTestResultContainer {
     protected final Run<?, ?> run;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/FavoriteContainerImpl.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 import jakarta.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/UserImpl.java
@@ -23,7 +23,7 @@ import io.jenkins.blueocean.rest.model.BlueUserPermission;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 import org.springframework.security.core.Authentication;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.Map;

--- a/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/junit/BlueJUnitTestResult.java
+++ b/blueocean-rest-impl/src/main/java/io/jenkins/blueocean/service/embedded/rest/junit/BlueJUnitTestResult.java
@@ -9,7 +9,7 @@ import io.jenkins.blueocean.rest.Reachable;
 import io.jenkins.blueocean.rest.factory.BlueTestResultFactory;
 import io.jenkins.blueocean.rest.hal.Link;
 import io.jenkins.blueocean.rest.model.BlueTestResult;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * TODO: move to junit plugin

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/service/embedded/rest/UserImplPermissionTest.java
@@ -40,7 +40,7 @@ import jakarta.servlet.ServletException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
+++ b/blueocean-rest-impl/src/test/java/io/jenkins/blueocean/util/HttpRequest.java
@@ -2,7 +2,7 @@ package io.jenkins.blueocean.util;
 
 import com.damnhandy.uri.template.UriTemplate;
 import io.jenkins.blueocean.commons.JsonConverter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Content;

--- a/blueocean-rest/pom.xml
+++ b/blueocean-rest/pom.xml
@@ -28,14 +28,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>de.skuzzle.enforcer</groupId>
-                        <artifactId>restrict-imports-enforcer-rule</artifactId>
-                        <version>0.7.0</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>check-no-jenkins-imports</id>
@@ -46,7 +40,7 @@
                         <configuration>
                             <rules>
                                 <!-- All packages can use Extension points -->
-                                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                                <RestrictImports>
                                     <basePackage>**</basePackage>
                                     <bannedImports>
                                         <bannedImport>jenkins.**</bannedImport>
@@ -60,13 +54,22 @@
                                         <allowedImport>hudson.security.csrf.CrumbExclusion</allowedImport>
                                         <allowedImport>hudson.util.AdaptedIterator</allowedImport>
                                         <allowedImport>hudson.Util</allowedImport>
+                                        <allowedImport>static hudson.Util.rawEncode</allowedImport>
+                                        <allowedImport>hudson.model.Action</allowedImport>
+                                        <allowedImport>hudson.model.Item</allowedImport>
+                                        <allowedImport>hudson.model.ItemGroup</allowedImport>
+                                        <allowedImport>hudson.model.Job</allowedImport>
+                                        <allowedImport>hudson.model.ModelObject</allowedImport>
+                                        <allowedImport>hudson.model.RootAction</allowedImport>
+                                        <allowedImport>hudson.model.Run</allowedImport>
+                                        <allowedImport>hudson.model.TopLevelItem</allowedImport>
+                                        <allowedImport>hudson.scm.ChangeLogSet</allowedImport>
+                                        <allowedImport>jenkins.model.Jenkins</allowedImport>
+                                        <allowedImport>jenkins.model.ModifiableTopLevelItemGroup</allowedImport>
                                     </allowedImports>
-                                    <excludedClasses>
-                                        <excludedClass>io.jenkins.blueocean.rest.factory.**</excludedClass>
-                                    </excludedClasses>
-                                </restrictImports>
+                                </RestrictImports>
                                 <!-- Factory package is allowed to import Jenkins models -->
-                                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                                <RestrictImports>
                                     <basePackage>io.jenkins.blueocean.rest.factory.**</basePackage>
                                     <bannedImports>
                                         <bannedImport>jenkins.**</bannedImport>
@@ -89,8 +92,8 @@
                                         <allowedImport>hudson.model.Job</allowedImport>
                                         <allowedImport>hudson.scm.ChangeLogSet</allowedImport>
                                     </allowedImports>
-                                </restrictImports>
-                                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                                </RestrictImports>
+                                <RestrictImports>
                                     <basePackage>io.jenkins.blueocean.rest.analytics.**</basePackage>
                                     <bannedImports>
                                         <bannedImport>jenkins.**</bannedImport>
@@ -101,7 +104,7 @@
                                         <allowedImport>hudson.ExtensionPoint</allowedImport>
                                         <allowedImport>hudson.ExtensionList</allowedImport>
                                     </allowedImports>
-                                </restrictImports>
+                                </RestrictImports>
                             </rules>
                         </configuration>
                     </execution>

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
@@ -5,7 +5,7 @@ import hudson.Main;
 import hudson.security.csrf.CrumbIssuer;
 import io.jenkins.blueocean.dev.RunBundleWatches;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang3StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.slf4j.Logger;

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/BlueOceanUI.java
@@ -5,7 +5,7 @@ import hudson.Main;
 import hudson.security.csrf.CrumbIssuer;
 import io.jenkins.blueocean.dev.RunBundleWatches;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.slf4j.Logger;

--- a/blueocean-web/src/main/java/io/jenkins/blueocean/dev/RunBundleWatches.java
+++ b/blueocean-web/src/main/java/io/jenkins/blueocean/dev/RunBundleWatches.java
@@ -7,7 +7,7 @@ import io.jenkins.blueocean.BlueOceanUI;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/blueocean/src/main/java/io/jenkins/blueocean/plugin/diagnosis/BlueOceanCredentialsMonitor.java
+++ b/blueocean/src/main/java/io/jenkins/blueocean/plugin/diagnosis/BlueOceanCredentialsMonitor.java
@@ -20,7 +20,7 @@ import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
 import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.kohsuke.accmod.Restricted;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.24</version>
+    <version>6.2116.v7501b_67dc517</version>
     <relativePath />
   </parent>
 
@@ -46,6 +46,7 @@
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
     <!-- override this as memory in parent pom is not big enough -->
     <argLine>-Xmx3g -Xms3g -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook}</argLine>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2116.v7501b_67dc517</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
 
@@ -46,7 +46,6 @@
     <access-modifier-checker.failOnError>true</access-modifier-checker.failOnError>
     <!-- override this as memory in parent pom is not big enough -->
     <argLine>-Xmx3g -Xms3g -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook}</argLine>
-    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">

--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,11 @@
           <artifactId>commons-codec</artifactId>
           <scope>provided</scope>
       </dependency>
-      <dependency>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-          <scope>provided</scope>
-      </dependency>
+<!--      <dependency>-->
+<!--          <groupId>commons-lang</groupId>-->
+<!--          <artifactId>commons-lang</artifactId>-->
+<!--          <scope>provided</scope>-->
+<!--      </dependency>-->
       <dependency>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-core</artifactId>
@@ -523,10 +523,22 @@
                       <failOnError>${access-modifier-checker.failOnError}</failOnError>
                   </configuration>
               </plugin>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-enforcer-plugin</artifactId>
+                  <dependencies>
+                      <dependency>
+                          <groupId>de.skuzzle.enforcer</groupId>
+                          <artifactId>restrict-imports-enforcer-rule</artifactId>
+                          <version>3.0.0</version>
+                      </dependency>
+                  </dependencies>
+              </plugin>
           </plugins>
       </pluginManagement>
     <plugins>
         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
             <executions>
                 <execution>
@@ -539,9 +551,25 @@
                             <bannedDependencies>
                                 <excludes>
                                     <exclude>org.apache.commons:commons-lang3</exclude>
+                                    <exclude>commons-lang:commons-lang</exclude>
                                 </excludes>
                                 <searchTransitive>false</searchTransitive>
                             </bannedDependencies>
+                        </rules>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>check-commons-lang</id>
+                    <phase>process-sources</phase>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <RestrictImports>
+                                <reason>Use commons-lang 2</reason>
+                                <bannedImport>org.apache.commons.lang.**</bannedImport>
+                            </RestrictImports>
                         </rules>
                     </configuration>
                 </execution>


### PR DESCRIPTION
# Description

Commons Lang 2 should be removed from Jenkins Core (https://github.com/jenkinsci/jenkins/pull/26105) but the plugin is using StringUtils from it.

Is required for https://github.com/jenkinsci/bom/pull/6234

# Testing done

I could not build the plugin locally, I rely on CI.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

